### PR TITLE
chore: add metrics polling interval as configurable field in helm chart

### DIFF
--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -40,6 +40,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        args:
+        - "-p{{ .Values.mayastor.metricsPollingInterval }}"
         command:
         - metrics-exporter-pool
         ports:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -167,6 +167,9 @@ mayastor:
   # logLevel for the core crate and other dependent crates
   logLevel: info,io_engine=info
   cpuCount: "2"
+  # metrics refresh time
+  # WARNING: Lowering metricsPollingInterval value will affect performance adversely
+  metricsPollingInterval: "5m"
   # node selectors to designate mayastor nodes for diskpool creation
   nodeSelector:
     openebs.io/engine: mayastor


### PR DESCRIPTION
Add metrics polling interval as configurable parameter in [chart/values.yaml](https://github.com/openebs/mayastor-extensions/blob/develop/chart/values.yaml)
    `metricsPollingInterval: "5m"`

By default, polling interval is five minutes.