### PR TITLE
build!: set openebs as image registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,7 +120,7 @@ pipeline {
           }
           agent { label 'nixos-mayastor' }
           steps {
-            withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+            withCredentials([usernamePassword(credentialsId: 'OPENEBS_DOCKERHUB', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
               sh 'echo $PASSWORD | docker login -u $USERNAME --password-stdin'
             }
             sh 'printenv'
@@ -163,7 +163,7 @@ pipeline {
         }
       }
       steps {
-        withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+        withCredentials([usernamePassword(credentialsId: 'OPENEBS_DOCKERHUB', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
             sh 'echo $PASSWORD | docker login -u $USERNAME --password-stdin'
         }
         sh 'printenv'

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -10,7 +10,7 @@ let
       inherit extraCommands;
       tag = extensions.version;
       created = "now";
-      name = "mayadata/mayastor-${pname}${image_suffix.${buildType}}";
+      name = "openebs/mayastor-${pname}${image_suffix.${buildType}}";
       contents = [ package ] ++ contents;
       config = {
         Entrypoint = [ package.binary ];


### PR DESCRIPTION
BREAKING CHANGE: Build container images using openebs not mayadata as the registry

Signed-off-by: GlennBullingham <glenn.bullingham@datacore.com>