### PR TITLE
fix: fix run on arm64

### DIFF
--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -23,8 +23,6 @@ spec:
       hostNetwork: true
       imagePullSecrets:
         {{- include "base_pull_secrets" . }}
-      nodeSelector:
-        kubernetes.io/arch: amd64
       # NOTE: Each container must have mem/cpu limits defined in order to
       # belong to Guaranteed QoS class, hence can never get evicted in case of
       # pressure unless they exceed those limits. limits and requests must be
@@ -78,7 +76,7 @@ spec:
             cpu: {{ .Values.csi.node.resources.requests.cpu | quote }}
             memory: {{ .Values.csi.node.resources.requests.memory | quote }}
       - name: csi-driver-registrar
-        image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
+        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
         args:
         - "--csi-address=/csi/csi.sock"
         - "--kubelet-registration-path=/var/lib/kubelet/plugins/io.openebs.mayastor/csi.sock"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -170,7 +170,6 @@ mayastor:
   # node selectors to designate mayastor nodes for diskpool creation
   nodeSelector:
     openebs.io/engine: mayastor
-    kubernetes.io/arch: amd64
   resources:
     limits:
       # cpu limits for mayastor component


### PR DESCRIPTION
Use k8s offical repo for image csi-node-driver-registrar, because it
provides muti-arch images for Arm64.

Remove CPU arch nodeSelector, Mayastor can run on arm64 now, not just
x86_64. See verfied result here:
https://linaro.atlassian.net/browse/STOR-104

Signed-off-by: Xinliang Liu <xinliang.liu@linaro.org>
close openebs/mayastor#1063

Verified with override values for arm images:
microk8s helm3 install mayastor . -f values-arm-override.yaml -n mayastor
```
cat >values-arm-override.yaml<<EOF
---
image:
  repo: xin3liang

etcd:
  image:
    repository: xin3liang/bitnami-etcd
    tag: 3.5.1-debian-10-r67
  replicaCount: 1
  volumePermissions:
    image:
      repository: xin3liang/bitnami-shell

loki-stack:
  enabled: false
EOF
```