### PR TITLE
fix(call-home): fix path join for output_filepath var

### DIFF
--- a/call-home/src/common/constants.rs
+++ b/call-home/src/common/constants.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 /// PRODUCT is the name of the project for which this call-home component is deployed.
 pub(crate) const PRODUCT: &str = "Mayastor";
 
@@ -6,24 +8,18 @@ pub(crate) const PRODUCT: &str = "Mayastor";
 /// The function encryption_dir() returns the user defined directory path for the encryption
 /// dir as an &str.
 const DEFAULT_ENCRYPTION_DIR_PATH: &str = "./";
-pub(crate) fn get_encryption_dir() -> String {
-    return match std::env::var("ENCRYPTION_DIR") {
-        Ok(input) => {
-            // This is a hack to eliminate a trailing slash.
-            match std::path::Path::new(&input).components().as_path().to_str() {
-                Some(path) => path.to_string(),
-                None => DEFAULT_ENCRYPTION_DIR_PATH.to_string(),
-            }
-        }
+pub(crate) fn encryption_dir() -> String {
+    match env::var("ENCRYPTION_DIR") {
+        Ok(input) => input,
         Err(_) => DEFAULT_ENCRYPTION_DIR_PATH.to_string(),
-    };
+    }
 }
 
 /// DEFAULT_ENCRYPTION_KEY_FILEPATH is the path to the encryption key.
 /// The function key_filepath() returns the user defined path for the encryption key.
 const DEFAULT_ENCRYPTION_KEY_FILEPATH: &str = "./castor.gpg";
-pub(crate) fn get_key_filepath() -> String {
-    match std::env::var("KEY_FILEPATH") {
+pub(crate) fn key_filepath() -> String {
+    match env::var("KEY_FILEPATH") {
         Ok(input) => input,
         Err(_) => DEFAULT_ENCRYPTION_KEY_FILEPATH.to_string(),
     }
@@ -32,10 +28,10 @@ pub(crate) fn get_key_filepath() -> String {
 /// RECEIVER_API_ENDPOINT is the URL to anonymous call-home metrics collection endpoint.
 pub(crate) const RECEIVER_ENDPOINT: &str = "";
 
-/// CALL_HOME_FREQUENCY is the frequency of call-home metrics transmission.
-/// The function call_home_frequency returns the frequency as a
+/// CALL_HOME_FREQUENCY_IN_HOURS is the frequency of call-home metrics transmission, in hours.
+/// The function call_home_frequency() returns the frequency as an std::time::Duration.
 const CALL_HOME_FREQUENCY_IN_HOURS: i64 = 24;
-pub(crate) fn get_call_home_frequency() -> std::time::Duration {
+pub(crate) fn call_home_frequency() -> std::time::Duration {
     chrono::Duration::hours(CALL_HOME_FREQUENCY_IN_HOURS)
         .to_std()
         .map_err(|error| {

--- a/call-home/src/main.rs
+++ b/call-home/src/main.rs
@@ -55,9 +55,9 @@ async fn run() -> anyhow::Result<()> {
     let endpoint = args.endpoint;
     let namespace = digest(args.namespace);
 
-    let sleep_duration = get_call_home_frequency();
-    let encryption_dir = get_encryption_dir();
-    let key_filepath = get_key_filepath();
+    let sleep_duration = call_home_frequency();
+    let encryption_dir = encryption_dir();
+    let key_filepath = key_filepath();
 
     // Generate kubernetes client.
     let k8s_client = K8sClient::new()

--- a/call-home/src/transmitter/encryption.rs
+++ b/call-home/src/transmitter/encryption.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 use std::{
     fs,
     io::{Error, ErrorKind},
+    path::Path,
     process::Command,
 };
 use tracing::debug;
@@ -36,7 +37,10 @@ pub(crate) fn encrypt(
         .take(32)
         .map(char::from)
         .collect();
-    let output_filepath = encryption_dir.clone() + "/" + &random_name + ".gpg";
+    let output_filepath = Path::new(encryption_dir)
+        .join(random_name + ".gpg")
+        .to_string_lossy()
+        .to_string();
 
     // TODO: Use a library instead of the gpg binary.
     let command = format!("gpg --yes --trust-model=always --homedir={} --keyring={} --recipient=product-health-report@caringo.com --no-default-keyring --encrypt -z=9 --output={} {}",


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>

This PR fixes the default encrytion dir path for the gpg command. The directory path used in the default constant must not have a trailing slash.