### PR TITLE
chore(etcd/compaction): enable compaction by default

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -304,6 +304,21 @@ etcd:
   # Ignored if lifecycleHooks is set or replicaCount=1
   removeMemberOnContainerTermination: false
 
+  # AutoCompaction
+  # Since etcd keeps an exact history of its keyspace, this history should be
+  # periodically compacted to avoid performance degradation
+  # and eventual storage space exhaustion.
+  # Auto compaction mode. Valid values: "periodic", "revision".
+  # - 'periodic' for duration based retention, defaulting to hours if no time unit is provided (e.g. 5m).
+  # - 'revision' for revision number based retention.
+  autoCompactionMode: revision
+  # Auto compaction retention length. 0 means disable auto compaction.
+  autoCompactionRetention: 100
+  extraEnvVars:
+    # Raise alarms when backend size exceeds the given quota.
+    - name: ETCD_QUOTA_BACKEND_BYTES
+      value: "8589934592" # 8GiB
+
   auth:
     rbac:
       enabled: false


### PR DESCRIPTION
Add compaction after 100 revisions.
Set space quota to 8GiB to prevent the keyspace from growing excessively large.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>