### PR TITLE
fix: fix run on microk8s

### DIFF
--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -68,7 +68,7 @@ spec:
         - name: plugin-dir
           mountPath: /csi
         - name: kubelet-dir
-          mountPath: /var/lib/kubelet
+          mountPath: {{ .Values.csi.node.kubeletDir }}
           mountPropagation: "Bidirectional"
         resources:
           limits:
@@ -81,7 +81,7 @@ spec:
         image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
         args:
         - "--csi-address=/csi/csi.sock"
-        - "--kubelet-registration-path=/var/lib/kubelet/plugins/io.openebs.mayastor/csi.sock"
+        - "--kubelet-registration-path={{ .Values.csi.node.kubeletDir }}/plugins/io.openebs.mayastor/csi.sock"
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi
@@ -114,13 +114,13 @@ spec:
           type: Directory
       - name: registration-dir
         hostPath:
-          path: /var/lib/kubelet/plugins_registry/
+          path: {{ .Values.csi.node.kubeletDir }}/plugins_registry/
           type: Directory
       - name: plugin-dir
         hostPath:
-          path: /var/lib/kubelet/plugins/io.openebs.mayastor/
+          path: {{ .Values.csi.node.kubeletDir }}/plugins/io.openebs.mayastor/
           type: DirectoryOrCreate
       - name: kubelet-dir
         hostPath:
-          path: /var/lib/kubelet
+          path: {{ .Values.csi.node.kubeletDir }}
           type: Directory

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -162,6 +162,7 @@ csi:
       # nvme_core module io timeout in seconds
       io_timeout: "30"
       io_timeout_enabled: true
+    kubeletDir: /var/lib/kubelet
 
 mayastor:
   # logLevel for the core crate and other dependent crates


### PR DESCRIPTION
Make kubelet directory configurable.
This patch references to
https://github.com/canonical/mayastor-control-plane/commit/c87e2ed54471496ca1ff6fb65c2512212042e0d2

When running in microk8s needs to set kubeletDir as
kubeletDir: /var/snap/microk8s/common/var/lib/kubelet

This fix #5.

Signed-off-by: Xinliang Liu <xinliang.liu@linaro.org>