### PR TITLE
feat(upgrade): set io-engine DaemonSet to use OnDelete updateStrategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 **/*.tfstate*
 **/rust-tags.*
 **/target
-/.idea
+**/.idea
 /default.etcd/
 /node_modules/
 /package-lock.json

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -9,9 +9,7 @@ spec:
     matchLabels:
       app: io-engine
   updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
+    type: OnDelete
   minReadySeconds: 10
   template:
     metadata:


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>

This PR sets the `spec.updateStrategy` on the io-engine DaemonSet to OnDelete. This is required for releases beyond 2.0 when we want to have granular control over the delete sequence of the Mayastor data plane components. This, together with Nexus HA, opens up the possibility for upgrade with live volumes.