### PR TITLE
feat(csi-node): allow csi topology segments and nodeSelector constraint

### DIFF
--- a/chart/templates/mayastor/csi/csi-controller-deployment.yaml
+++ b/chart/templates/mayastor/csi/csi-controller-deployment.yaml
@@ -68,6 +68,9 @@ spec:
             - "--csi-socket=/var/lib/csi/sockets/pluginproxy/csi.sock"
             - "--rest-endpoint=http://{{ .Release.Name }}-api-rest:8081"{{ if .Values.base.jaeger.enabled }}
             - "--jaeger={{ .Values.base.jaeger.agent.name }}:{{ .Values.base.jaeger.agent.port }}"{{ end }}
+            {{- range $key, $val := .Values.csi.node.topology.segments }}
+            - "--node-selector={{ $key }}={{ $val }}"
+            {{- end }}
           env:
             - name: RUST_LOG
               value: {{ .Values.csi.controller.logLevel }}

--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -3,7 +3,9 @@ kind: DaemonSet
 metadata:
   name: {{ .Release.Name }}-csi-node
   labels:
-    openebs.io/engine: io-engine
+    {{- range $key, $val := .Values.csi.node.topology.segments }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -60,6 +62,9 @@ spec:
         - "--grpc-endpoint=$(MY_POD_IP):10199"{{ if .Values.csi.node.nvme.io_timeout_enabled }}
         - "--nvme-core-io-timeout={{ .Values.csi.node.nvme.io_timeout }}"{{ end }}
         - "--nvme-nr-io-queues={{ .Values.mayastor.cpuCount }}"
+        {{- range $key, $val := .Values.csi.node.topology.segments }}
+        - "--node-selector={{ $key }}={{ $val }}"
+        {{- end }}
         command:
         - csi-node
         volumeMounts:

--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -25,9 +25,15 @@ spec:
       hostNetwork: true
       imagePullSecrets:
         {{- include "base_pull_secrets" . }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
-      {{- end }}
+      nodeSelector:
+        {{- if .Values.nodeSelector }}
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+        {{- end }}
+        {{- if .Values.csi.node.topology.nodeSelector }}
+        {{- range $key, $val := .Values.csi.node.topology.segments }}
+        {{ $key }}: {{ $val }}
+        {{- end }}
+        {{- end }}
       # NOTE: Each container must have mem/cpu limits defined in order to
       # belong to Guaranteed QoS class, hence can never get evicted in case of
       # pressure unless they exceed those limits. limits and requests must be

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -165,6 +165,8 @@ csi:
     topology:
       segments:
         openebs.io/csi-node: mayastor
+      # add topology segments to the csi-node daemonset node selector
+      nodeSelector: false
     resources:
       limits:
         # cpu limits for csi node plugin

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -162,6 +162,9 @@ csi:
         memory: "64Mi"
   node:
     logLevel: info
+    topology:
+      segments:
+        openebs.io/csi-node: mayastor
     resources:
       limits:
         # cpu limits for csi node plugin


### PR DESCRIPTION
feat(csi-node): allow configuring csi topology selector

This is "common" segment that all csi-nodes report as part of their topology.
This allows us to affinitize a pv to a csi-node (any).
When the csi-node is no longer running on a particular node the segment must be
"manually" removed from the kubernetes node labels.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

feat(csi-node): add nodeSelector to the csi-node deployment

By default, the nodeSelector is disabled, which keeps in the current behaviour.
If enabled, each node where an application pod needs to run should be labelled
with the csi topology segments.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>