### PR TITLE
refactor(call-home): use PathBuf instead of String for paths

### DIFF
--- a/call-home/src/common/constants.rs
+++ b/call-home/src/common/constants.rs
@@ -1,4 +1,7 @@
-use std::env;
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 /// PRODUCT is the name of the project for which this call-home component is deployed.
 pub(crate) const PRODUCT: &str = "Mayastor";
@@ -8,20 +11,40 @@ pub(crate) const PRODUCT: &str = "Mayastor";
 /// The function encryption_dir() returns the user defined directory path for the encryption
 /// dir as an &str.
 const DEFAULT_ENCRYPTION_DIR_PATH: &str = "./";
-pub(crate) fn encryption_dir() -> String {
-    match env::var("ENCRYPTION_DIR") {
-        Ok(input) => input,
-        Err(_) => DEFAULT_ENCRYPTION_DIR_PATH.to_string(),
+pub(crate) fn encryption_dir() -> PathBuf {
+    const KEY: &str = "ENCRYPTION_DIR";
+    match env::var(KEY) {
+        Ok(input) => {
+            let path = Path::new(&input);
+            // Validate path.
+            match path.exists() && path.is_dir() {
+                true => path.to_path_buf(),
+                false => {
+                    panic!("validation failed for {} value \"{}\": path must exist and must be that of a directory", KEY, &input);
+                }
+            }
+        }
+        Err(_) => Path::new(DEFAULT_ENCRYPTION_DIR_PATH).to_path_buf(),
     }
 }
 
 /// DEFAULT_ENCRYPTION_KEY_FILEPATH is the path to the encryption key.
 /// The function key_filepath() returns the user defined path for the encryption key.
 const DEFAULT_ENCRYPTION_KEY_FILEPATH: &str = "./castor.gpg";
-pub(crate) fn key_filepath() -> String {
-    match env::var("KEY_FILEPATH") {
-        Ok(input) => input,
-        Err(_) => DEFAULT_ENCRYPTION_KEY_FILEPATH.to_string(),
+pub(crate) fn key_filepath() -> PathBuf {
+    const KEY: &str = "KEY_FILEPATH";
+    match env::var(KEY) {
+        Ok(input) => {
+            let path = Path::new(&input);
+            // Validate path.
+            match path.exists() && path.is_file() {
+                true => path.to_path_buf(),
+                false => {
+                    panic!("validation failed for {} value \"{}\": path must exist and must be that of a file", KEY, &input);
+                }
+            }
+        }
+        Err(_) => Path::new(DEFAULT_ENCRYPTION_KEY_FILEPATH).to_path_buf(),
     }
 }
 

--- a/call-home/src/common/errors.rs
+++ b/call-home/src/common/errors.rs
@@ -48,3 +48,28 @@ impl From<reqwest_middleware::Error> for ReceiverError {
         Self::HttpClientWithMiddlewareError { source }
     }
 }
+
+/// EncryptError is a custom error enum which is returned by the
+/// crate::transmitter::encryption::encrypt() function.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub), context(suffix(false)))]
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum EncryptError {
+    #[snafu(display("error during JSON marshalling: {}", source))]
+    SerdeSerializeError { source: serde_json::Error },
+
+    #[snafu(display("file io error: {}", source))]
+    IoError { source: std::io::Error },
+}
+
+impl From<serde_json::Error> for EncryptError {
+    fn from(source: serde_json::Error) -> Self {
+        Self::SerdeSerializeError { source }
+    }
+}
+
+impl From<std::io::Error> for EncryptError {
+    fn from(source: std::io::Error) -> Self {
+        Self::IoError { source }
+    }
+}

--- a/call-home/src/main.rs
+++ b/call-home/src/main.rs
@@ -44,7 +44,7 @@ async fn main() {
         .init();
 
     if let Err(error) = run().await {
-        tracing::error!(?error, " failed call-home");
+        error!(?error, "failed call-home");
         std::process::exit(1);
     }
 }
@@ -104,7 +104,7 @@ async fn run() -> anyhow::Result<()> {
             .post(output)
             .await
             .map_err(|error| anyhow::anyhow!("failed HTTP POST request: {:?}", error))?;
-        info!("HTTP Response:\n{:#?}", response);
+        info!(?response, "HTTP Response");
 
         // Block till next transmission window.
         sleep(sleep_duration).await;

--- a/call-home/src/transmitter/encryption.rs
+++ b/call-home/src/transmitter/encryption.rs
@@ -1,11 +1,9 @@
-use crate::Report;
+use crate::{common::errors::EncryptError, Report};
 use mktemp::Temp;
 use rand::{distributions::Alphanumeric, Rng};
-use serde_json::json;
 use std::{
     fs,
-    io::{Error, ErrorKind},
-    path::Path,
+    path::{Path, PathBuf},
     process::Command,
 };
 use tracing::debug;
@@ -13,23 +11,18 @@ use tracing::debug;
 /// 'encrypt' accepts a crate::collector::Report, marshals it into JSON and encrypts it.
 pub(crate) fn encrypt(
     report: &Report,
-    encryption_dir: &String,
-    key_filepath: &String,
-) -> Result<Vec<u8>, Error> {
+    encryption_dir: &PathBuf,
+    key_filepath: &Path,
+) -> Result<Vec<u8>, EncryptError> {
     // The underlying filesystem resource is garbage collected
     // when this function returns.
     // Ref: https://docs.rs/mktemp/0.4.1/mktemp/index.html
     let temp_file = Temp::new_file_in(encryption_dir)?;
     debug!("Successfully created temporary input file.");
 
-    let path_buffer = temp_file.to_path_buf();
-    let input_filepath: &str = path_buffer
-        .to_str()
-        .ok_or_else(|| Error::new(ErrorKind::Other, "Error converting Pathbuf to &str"))?;
-    fs::write(
-        input_filepath,
-        <String as AsRef<[u8]>>::as_ref(&json!(report).to_string()),
-    )?;
+    let input_filepath = temp_file.to_path_buf();
+    let report_content = serde_json::to_vec(report)?;
+    fs::write(&input_filepath, &report_content)?;
     debug!("Successfully written Report data to temporary input file.");
 
     let random_name: String = rand::thread_rng()
@@ -37,16 +30,14 @@ pub(crate) fn encrypt(
         .take(32)
         .map(char::from)
         .collect();
-    let output_filepath = Path::new(encryption_dir)
-        .join(random_name + ".gpg")
-        .to_string_lossy()
-        .to_string();
+    let output_filepath = Path::new(encryption_dir).join(random_name + ".gpg");
 
     // TODO: Use a library instead of the gpg binary.
     let command = format!("gpg --yes --trust-model=always --homedir={} --keyring={} --recipient=product-health-report@caringo.com --no-default-keyring --encrypt -z=9 --output={} {}",
-                          encryption_dir, key_filepath,
-                          &output_filepath,
-                          &input_filepath);
+                          encryption_dir.to_string_lossy(),
+                          key_filepath.to_string_lossy(),
+                          output_filepath.to_string_lossy(),
+                          input_filepath.to_string_lossy());
     let _ = Command::new("sh").args(&["-c", command.trim()]).output()?;
     debug!("Successfully executed gpg command.");
 


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>

This PR uses the PathBuf type instead of the String type for filepaths. It is idiomatic to use PathBuf for paths.