### PR TITLE
fix: use core agent server endpoint as socket

### DIFF
--- a/chart/templates/mayastor/agents/agent-core-deployment.yaml
+++ b/chart/templates/mayastor/agents/agent-core-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - "--request-timeout={{ .Values.base.default_req_timeout }}"
             - "--cache-period={{ .Values.base.cache_poll_period }}"{{ if .Values.base.jaeger.enabled }}
             - "--jaeger={{ .Values.base.jaeger.agent.name }}:{{ .Values.base.jaeger.agent.port }}"{{ end }}
-            - "--grpc-server-addr=https://0.0.0.0:50051"
+            - "--grpc-server-addr=0.0.0.0:50051"
           ports:
             - containerPort: 50051
           env:


### PR DESCRIPTION
Required after https://github.com/openebs/mayastor-control-plane/pull/322

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>