### PR TITLE
chore: use silence log env variable for control-plane components

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,5 +1,5 @@
 status = [ "continuous-integration/jenkins/branch" ]
-pr_status = [ "commitlint" ]
+pr_status = [ "commitlint", "DCO" ]
 timeout_sec = 10000
 required_approvals = 2
 delete_merged_branches = true

--- a/chart/templates/mayastor/agents/agent-core-deployment.yaml
+++ b/chart/templates/mayastor/agents/agent-core-deployment.yaml
@@ -45,6 +45,10 @@ spec:
           env:
             - name: RUST_LOG
               value: {{ .Values.core.logLevel }}
+            {{- if default .Values.base.logSilenceLevel .Values.core.logSilenceLevel }}
+            - name: RUST_LOG_SILENCE
+              value: {{ default .Values.base.logSilenceLevel .Values.core.logSilenceLevel }}
+            {{- end }}
             - name: MY_POD_NAME
               valueFrom:
                 fieldRef:

--- a/chart/templates/mayastor/apis/api-rest-deployment.yaml
+++ b/chart/templates/mayastor/apis/api-rest-deployment.yaml
@@ -46,3 +46,7 @@ spec:
           env:
             - name: RUST_LOG
               value: {{ .Values.rest.logLevel }}
+            {{- if default .Values.base.logSilenceLevel .Values.rest.logSilenceLevel }}
+            - name: RUST_LOG_SILENCE
+              value: {{ default .Values.base.logSilenceLevel .Values.rest.logSilenceLevel }}
+            {{- end }}

--- a/chart/templates/mayastor/csi/csi-controller-deployment.yaml
+++ b/chart/templates/mayastor/csi/csi-controller-deployment.yaml
@@ -74,6 +74,10 @@ spec:
           env:
             - name: RUST_LOG
               value: {{ .Values.csi.controller.logLevel }}
