### PR TITLE
chore: add gh action to release helm chart as a gh-page

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -1,0 +1,16 @@
+name: Release Helm Chart
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  release-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish Mayastor Helm chart
+        uses: stefanprodan/helm-gh-pages@v1.5.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: .

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -22,9 +22,8 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "2.0.0-develop"
 
-# appVersion: "latest"
 dependencies:
   - name: etcd
     repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami


### PR DESCRIPTION
Adds the release workflow and set the mayastor version to 2.0.0-develop.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>