### PR TITLE
feat(upgrade): refactor upgrade controller and kubectl plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2872,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.148"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -2891,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.148"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/k8s/plugin/src/constant.rs
+++ b/k8s/plugin/src/constant.rs
@@ -39,7 +39,7 @@ pub(crate) const UPGRADE_OPERATOR_SERVICE: &str = "operator-upgrade";
 pub(crate) const UPGRADE_OPERATOR_SERVICE_PORT: i32 = 8080;
 /// Service internal port constant for upgrade operator.
 pub(crate) const UPGRADE_OPERATOR_INTERNAL_PORT: i32 = 8080;
-/// Upgrade image tag
+/// This is the upgrade-operator container image.
 pub(crate) const UPGRADE_IMAGE: &str = "openebs/mayastor-operator-upgrade:develop";
 /// The service port for upgrade operator.
 pub const UPGRADE_OPERATOR_HTTP_PORT: &str = "http";

--- a/k8s/plugin/src/resources/uo_client.rs
+++ b/k8s/plugin/src/resources/uo_client.rs
@@ -62,7 +62,7 @@ impl UpgradeOperatorClient {
         })
     }
 
-    /// Function to appply the upgrade.
+    /// Function to apply the upgrade.
     pub async fn apply_upgrade(&mut self) -> Result<Option<Vec<String>>, UpgradeClientError> {
         self.upgrade_actions(Method::PUT).await
     }

