### PR TITLE
chore: temporarily pin io-engine api-version to v0

### DIFF
--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -79,6 +79,7 @@ spec:
         - "-y/var/local/io-engine/config.yaml"
         - "-l{{ include "cpuFlag" . }}"
         - "-p={{ .Release.Name }}-etcd:{{ .Values.etcd.service.port }}"
+        - "--api-versions=v0"
         command:
         - io-engine
         securityContext:


### PR DESCRIPTION
This will be changed to v1 when the control-plane supports v1.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>