### PR TITLE
feat(publish-tag): publish the helm chart on tag push

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -1,18 +1,34 @@
 name: Release Helm Chart
 on:
   push:
-    branches:
-      - develop
-    paths:
-      - 'chart/**'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+**'
 
 jobs:
   release-chart:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v17
+      - name: Pre-populate nix-shell
+        run: |
+          export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
+          echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
+          nix-shell --pure --run "echo" ./scripts/helm/shell.nix
+      - name: Publish locally in the workspace
+        run: |
+          if [ "${{ github.ref_type }}" == "tag" ]; then
+            tag="${{ github.ref_name }}"
+            # Publish the Chart.yaml locally
+            # Note this does not commit the Chart.yaml changes this the branch
+            nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --app-tag "$tag"" ./scripts/helm/shell.nix
+          else
+            echo "Only tag pushes are supported!"
+            exit 1
+          fi
       - name: Publish Mayastor Helm chart
         uses: stefanprodan/helm-gh-pages@v1.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           charts_dir: .
+

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0-develop"
+appVersion: "2.0.0"
 
 dependencies:
   - name: etcd

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,4 +1,4 @@
 OpenEBS Mayastor has been installed. Check its status by running:
 $ kubectl get pods -n {{ .Release.Namespace }}
 
-For more information or to view the documentation, visit our website at https://openebs.io.
+For more information or to view the documentation, visit our website at https://mayastor.gitbook.io/introduction/.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,7 +4,7 @@ image:
   # image registry's namespace where all Mayastor images exist (default: mayadata)
   repo: mayadata
   # release tag for OpenEBS Mayastor images
-  tag: develop
+  tag: v2.0.0
   # imagePullPolicy for all Mayastor images
   pullPolicy: Always
 