--- a/k8s/plugin/src/resources/upgrade.rs
+++ b/k8s/plugin/src/resources/upgrade.rs
@@ -297,7 +297,6 @@ impl UpgradeResources {
         } else {
             match action {
                 Actions::Create => {
-                    let ns = Some(ns.to_string());
                     let upgrade_deploy = objects::upgrade_operator_deployment(
                         ns,
                         UPGRADE_IMAGE.to_string(),

--- a/operators/Cargo.toml
+++ b/operators/Cargo.toml
@@ -21,7 +21,8 @@ schemars = "0.8.10"
 serde = "1.0.143"
 serde_json = "1.0.83"
 serde_yaml = "0.9.9"
-tokio = {version="1.20.1", features = ["macros", "rt-multi-thread", "time"]}
+tokio = { version = "1.20.2", features = ["rt-multi-thread", "macros", "time"] }
+actix-web = "4.2.1"
 validator = {version="0.16.0",features=["derive"]}
 tracing = "0.1.36"
 tracing-subscriber = {version = "0.3.15", features = ["env-filter", "std"]}
@@ -33,7 +34,6 @@ once_cell = "1.14.0"
 openapi = {path = "../dependencies/control-plane/openapi"}
 clap = { version = "3.2.16", features = ["cargo", "derive"] }
 url = "2.3.1"
-actix-web = "4.2.1"
 thiserror = "1.0.37"
 humantime = "2.1.0"
 file = "1.1.2"

--- a/operators/src/upgrade/bin/main.rs
+++ b/operators/src/upgrade/bin/main.rs
@@ -1,19 +1,20 @@
 use actix_web::{middleware, HttpServer};
 use operators::upgrade::{
     common::{constants::UPGRADE_OPERATOR_INTERNAL_PORT, error::Error},
-    config::{CliArgs, UpgradeOperatorConfig},
+    config::{CliArgs, UpgradeConfig},
+    controller::reconciler::start_upgrade_worker,
     rest::service,
 };
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
 /// Initialize upgrade operator config that are passed through arguments.
-async fn initialize_operator(args: CliArgs) -> Result<(), Error> {
+async fn initialize_upgrade_config(args: CliArgs) -> Result<(), Error> {
     info!("Initializing Upgrade operator...");
-    UpgradeOperatorConfig::initialize(args).await
+    UpgradeConfig::initialize(args).await
 }
 
-#[actix_web::main]
+#[tokio::main]
 async fn main() -> Result<(), Error> {
     // Initialize logging.
     tracing_subscriber::fmt()
@@ -22,34 +23,48 @@ async fn main() -> Result<(), Error> {
 
     let args = CliArgs::args();
 
-    initialize_operator(args).await.map_err(|error| {
+    initialize_upgrade_config(args).await.map_err(|error| {
         error!(?error, "Failed to initialize Upgrade Operator");
         error
     })?;
 
-    let app = move || {
+    match UpgradeConfig::get_config()
+        .k8s_client()
+        .create_upgrade_action_crd()
+        .await
+    {
+        Ok(()) => info!("UpgradeAction CRD created"),
+        Err(error) => {
+            error!(?error, "Failed to create UpgradeAction CRD");
+            std::process::exit(1);
+        }
+    };
+    info!("Starting Upgrade controller...");
+    tokio::task::spawn(async move { start_upgrade_worker().await });
+
+    // Start Upgrade API.
+    info!(
+        "Starting to listen on port {}...",
+        UPGRADE_OPERATOR_INTERNAL_PORT
+    );
+    HttpServer::new(move || {
         actix_web::App::new()
             .wrap(middleware::Logger::default())
             .service(service::apply_upgrade)
             .service(service::get_upgrade)
-    };
-
-    let app_server = HttpServer::new(app)
-        .bind(("0.0.0.0", UPGRADE_OPERATOR_INTERNAL_PORT))
-        .map_err(|error| {
-            error!(
-                ?error,
-                "Failed to bind API to socket address 0.0.0.0:{}", UPGRADE_OPERATOR_INTERNAL_PORT
-            );
-            Error::from(error)
-        })?;
-
-    // Start Upgrade API.
-    info!(
-        "Starting to listen on port {}",
-        UPGRADE_OPERATOR_INTERNAL_PORT
-    );
-    app_server.workers(2_usize).run().await.map_err(|error| {
+    })
+    .bind(("0.0.0.0", UPGRADE_OPERATOR_INTERNAL_PORT))
+    .map_err(|error| {
+        error!(
+            ?error,
+            "Failed to bind API to socket address 0.0.0.0:{}", UPGRADE_OPERATOR_INTERNAL_PORT
+        );
+        Error::from(error)
+    })?
+    .workers(2_usize)
+    .run()
+    .await
+    .map_err(|error| {
         error!(?error, "Failed to start Upgrade API server");
         Error::from(error)
     })

--- a/operators/src/upgrade/config.rs
+++ b/operators/src/upgrade/config.rs
@@ -8,14 +8,14 @@ use url::Url;
 
 use super::{helm::client::HelmClient, k8s::client::K8sClient};
 
-static CONFIG: OnceCell<UpgradeOperatorConfig> = OnceCell::new();
+static CONFIG: OnceCell<UpgradeConfig> = OnceCell::new();
 
 /// Cli Args to initialize rest-endpoint, namespace and chart.
 #[derive(Parser)]
 #[clap(author, version, about)]
 pub struct CliArgs {
     /// An URL endpoint to the control plane's rest endpoint.
-    #[clap(short, long, default_value = "http://mayastor-api-rest:8081")]
+    #[clap(short = 'e', long, default_value = "http://mayastor-api-rest:8081")]
     rest_endpoint: Url,
 
     /// The namespace we are supposed to operate in.
@@ -23,8 +23,8 @@ pub struct CliArgs {
     namespace: String,
 
     /// The chart_name we are supposed to operate in.
-    #[clap(short, long, default_value = "mayastor")]
-    chart_name: String,
+    #[clap(short = 'r', long, default_value = "mayastor")]
+    release_name: String,
 }
 
 impl CliArgs {
@@ -33,20 +33,20 @@ impl CliArgs {
     }
 }
 
-/// Upgrade operator config that can be passed through arguments.
-pub struct UpgradeOperatorConfig {
+/// Upgrade config that can be passed through arguments.
+pub struct UpgradeConfig {
     k8s_client: K8sClient,
     helm_client: HelmClient,
     rest_client: ApiClient,
     namespace: String,
-    chart_name: String,
+    release_name: String,
 }
 
-impl UpgradeOperatorConfig {
+impl UpgradeConfig {
     /// Initialize operator configs.
     pub async fn initialize(args: CliArgs) -> Result<(), Error> {
         let k8s_client = K8sClient::new().await.map_err(|error| {
-            error!(?error, "failed to generate kube API client");
+            error!(?error, "Failed to generate kube API client");
             error
         })?;
         let rest_endpoint = args.rest_endpoint;
@@ -62,30 +62,30 @@ impl UpgradeOperatorConfig {
             })?;
         let rest_client = ApiClient::new(config_rest);
         let namespace = args.namespace;
-        let chart_name = args.chart_name;
+        let release_name = args.release_name;
         let helm_client = HelmClient::new()
             .await?
-            .with_chart(chart_name.to_string(), namespace.to_string())?;
+            .with_chart(release_name.to_string(), namespace.to_string())?;
 
         CONFIG.get_or_init(|| Self {
             k8s_client,
             helm_client,
             rest_client,
             namespace: namespace.to_string(),
-            chart_name: chart_name.to_string(),
+            release_name: release_name.to_string(),
         });
         Ok(())
     }
 
     /// Get Upgrade operator config.
-    pub(crate) fn get_config() -> &'static UpgradeOperatorConfig {
+    pub fn get_config() -> &'static UpgradeConfig {
         CONFIG
             .get()
             .expect("Upgrade operator config is not initialized")
     }
 
     /// Get k8s client.
-    pub(crate) fn k8s_client(&self) -> K8sClient {
+    pub fn k8s_client(&self) -> K8sClient {
         self.k8s_client.clone()
     }
 
@@ -106,6 +106,6 @@ impl UpgradeOperatorConfig {
 
     /// Get chart name.
     pub(crate) fn chart_name(&self) -> &String {
-        &self.chart_name
+        &self.release_name
     }
 }

--- a/operators/src/upgrade/controller/mod.rs
+++ b/operators/src/upgrade/controller/mod.rs
@@ -1,2 +1,5 @@
 /// Reconciler.
 pub mod reconciler;
+
+/// Utilities for the controller.
+pub mod utils;

--- a/operators/src/upgrade/controller/utils.rs
+++ b/operators/src/upgrade/controller/utils.rs
@@ -1,0 +1,97 @@
+use k8s_openapi::api::core::v1::Pod;
+use kube::{api::ObjectList, ResourceExt};
+use openapi::clients::tower::ApiClient;
+use std::collections::HashSet;
+use tracing::{error, warn};
+
+use crate::upgrade::common::error::Error;
+
+/// This function checks if a set of of Pod uids belong to the Pods from a given
+/// kube::api::ObjectList<Pod>.
+pub(crate) fn at_least_one_pod_uid_exists(
+    uid_set: &HashSet<&String>,
+    pod_list: ObjectList<Pod>,
+) -> bool {
+    for pod in pod_list.iter() {
+        match pod.metadata.uid.as_ref() {
+            Some(uid) => {
+                if uid_set.contains(uid) {
+                    return true;
+                }
+            }
+            None => {
+                // It's ok to panic here because all kubernetes objects should have uids.
+                panic!("Could not list all io-engine Pods' metadata.uids");
+            }
+        }
+    }
+
+    false
+}
+
+/// This function returns 'true' only if all of the containers in the Pods contained in the
+/// ObjectList<Pod> have their Ready status.condition value set to true.
+pub(crate) fn all_pods_are_ready(pod_list: ObjectList<Pod>) -> bool {
+    let not_ready_warning = |pod_name: &String, namespace: &String| {
+        warn!("Couldn't verify the ready condition of io-engine Pod '{}' in namespace '{}' to be true", pod_name, namespace);
+    };
+    for pod in pod_list.iter() {
+        match &pod
+            .status
+            .as_ref()
+            .and_then(|status| status.conditions.as_ref())
+        {
+            Some(conditions) => {
+                for condition in *conditions {
+                    if condition.type_.eq("Ready") && condition.status.eq("True") {
+                        continue;
+                    } else {
+                        not_ready_warning(&pod.name_any(), &pod.namespace().unwrap());
+                        return false;
+                    }
+                }
+            }
+            None => {
+                not_ready_warning(&pod.name_any(), &pod.namespace().unwrap());
+                return false;
+            }
+        }
+    }
+
+    false
+}
+
+/// This function checks if at least one volume is published.
+pub(crate) async fn at_least_one_volume_is_published(
+    rest_client: ApiClient,
+) -> Result<bool, Error> {
+    // The number of volumes to get per request.
+    let max_entries = 200;
+    let mut starting_token = Some(0_isize);
+    let mut volumes = Vec::with_capacity(max_entries as usize);
+
+    // The last paginated request will set the `starting_token` to `None`.
+    while starting_token.is_some() {
+        let vols = rest_client
+            .volumes_api()
+            .get_volumes(max_entries, None, starting_token)
+            .await
+            .map_err(|error| {
+                error!(?error, "Failed to list volumes");
+                error
+            })?;
+
+        let v = vols.into_body();
+        volumes.extend(v.entries);
+        starting_token = v.next_token;
+    }
+
+    // Checking if spec.target exists, spec.target exists only for published volumes.
+    for volume in volumes.into_iter() {
+        if volume.spec.target.is_some() {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}

--- a/operators/src/upgrade/helm/client.rs
+++ b/operators/src/upgrade/helm/client.rs
@@ -1,11 +1,10 @@
+use crate::upgrade::common::{constants::chart_dir_path, error::Error};
 use serde::Deserialize;
 use std::{
     ffi::OsStr,
     path::PathBuf,
     process::{Command, Output},
 };
-
-use crate::upgrade::common::{constants::chart_dir_path, error::Error};
 use tracing::error;
 
 /// Helm arguments that are required to run helm commands.
@@ -132,6 +131,11 @@ impl HelmArgs {
     /// Run helm ls command.
     fn ls(self, exact_match: &String) -> Result<Output, Error> {
         self.run(["ls", "--filter", exact_match, "--output=json"])
+    }
+
+    /// Run helm show chart command
+    fn show_chart(&self) -> Result<Output, Error> {
+        self.run(["show", "chart", chart_dir_path().to_str().unwrap()])
     }
 
     /// Create helm command and run.

--- a/operators/src/upgrade/k8s/client.rs
+++ b/operators/src/upgrade/k8s/client.rs
@@ -1,6 +1,6 @@
 use crate::upgrade::{
     common::constants::components,
-    config::UpgradeOperatorConfig,
+    config::UpgradeConfig,
     k8s::crd::v0::{UpgradeAction, UpgradeActionSpec},
 };
 use k8s_openapi::{
@@ -20,7 +20,7 @@ use crate::upgrade::common::{constants::NODE_LABEL, error::Error};
 
 /// K8sClient is used to talk to the kube-apiserver.
 #[derive(Clone)]
-pub(crate) struct K8sClient {
+pub struct K8sClient {
     client: kube::Client,
 }
 
@@ -59,7 +59,7 @@ impl K8sClient {
     }
 
     /// Creates UpgradeAction CustomResource
-    pub(crate) async fn create_upgrade_action_crd(&self) -> Result<(), Error> {
+    pub async fn create_upgrade_action_crd(&self) -> Result<(), Error> {
         let ua: Api<CustomResourceDefinition> = Api::all(self.client.clone());
         let crds = self.get_crds().await?;
 
@@ -84,10 +84,8 @@ impl K8sClient {
 
     /// GETs UpgradeAction CustomResource from kube-apiserver.
     pub(crate) async fn get_upgrade_action_resource(&self) -> Result<UpgradeAction, Error> {
-        let uas: Api<UpgradeAction> = Api::namespaced(
-            self.client.clone(),
-            UpgradeOperatorConfig::get_config().namespace(),
-        );
+        let uas: Api<UpgradeAction> =
+            Api::namespaced(self.client.clone(), UpgradeConfig::get_config().namespace());
 
         match uas.get("upgrade").await {
             Ok(u) => Ok(u),
@@ -100,10 +98,8 @@ impl K8sClient {
 
     /// get_upgrade_action_resource creates UpgradeAction CustomResource.
     pub(crate) async fn create_upgrade_action_resource(&self) -> Result<UpgradeAction, Error> {
-        let uas: Api<UpgradeAction> = Api::namespaced(
-            self.client.clone(),
-            UpgradeOperatorConfig::get_config().namespace(),
-        );
+        let uas: Api<UpgradeAction> =
+            Api::namespaced(self.client.clone(), UpgradeConfig::get_config().namespace());
         match self.get_upgrade_action_resource().await {
             Ok(u) => {
                 return Ok(u);
@@ -119,11 +115,7 @@ impl K8sClient {
         );
 
         match uas.create(&PostParams::default(), &ua).await {
-            Ok(o) => {
-                tokio::time::sleep(Duration::from_secs(5)).await;
-                Ok(o)
-            }
-
+            Ok(o) => Ok(o),
             Err(error) => {
                 error!(?error, "Failed to create CustomResource");
                 tokio::time::sleep(Duration::from_secs(1)).await;

--- a/operators/src/upgrade/k8s/crd/v0.rs
+++ b/operators/src/upgrade/k8s/crd/v0.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, str::FromStr};
 use validator::Validate;
 
+/// Define spec for upgrade action.
 #[derive(
     CustomResource,
     Serialize,
@@ -34,8 +35,6 @@ use validator::Validate;
     printcolumn = r#"{"name":"Target Version", "type":"string", "jsonPath":".spec.target_version"}"#,
     printcolumn = r#"{"name":"Current Version", "type":"string", "jsonPath":".spec.current_version"}"#
 )]
-
-/// Define spec for upgrade action.
 pub struct UpgradeActionSpec {
     /// Records the current version of the product.
     #[validate(regex = "SEMVER_RE")]
@@ -80,15 +79,15 @@ impl UpgradeActionSpec {
 /// 'UpgradePhase' defines the status of each components.
 #[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
 pub enum UpgradePhase {
-    /// Components in Waiting phase.
+    // Components in Waiting phase.
     Waiting,
-    /// Components in Updating phase.
+    // Components in Updating phase.
     Updating,
-    /// Components in Verifying phase which comnes after updationg.
+    // Components in Verifying phase which comes after update.
     Verifying,
-    /// Components in Completed phase which denotes updateion is complete.
+    // Components in Completed phase which denotes update is complete.
     Completed,
-    /// Components in Error phase.
+    // Components in Error phase.
     Error,
 }
 
@@ -121,18 +120,18 @@ impl From<UpgradePhase> for String {
 /// 'UpgradeState' defines the status of upgradeaction resource.
 #[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
 pub enum UpgradeState {
-    /// Upgrade in NotStarted phase, which denotes cr is created.
+    // Upgrade in NotStarted phase, which denotes cr is created.
     NotStarted,
-    /// Upgrade in UpdatingControlPlane phase, which denotes helm chart upgrade has been started.
+    // Upgrade in UpdatingControlPlane phase, which denotes helm chart upgrade has been started.
     UpdatingControlPlane,
-    /// Upgrade in UpdatingDataPlane phase, which denotes that the io-engine
-    /// DaemonSet pods are being restarted.
+    // Upgrade in UpdatingDataPlane phase, which denotes that the io-engine
+    // DaemonSet pods are being restarted.
     UpdatingDataPlane,
-    /// Upgrade in VerifyingUpdate phase, which denotes components has completed updating phase.
+    // Upgrade in VerifyingUpdate phase, which denotes components has completed updating phase.
     VerifyingUpdate,
-    /// Upgrade in SuccessfulUpdate phase, which denotes upgrade has been successfully verified.
+    // Upgrade in SuccessfulUpdate phase, which denotes upgrade has been successfully verified.
     SuccessfulUpdate,
-    /// Upgrade in Error state.
+    // Upgrade in Error state.
     Error,
 }
 

--- a/operators/src/upgrade/phases/preflight.rs
+++ b/operators/src/upgrade/phases/preflight.rs
@@ -1,13 +1,10 @@
 use tracing::log::error;
 
-use crate::upgrade::{common::error::Error, config::UpgradeOperatorConfig};
+use crate::upgrade::{common::error::Error, config::UpgradeConfig};
 
 /// check node status.
 async fn check_node_health() -> Result<bool, Error> {
-    let nodes = UpgradeOperatorConfig::get_config()
-        .k8s_client()
-        .get_nodes()
-        .await?;
+    let nodes = UpgradeConfig::get_config().k8s_client().get_nodes().await?;
     for n in nodes {
         match n.status {
             Some(status) => match status.conditions {
@@ -36,7 +33,7 @@ async fn check_node_health() -> Result<bool, Error> {
 
 /// check volume targets.
 async fn check_volume_targets() -> Result<bool, Error> {
-    let volumes = UpgradeOperatorConfig::get_config()
+    let volumes = UpgradeConfig::get_config()
         .rest_client()
         .volumes_api()
         .get_volumes(0, None, None)

--- a/operators/src/upgrade/phases/updating.rs
+++ b/operators/src/upgrade/phases/updating.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 
 use crate::upgrade::{
     common::{constants::DEFAULT_VALUES_PATH, error::Error},
-    config::UpgradeOperatorConfig,
+    config::UpgradeConfig,
 };
 
 // Create a new file to store values.
@@ -28,7 +28,7 @@ pub(crate) fn values_pathfile() -> Result<PathBuf, Error> {
 /// Start updating components.
 pub async fn components_update(opts: Vec<(String, String)>) -> Result<(), Error> {
     let output_filepath = values_pathfile().unwrap();
-    let output = UpgradeOperatorConfig::get_config()
+    let output = UpgradeConfig::get_config()
         .helm_client()
         .get_values()
         .unwrap();
@@ -36,7 +36,7 @@ pub async fn components_update(opts: Vec<(String, String)>) -> Result<(), Error>
 
     fs::write(output_filepath.clone(), output)?;
 
-    match UpgradeOperatorConfig::get_config()
+    match UpgradeConfig::get_config()
         .helm_client()
         .upgrade(vec![output_filepath.clone()], opts)
         .await


### PR DESCRIPTION
Upgrade operator changes:
- run controller asynchronously/respond to apply upgrade REST call
- add check to see if the io-engine pods all come to running state after upgrade
- add check to verify if all volumes are unpublished before restarting io-engine
- add loop to retry data-plane upgrade
- add check to verify if io-engine pods are restarted


Kubectl plugin changes:
- update upgrade operator deployment args flags
- add get, list, create, delete, patch permissions for poddisruptionbudget resource

Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>