### PR TITLE
chore: remove node ports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,14 +12,14 @@ repos:
     -   id: rust-lint
         name: Rust lint
         description: Run cargo clippy on files included in the commit.
-        entry: cargo clippy --all --all-targets -- -D warnings
+        entry: nix-shell --pure --run 'cargo clippy --all --all-targets -- -D warnings'
         pass_filenames: false
         types: [file, rust]
         language: system
     -   id: rust-style
         name: Rust style
         description: Run cargo fmt on files included in the commit.
-        entry: cargo fmt --all -- --check
+        entry: nix-shell --pure --run 'cargo fmt --all -- --check'
         pass_filenames: true
         types: [file, rust]
         language: system
@@ -27,6 +27,6 @@ repos:
         name: Commit Lint
         description: Runs commitlint against the commit message.
         language: system
-        entry: bash -c "npm install @commitlint/config-conventional @commitlint/cli; cat $1 | npx commitlint"
+        entry: bash -c 'nix-shell --pure --run "cat $1 | commitlint"'
         args: [$1]
         stages: [commit-msg]

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -258,9 +258,7 @@ etcd:
   # etcd service parameters defines how the etcd service is exposed
   service:
     # K8s service type
-    # NOTE: Mayastor Supportability tool will work without any network
-    #       workarounds(i.e port-forward) only if type is configured as NodePort
-    type: NodePort
+    type: ClusterIP
 
     # etcd client port
     port: 2379
@@ -341,9 +339,7 @@ loki-stack:
     # Loki service parameters defines how the Loki service is exposed
     service:
       # K8s service type
-      # NOTE: Mayastor Supportability tool will work without any network
-      #       workarounds only if type is configured as NodePort
-      type: NodePort
+      type: ClusterIP
       port: 3100
       # Port where REST endpoints of Loki are accessible from outside cluster
       nodePort: 31001

--- a/shell.nix
+++ b/shell.nix
@@ -19,6 +19,7 @@ mkShell {
   buildInputs = [
     cargo-expand
     cargo-udeps
+    commitlint
     git
     pkg-config
     pre-commit


### PR DESCRIPTION
chore: remove node ports

Our kubectl-plugin no longer needs node ports to reach our services.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

chore: temporarily pin io-engine to v0

This will be changed to v1 when the control-plane supports v1.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

fix: run pre-commit hooks under the nix-shell

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>