--- a/scripts/helm/publish-chart-yaml.sh
+++ b/scripts/helm/publish-chart-yaml.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+
+# On a new appTag, update the Chart.yaml which is used to publish the chart to the appropriate
+# version and appVersion.
+# For this first iteration version and appVersion in the Chart.yaml *MUST* point to the stable
+# next release 2.0.0
+# When a new appTag is pushed, if it's a prerelease and the prerelease prefix already exists,
+# the version is incremented by 1 and the appVersion is set to the appTag.
+# If the prerelease prefix is newer (eg: moving on from alpha to beta), then both version and appVersions
+# are changed to the appTag.
+# If the appTag is a stable release then both version and appVersions are changed to the appTag.
+
+die()
+{
+  local _return="${2:-1}"
+  echo "$1" >&2
+  exit "${_return}"
+}
+
+set -euo pipefail
+
+# Checks if version is semver and removes "v" from the beginning
+version()
+{
+  version="$1"
+  name="${2:-"The"}"
+  if [ "$(semver validate "$version")" != "valid" ]; then
+    die "$name version $version is not a valid semver!"
+  fi
+  release=$(semver get release "$version")
+  prerel=$(semver get prerel "$version")
+  if [ "$prerel" == "" ]; then
+    echo "$release"
+  else
+    echo "$release-$prerel"
+  fi
+}
+
+# Get the version non-numeric prerelease prefix, eg:
+# version_prefix 2.0.1-alpha.1 -> 2.0.1-alpha
+version_prefix()
+{
+  version=$(version "$1")
+  bump=$(semver bump prerel "$version")
+  common=$(grep -zPo '(.*).*\n\K\1' <<< "$version"$'\n'"$bump" | tr -d '\0')
+  echo "$common"
+}
+
+index_yaml()
+{
+  if [ -n "$INDEX_FILE" ]; then
+    cat "$INDEX_FILE"
+  else
+    git fetch "$INDEX_REMOTE" "$INDEX_BRANCH" --depth 1 2>/dev/null
+    INDEX_FILE_YAML="$(git show "$INDEX_REMOTE"/"$INDEX_BRANCH":"$INDEX_BRANCH_FILE")"
+    echo "$INDEX_FILE_YAML"
+  fi
+}
+
+help() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+  -d, --dry-run                             Output actions that would be taken, but don't run them.
+  -h, --help                                Display this text.
+  --app-tag        <tag>                    The appVersion tag.
+  --override-index <latest_version>         Override the latest chart version from the published chart's index.
+  --index-file     <index_yaml>             Use the provided index.yaml instead of fetching from the git branch.
+  --override-chart <version> <app_version>  Override the Chart.yaml version and app version.
+
+Examples:
+  $(basename "$0") --app-tag v2.0.0-alpha.0
+EOF
+}
+
+SCRIPTDIR="$(dirname "$(realpath "${BASH_SOURCE[0]:-"$0"}")")"
+ROOTDIR="$SCRIPTDIR/../.."
+CHART_FILE=${CHART_FILE:-"$ROOTDIR/chart/Chart.yaml"}
+CHART_VALUES=${CHART_VALUES:-"$ROOTDIR/chart/values.yaml"}
+CHART_NAME="mayastor"
+# Tag that has been pushed
+APP_TAG=
+# Version from the Chart.yaml
+CHART_VERSION=
+# AppVersion from the Chart.yaml
+CHART_APP_VERSION=
+# Latest "most compatible" (matches CHART_VERSION Mmp) version from the Index
+INDEX_LT_VERSION=
+INDEX_REMOTE="${INDEX_REMOTE:-origin}"
+INDEX_BRANCH="gh-pages"
+INDEX_BRANCH_FILE="index.yaml"
+INDEX_FILE=
+DRY_RUN=
+
+# Check if all needed tools are installed
+semver --version >/dev/null
+yq --version >/dev/null
+
+# Parse arguments
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    -d|--dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      help
+      exit 0
+      ;;
+    --app-tag)
+      shift
+      APP_TAG=$1
+      shift
+      ;;
+    --override-index)
+      shift
+      INDEX_LT_VERSION=$1
+      shift
+      ;;
+    --index-file)
+      shift
+      INDEX_FILE=$1
+      shift
+      ;;
+    --override-chart)
+      shift
+      CHART_VERSION=$1
+      shift
+      CHART_APP_VERSION=$1
+      shift
+      ;;
+    *)
+      help
+      die "Unknown option: $1"
+      ;;
+  esac
+done
+
+if [ -z "$APP_TAG" ]; then
+  die "--app-tag not specified"
+fi
+
+if [ -n "$INDEX_FILE" ]; then
+  test -f "$INDEX_FILE" || die "Index file ($INDEX_FILE) not found"
+fi
+
+if [ -z "$CHART_VERSION" ]; then
+  CHART_VERSION=$(yq '.version' "$CHART_FILE")
+fi
+if [ -z "$CHART_APP_VERSION" ]; then
+  CHART_APP_VERSION=$(yq '.appVersion' "$CHART_FILE")
+fi
+
+APP_TAG=$(version "$APP_TAG")
+CHART_VERSION=$(version "$CHART_VERSION")
+CHART_APP_VERSION=$(version "$CHART_APP_VERSION")
+
+echo "APP_TAG: $APP_TAG"
+echo "CHART_VERSION: $CHART_VERSION"
+echo "CHART_APP_VERSION: $CHART_APP_VERSION"
+
+# Allow only for a semver difference of at most prerelease
+allowed_diff=("" "prerelease")
+
+diff="$(semver diff "$CHART_VERSION" "$CHART_APP_VERSION")"
+if ! [[ " ${allowed_diff[*]} " =~ " $diff " ]]; then
+  die "Difference($diff) between CHART_VERSION($CHART_VERSION) CHART_APP_VERSION($CHART_APP_VERSION) not allowed!"
+fi
+
+diff="$(semver diff "$APP_TAG" "$CHART_APP_VERSION")"
+if ! [[ " ${allowed_diff[*]} " =~ " $diff " ]]; then
+  die "Difference($diff) between APP_TAG($APP_TAG) CHART_APP_VERSION($CHART_APP_VERSION) not allowed!"
+fi
+
+if [ "$(semver get prerel "$CHART_VERSION")" != "" ]; then
+  die "Script expects CHART_VERSION($CHART_VERSION) to point to the future stable release"
+fi
+if [ "$(semver get prerel "$CHART_APP_VERSION")" != "" ]; then
+  die "Script expects CHART_APP_VERSION($CHART_APP_VERSION) to point to the future stable release"
+fi
+
+if [ -z "$INDEX_LT_VERSION" ]; then
+  INDEX_FILE_YAML=$(index_yaml)
+  len_versions="$(echo "$INDEX_FILE_YAML" | yq ".entries.${CHART_NAME} | length")"
+  INDEX_VERSIONS=""
+  if [ "$len_versions" != "0" ]; then
+    INDEX_VERSIONS="$(echo "$INDEX_FILE_YAML" | yq ".entries.${CHART_NAME}[].version")"
+  fi
+else
+  INDEX_VERSIONS="$INDEX_LT_VERSION"
+  INDEX_LT_VERSION=
+fi
+
+version_prefix=$(version_prefix "$APP_TAG")
+INDEX_CHART_VERSIONS=$(echo "$INDEX_VERSIONS" | grep "$version_prefix" || echo)
+if [ "$INDEX_CHART_VERSIONS" != "" ]; then
+  INDEX_LT_VERSION=$(echo "$INDEX_CHART_VERSIONS" | sort -r | head -n1)
+fi
+
+if [ "$(echo "$INDEX_VERSIONS" | grep -x "$APP_TAG" || echo)" == "$APP_TAG" ] && [ "$(semver get prerel "$APP_TAG")" == "" ]; then
+  die "A stable chart version $APP_TAG matching the app tag is already in the index. What should I do?"
+fi
+
+if [ -n "$INDEX_LT_VERSION" ]; then
+  INDEX_LT_VERSION=$(version "$INDEX_LT_VERSION" "Latest index")
+  # If the latest index that matches ours is a release
+  if [ "$(semver get prerel "$INDEX_LT_VERSION")" == "" ]; then
+    die "A stable chart version $INDEX_LT_VERSION is already in the index. What should I do?"
+  fi
+fi
+
+if [ "$(semver get prerel "$APP_TAG")" == "" ]; then
+  # It's the stable release!
+  newChartVersion="$APP_TAG"
+  newChartAppVersion="$APP_TAG"
+else
+  if [ "$INDEX_LT_VERSION" == "" ]; then
+    # The first pre-release starts with the app tag
+    newChartVersion="$APP_TAG"
+  else
+    # if the app tag is newer than the index, bump the index to the app tag
+    if [ "$(semver compare "$INDEX_LT_VERSION" "$APP_TAG")" == "-1" ]; then
+      newChartVersion="$APP_TAG"
+    else
+      newChartVersion=$(semver bump prerel "$INDEX_LT_VERSION")
+    fi
+  fi
+
+  newChartAppVersion="$APP_TAG"
+fi
+
+echo "NEW_CHART_VERSION: $newChartVersion"
+echo "NEW_CHART_APP_VERSION: $newChartAppVersion"
+
+if [ -z "$DRY_RUN" ]; then
+  sed -i "s/^version:.*$/version: $newChartVersion/" "$CHART_FILE"
+  sed -i "s/^appVersion:.*$/appVersion: \"$newChartAppVersion\"/" "$CHART_FILE"
+  yq -i ".image.tag |= \"v$newChartAppVersion\"" "$CHART_VALUES"
+fi

