### PR TITLE
feat(ha-cluster-agent): added helm template for ha cluster agent

### DIFF
--- a/chart/templates/mayastor/agents/core/agent-core-and-ha-cluster-deployment.yaml
+++ b/chart/templates/mayastor/agents/core/agent-core-and-ha-cluster-deployment.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-agent-core
+  name: {{ .Release.Name }}-agent-core-and-ha-cluster
   labels:
-    app: agent-core
+    app: agent-core-and-ha-cluster
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: agent-core
+      app: agent-core-and-ha-cluster
   template:
     metadata:
       labels:
-        app: agent-core
+        app: agent-core-and-ha-cluster
         openebs.io/logging: "true"
     spec:
       serviceAccount: {{ .Release.Name }}-service-account
@@ -42,6 +42,37 @@ spec:
             - "--grpc-server-addr=0.0.0.0:50051"
           ports:
             - containerPort: 50051
+          env:
+            - name: RUST_LOG
+              value: {{ .Values.agents.core.logLevel }}
+            {{- if default .Values.base.logSilenceLevel .Values.agents.core.logSilenceLevel }}
+            - name: RUST_LOG_SILENCE
+              value: {{ default .Values.base.logSilenceLevel .Values.agents.core.logSilenceLevel }}
+            {{- end }}
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+        - name: agent-ha-cluster
+          resources:
+            limits:
+              cpu: {{ .Values.agents.ha.cluster.resources.limits.cpu | quote }}
+              memory: {{ .Values.agents.ha.cluster.resources.limits.memory | quote }}
+            requests:
+              cpu: {{ .Values.agents.ha.cluster.resources.requests.cpu | quote }}
+              memory: {{ .Values.agents.ha.cluster.resources.requests.memory | quote }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/mayastor-agent-ha-cluster:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-g=0.0.0.0:11500"
+            - "--store {{ .Release.Name }}-etcd:{{ .Values.etcd.service.port }}"
+            - "--core-grpc=0.0.0.0:50051"
+          ports:
+            - containerPort: 11500
           env:
             - name: RUST_LOG
               value: {{ .Values.agents.core.logLevel }}

--- a/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
+++ b/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-agent-core-and-ha-cluster
+  name: {{ .Release.Name }}-agent-core
   labels:
-    app: agent-core-and-ha-cluster
+    app: agent-core
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: agent-core-and-ha-cluster
+      app: agent-core
   template:
     metadata:
       labels:
-        app: agent-core-and-ha-cluster
+        app: agent-core
         openebs.io/logging: "true"
     spec:
       serviceAccount: {{ .Release.Name }}-service-account

--- a/chart/templates/mayastor/agents/core/agent-core-service.yaml
+++ b/chart/templates/mayastor/agents/core/agent-core-service.yaml
@@ -1,13 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-agent-core
+  name: {{ .Release.Name }}-agent-core-and-ha-cluster
   labels:
-    app: agent-core
+    app: agent-core-and-ha-cluster
 spec:
   clusterIP: None
   selector:
-    app: agent-core
+    app: agent-core-and-ha-cluster
   ports:
     - name: grpc
       port: 50051
+    - name: ha-cluster
+      port: 11500

--- a/chart/templates/mayastor/agents/core/agent-core-service.yaml
+++ b/chart/templates/mayastor/agents/core/agent-core-service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-agent-core-and-ha-cluster
+  name: {{ .Release.Name }}-agent-core
   labels:
-    app: agent-core-and-ha-cluster
+    app: agent-core
 spec:
   clusterIP: None
   selector:
-    app: agent-core-and-ha-cluster
+    app: agent-core
   ports:
     - name: grpc
       port: 50051

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -141,7 +141,7 @@ agents:
           memory: "32Mi"
         requests:
           # cpu requests for ha cluster agent
-          cpu: "500m"
+          cpu: "100m"
           # memory requests for ha cluster agent
           memory: "16Mi"
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -131,6 +131,19 @@ agents:
           cpu: "100m"
           # memory requests for ha node agent
           memory: "64Mi"
+    cluster:
+      logLevel: info
+      resources:
+        limits:
+          # cpu limits for ha cluster agent
+          cpu: "100m"
+          # memory limits for ha cluster agent
+          memory: "32Mi"
+        requests:
+          # cpu requests for ha cluster agent
+          cpu: "500m"
+          # memory requests for ha cluster agent
+          memory: "16Mi"
 
 apis:
   rest:


### PR DESCRIPTION
HA cluster agent is added as a separate new container to the `agent-core` deployment since cluster agents depends on core-agent for its working and hence should have the dynamic behaviour as that of the core-agent. Therefore instead of adding `ha-cluster-agent` as a separate deployment, it is added alongside `core-agent`.

Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>