### PR TITLE
fix(local): pin csi-nodes to io-engine nodes

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -20,7 +20,7 @@ jobs:
           if [ "${{ github.ref_type }}" == "tag" ]; then
             tag="${{ github.ref_name }}"
             # Publish the Chart.yaml locally
-            # Note this does not commit the Chart.yaml changes this the branch
+            # Note this does not commit the Chart.yaml changes to the branch
             nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --app-tag "$tag"" ./scripts/helm/shell.nix
           else
             echo "Only tag pushes are supported!"

--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -34,6 +34,9 @@ spec:
         {{ $key }}: {{ $val }}
         {{- end }}
         {{- end }}
+        {{- if .Values.csi.node.topology.pinToIoEngineDs }}
+        {{- toYaml .Values.mayastor.nodeSelector | nindent 8 }}
+        {{- end }}
       # NOTE: Each container must have mem/cpu limits defined in order to
       # belong to Guaranteed QoS class, hence can never get evicted in case of
       # pressure unless they exceed those limits. limits and requests must be

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -184,6 +184,8 @@ csi:
         openebs.io/csi-node: mayastor
       # add topology segments to the csi-node daemonset node selector
       nodeSelector: false
+      # this ensures the csi-node runs on io-engine nodes
+      pinToIoEngineDs: true
     resources:
       limits:
         # cpu limits for csi node plugin


### PR DESCRIPTION
This ensures volumes can only be published on io-engine nodes, until the HA feature is complete. See existing docs for why this is necessary.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>