--- a/scripts/helm/shell.nix
+++ b/scripts/helm/shell.nix
@@ -1,0 +1,18 @@
+{}:
+let
+  sources = import ../../nix/sources.nix;
+  pkgs = import sources.nixpkgs {
+    overlays = [ (_: _: { inherit sources; }) (import ../../nix/overlay.nix { }) ];
+  };
+in
+with pkgs;
+let
+in
+mkShell {
+  name = "helm-scripts-shell";
+  buildInputs = [
+    git
+    semver-tool
+    yq-go
+  ];
+}

--- a/scripts/helm/test-publish-chart-yaml.sh
+++ b/scripts/helm/test-publish-chart-yaml.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+
+die()
+{
+  local _return="${2:-1}"
+  echo "$1" >&2
+  exit "${_return}"
+}
+
+set -euo pipefail
+
+SCRIPTDIR="$(dirname "$(realpath "${BASH_SOURCE[0]:-"$0"}")")"
+ROOTDIR="$SCRIPTDIR/../.."
+CHART_FILE=${CHART_FILE:-"$ROOTDIR/chart/Chart.yaml"}
+INDEX_REMOTE="${INDEX_REMOTE:-origin}"
+INDEX_FILE=$(mktemp)
+DEBUG=${DEBUG:-}
+
+trap "rm '$INDEX_FILE'" HUP QUIT EXIT TERM INT
+
+# Tag that has been pushed
+APP_TAG=
+# Version from the Chart.yaml
+CHART_VERSION=
+# AppVersion from the Chart.yaml
+CHART_APP_VERSION=
+# Updated Version from the Chart.yaml
+NEW_CHART_VERSION=
+# Updated AppVersion from the Chart.yaml
+NEW_CHART_APP_VERSION=
+INDEX_CHART_VERSIONS=
+EXPECT_FAIL=
+
+build_output()
+{
+  cat <<EOF
+APP_TAG: $APP_TAG
+CHART_VERSION: $CHART_VERSION
+CHART_APP_VERSION: $CHART_APP_VERSION
+NEW_CHART_VERSION: $NEW_CHART_VERSION
+NEW_CHART_APP_VERSION: $NEW_CHART_APP_VERSION
+EOF
+}
+
+build_index_file()
+{
+  cat <<EOF >$INDEX_FILE
+apiVersion: v1
+entries:
+  mayastor:
+EOF
+
+  for v in "${INDEX_CHART_VERSIONS[@]}"
+  do
+    echo "  - version: $v" >> $INDEX_FILE
+  done
+}
+
+call_script()
+{
+  $SCRIPTDIR/publish-chart-yaml.sh --app-tag "$APP_TAG" --override-chart "$CHART_VERSION" "$CHART_APP_VERSION" --index-file "$INDEX_FILE" --dry-run
+}
+
+test_one()
+{
+  RED='\033[0;31m'
+  ORANGE='\033[0;33m'
+  GREEN='\033[0;32m'
+  YEL='\033[1;33m'
+  PRP='\033[0;35m'
+  NC='\033[0m' # No Color
+
+  build_index_file
+  set +e
+  if [ -n "$DEBUG" ]; then
+    actual=$(call_script)
+  else
+    actual=$(call_script 2>/dev/null)
+  fi
+  _err=$?
+  set -e
+
+  if [ $_err != 0 ]; then
+    if [ -z "$EXPECT_FAIL" ]; then
+      echo -e "${PRP}L${NC}$BASH_LINENO${ORANGE} =>${NC} ${RED}FAIL${NC} \$?=$_err"
+    else
+      echo -e "${PRP}L${NC}$BASH_LINENO${ORANGE} =>${NC} ${GREEN}OK${NC} \$?=$_err"
+    fi
+  else
+    output=$(build_output)
+    if [ "$output" != "$actual" ]; then
+      echo -e "${PRP}L${NC}$BASH_LINENO${ORANGE} =>${NC} ${RED}FAIL${NC}"
+      echo -e "${ORANGE}Expected:${NC}\n$output"
+      echo -e "${ORANGE}Actual:${NC}\n$actual"
+    else
+      echo -e "${PRP}L${NC}$BASH_LINENO${ORANGE} =>${NC} ${GREEN}OK${NC}"
+    fi
+  fi
+
+  APP_TAG=
+  CHART_VERSION=
+  CHART_APP_VERSION=
+  INDEX_CHART_VERSIONS=
+  NEW_CHART_VERSION=
+  NEW_CHART_APP_VERSION=
+  EXPECT_FAIL=
+}
+
+APP_TAG=2.0.0-a.0
+CHART_VERSION=2.0.0
+CHART_APP_VERSION=2.0.0
+INDEX_CHART_VERSIONS=()
+NEW_CHART_VERSION=2.0.0-a.0
+NEW_CHART_APP_VERSION=2.0.0-a.0
+EXPECT_FAIL=
+test_one "Add the first alpha version"
+
+APP_TAG=2.0.0-a.0
+CHART_VERSION=2.0.0
+CHART_APP_VERSION=2.0.0
+INDEX_CHART_VERSIONS=(2.0.0-a.0)
+NEW_CHART_VERSION=2.0.0-a.1
+NEW_CHART_APP_VERSION=2.0.0-a.0
+test_one "Adding the first alpha tag, but it already exists in the index, so it gets bumped"
+
+APP_TAG=2.0.0-b.0
+CHART_VERSION=2.0.0
+CHART_APP_VERSION=2.0.0
+INDEX_CHART_VERSIONS=(2.0.0-a.0)
+NEW_CHART_VERSION=2.0.0-b.0
+NEW_CHART_APP_VERSION=2.0.0-b.0
+test_one "Updating to the first beta tag"
+
+APP_TAG=2.0.0-a.1
+CHART_VERSION=2.0.0
+CHART_APP_VERSION=2.0.0
+INDEX_CHART_VERSIONS=(2.0.0-a.0)
+NEW_CHART_VERSION=2.0.0-a.1
+NEW_CHART_APP_VERSION=2.0.0-a.1
+test_one "Updating to a newer prerelease tag within the same prefix"
+
+APP_TAG=2.0.0-b.0
+CHART_VERSION=2.0.0
+CHART_APP_VERSION=2.0.0
+INDEX_CHART_VERSIONS=(2.0.0-a.0 2.0.0-b.3)
+NEW_CHART_VERSION=2.0.0-b.4
+NEW_CHART_APP_VERSION=2.0.0-b.0
+test_one "Updating to the first beta tag, but a newer version already exists in the index, so it gets bumped"
+
+APP_TAG=2.0.0-a.0
+CHART_VERSION=2.0.0-a.0
+CHART_APP_VERSION=2.0.0
+INDEX_CHART_VERSIONS=()
+EXPECT_FAIL=1
+test_one "Chart Version and appVersion must match"
+
+APP_TAG=2.0.0-a.0
+CHART_VERSION=2.0.0
+CHART_APP_VERSION=2.0.0-a.0
+EXPECT_FAIL=1
+test_one "Chart Version and appVersion must match"
+
+APP_TAG=2.0.1
+CHART_VERSION=2.0.0
+CHART_APP_VERSION=2.0.0
+EXPECT_FAIL=1
+test_one "Chart Versions and app tag must not differ more than prerelease"
+
+APP_TAG=2.0.0-b.1
+CHART_VERSION=2.0.0
+CHART_APP_VERSION=2.0.0
+INDEX_CHART_VERSIONS=(2.0.0-c.0)
+NEW_CHART_VERSION=2.0.0-b.1
+NEW_CHART_APP_VERSION=2.0.0-b.1
+test_one "A newer prerelease already exists, update chart on the app tag prerelease prefix"
+
+APP_TAG=2.0.0
+CHART_VERSION=2.0.0
+CHART_APP_VERSION=2.0.0
+INDEX_CHART_VERSIONS=(2.0.0)
+EXPECT_FAIL=1
+test_one "The stable version is already published"
+
+APP_TAG=2.0.0
+CHART_VERSION=2.0.0
+CHART_APP_VERSION=2.0.0
+INDEX_CHART_VERSIONS=(2.0.0-c.0 2.0.0-b.3 2.0.0)
+EXPECT_FAIL=1
+test_one "The stable version is already published"
+
+APP_TAG=2.0.0
+CHART_VERSION=2.0.0
+CHART_APP_VERSION=2.0.0
+INDEX_CHART_VERSIONS=(2.0.1 2.0.0-a.0)
+NEW_CHART_VERSION=2.0.0
+NEW_CHART_APP_VERSION=2.0.0
+test_one "A more stable version is already published, but the app tag stable is new"
+
+echo "Done"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -49,6 +49,7 @@ RM="rm"
 SCRIPTDIR=$(dirname "$0")
 TAG=`get_tag`
 BRANCH=`git rev-parse --abbrev-ref HEAD`
+BRANCH=${BRANCH////-}
 IMAGES=
 DEFAULT_IMAGES="exporters.metrics.pool obs.callhome"
 UPLOAD=

--- a/shell.nix
+++ b/shell.nix
@@ -33,6 +33,8 @@ mkShell {
     python3
     utillinux
     which
+    semver-tool
+    yq-go
   ] ++ pkgs.lib.optional (!norust) channel.default_src.nightly;
 
   PROTOC = "${protobuf}/bin/protoc";


### PR DESCRIPTION
This is an interim solution for this next release until we sort out what the automated procedure will be like.
We'll keep the the versions and images pointing to the v2.0.0 release, so the chart will not be working from the git repo as is, without overriding the image tags.

When a new tag is pushed (eg: 2.0.0-alpha.2), we publish a helm chart with that semver for the appVersion and for the version. Exception: if the version has already increased, we'll simply bump the version.

A test has been added which shows how this works.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>