+            {{- if default .Values.base.logSilenceLevel .Values.csi.controller.logSilenceLevel }}
+            - name: RUST_LOG_SILENCE
+              value: {{ default .Values.base.logSilenceLevel .Values.csi.controller.logSilenceLevel }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -40,6 +40,10 @@ spec:
         env:
         - name: RUST_LOG
           value: {{ .Values.csi.node.logLevel }}
+        {{- if default .Values.base.logSilenceLevel .Values.csi.node.logSilenceLevel }}
+        - name: RUST_LOG_SILENCE
+          value: {{ default .Values.base.logSilenceLevel .Values.csi.node.logSilenceLevel }}
+        {{- end }}
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -56,7 +60,6 @@ spec:
         - "--grpc-endpoint=$(MY_POD_IP):10199"{{ if .Values.csi.node.nvme.io_timeout_enabled }}
         - "--nvme-core-io-timeout={{ .Values.csi.node.nvme.io_timeout }}"{{ end }}
         - "--nvme-nr-io-queues={{ .Values.mayastor.cpuCount }}"
-        - "-v"
         command:
         - csi-node
         volumeMounts:

--- a/chart/templates/mayastor/operators/operator-diskpool-deployment.yaml
+++ b/chart/templates/mayastor/operators/operator-diskpool-deployment.yaml
@@ -43,6 +43,10 @@ spec:
           env:
             - name: RUST_LOG
               value: {{ .Values.operators.pool.logLevel }}
+            {{- if default .Values.base.logSilenceLevel .Values.operators.pool.logSilenceLevel }}
+            - name: RUST_LOG_SILENCE
+              value: {{ default .Values.base.logSilenceLevel .Values.operators.pool.logSilenceLevel }}
+            {{- end }}
             - name: MY_POD_NAME
               valueFrom:
                 fieldRef:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -20,6 +20,8 @@ base:
   default_req_timeout: 5s
   # cache timeout for core agent & diskpool deployment
   cache_poll_period: 30s
+  # silence specific module components
+  logSilenceLevel:
   initContainers:
     enabled: true
     containers:
@@ -65,8 +67,8 @@ base:
 
 operators:
   pool:
-    # logLevel for mayastor diskpool operator & other dependent crate
-    logLevel: info,operator_diskpool=info
+    # logLevel for diskpool operator & other dependent crate
+    logLevel: info
     resources:
       limits:
         # cpu limits for diskpool operator
@@ -120,21 +122,6 @@ rest:
       # cpu requests for rest
       cpu: "50m"
       # memory requests for rest
-      memory: "32Mi"
-
-license:
-  # logLevel for the licensing crate
-  logLevel: info
-  resources:
-    limits:
-      # cpu limits for license component
-      cpu: "100m"
-      # memory limits for license component
-      memory: "64Mi"
-    requests:
-      # cpu requests for license component
-      cpu: "50m"
-      # memory requests for license component
       memory: "32Mi"
 
 csi:

--- a/exporter/src/bin/pool/main.rs
+++ b/exporter/src/bin/pool/main.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<(), String> {
         .expect("gRPC client not initialized");
 
     tokio::spawn(async move {
-        let _p = cache::store_data(client)
+        cache::store_data(client)
             .await
             .expect("Unable to store data in cache");
     });

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -7,7 +7,7 @@ let
 in
 rec {
   rust_default = { override ? { } }: rec {
-    nightly = pkgs.rust-bin.nightly."2021-11-22".default.override (override);
+    nightly = pkgs.rust-bin.nightly."2022-06-22".default.override (override);
     stable = pkgs.rust-bin.stable.latest.default.override (override);
   };
   default = rust_default { };

--- a/nix/lib/version.nix
+++ b/nix/lib/version.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation {
   src = whitelistSource ../../. [ ".git" ];
   buildCommand = ''
     cd $src
+    export GIT_DIR=".git"
     vers=`${git}/bin/git tag --points-at HEAD`
     if [ -z "$vers" ]; then
       vers=`${git}/bin/git rev-parse --short=12 HEAD`

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
-        "sha256": "1jhagazh69w7jfbrchhdss54salxc66ap1a1yd7xasc92vr0qsx4",
+        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
+        "sha256": "0l2bkzg4w9j94rjpb6yx5q3k4yi2nzp3q7dp6xjq5rdkwwbgq5gl",
         "type": "tarball",
-        "url": "https://github.com/nix-community/naersk/archive/2fc8ce9d3c025d59fee349c1f80be9785049d653.tar.gz",
+        "url": "https://github.com/nix-community/naersk/archive/cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -17,22 +17,22 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "5830a4dd348d77e39a0f3c4c762ff2663b602d4c",
-        "sha256": "1d3lsrqvci4qz2hwjrcnd8h5vfkg8aypq3sjd4g3izbc8frwz5sm",
+        "rev": "82e5cd1ad3c387863f0545d7591512e76ab0fc41",
+        "sha256": "090l219mzc0gi33i3psgph6s2pwsc8qy4lyrqjdj4qzkvmaj65a7",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/5830a4dd348d77e39a0f3c4c762ff2663b602d4c.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/82e5cd1ad3c387863f0545d7591512e76ab0fc41.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "master",
+        "branch": "release-22.05",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6695286d1ddcabe71b9eeda1dc0701765fa3dbb6",
-        "sha256": "0y7lxr9rx73jy66bk5bcp47c3rzcfxnmq1qv1jgcpqk6i9jig8zx",
+        "rev": "f204a18d7b7383dd9510c7734209f25c69e76280",
+        "sha256": "0cn6m3gsh6k5h9y3qnn0x37gzykw4kk202m2rd5fq8kmjzp3p1ij",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6695286d1ddcabe71b9eeda1dc0701765fa3dbb6.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/f204a18d7b7383dd9510c7734209f25c69e76280.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {
@@ -41,10 +41,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "844ee700e1886b5826b809ecaef03cbd96b0b049",
-        "sha256": "1c4yk6j0qmbvsx6x5s2zcmbd247kxpfzjvq3ibw6pcjgif7w9a06",
+        "rev": "1a133f54a0229af8310879eac2c4a82c0576a0b9",
+        "sha256": "0hab9wfr3shcb4z508gjc3y9slnxdjhfnmqhpvrkx4v2gq7pkm8n",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/844ee700e1886b5826b809ecaef03cbd96b0b049.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/1a133f54a0229af8310879eac2c4a82c0576a0b9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,14 +1,8 @@
-extern crate bytes;
-extern crate prost;
-extern crate prost_derive;
-extern crate serde;
-extern crate serde_derive;
-extern crate serde_json;
-extern crate tonic;
 #[allow(clippy::type_complexity)]
 #[allow(clippy::unit_arg)]
 #[allow(clippy::redundant_closure)]
 #[allow(clippy::upper_case_acronyms)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 pub mod mayastor {
     use std::str::FromStr;
 


### PR DESCRIPTION
chore(nix): upgrade to release channel

Also pin the rust nightly to the same day as the control-plane.

---

chore: use silence log env variable for control-plane components

Use the env var RUST_LOG_SILENCE which silences overly verbose components.
By default we use whatever is set during compile time.
A common base.logSilenceLevel is added to set a common silence for all components but each
component can also override it.