### PR TITLE
feat(upgrade): fetch and use release name for upgrade components

### DIFF
--- a/k8s/plugin/src/constant.rs
+++ b/k8s/plugin/src/constant.rs
@@ -1,14 +1,3 @@
-// macros to define mayastor related objects.
-#[macro_export]
-macro_rules! upgrade_group {
-    () => {
-        "mayastor"
-    };
-    ($s:literal) => {
-        concat!(upgrade_group!(), "-", $s)
-    };
-}
-
 /// macros to define labels for upgrade operator.
 #[macro_export]
 macro_rules! upgrade_labels {
@@ -23,6 +12,11 @@ macro_rules! upgrade_labels {
     };
 }
 
+/// Append the release name to k8s objects.
+pub(crate) fn upgrade_group(release_name: &str, name: &str) -> String {
+    format!("{}-{}", release_name, name)
+}
+
 /// Upgrade endpoint
 pub(crate) const UPGRADE_OPERATOR_END_POINT: &str = "/upgrade";
 /// label used for upgrade operator.
@@ -32,17 +26,15 @@ pub(crate) const LABEL: &str = "app";
 /// Upgrade operator.
 pub(crate) const UPGRADE_OPERATOR: &str = "operator-upgrade";
 /// Service account name for upgrade operator.
-pub(crate) const UPGRADE_OPERATOR_SERVICE_ACCOUNT: &str =
-    upgrade_group!("operator-upgrade-service-account");
+pub(crate) const UPGRADE_OPERATOR_SERVICE_ACCOUNT: &str = "operator-upgrade-service-account";
 /// Role constant for upgrade operator.
-pub(crate) const UPGRADE_OPERATOR_CLUSTER_ROLE: &str = upgrade_group!("operator-upgrade-role");
+pub(crate) const UPGRADE_OPERATOR_CLUSTER_ROLE: &str = "operator-upgrade-role";
 /// Role binding constant for upgrade operator.
-pub(crate) const UPGRADE_OPERATOR_CLUSTER_ROLE_BINDING: &str =
-    upgrade_group!("operator-upgrade-role-binding");
+pub(crate) const UPGRADE_OPERATOR_CLUSTER_ROLE_BINDING: &str = "operator-upgrade-role-binding";
 /// Deployment constant for upgrade operator.
-pub(crate) const UPGRADE_CONTROLLER_DEPLOYMENT: &str = upgrade_group!("operator-upgrade");
+pub(crate) const UPGRADE_CONTROLLER_DEPLOYMENT: &str = "operator-upgrade";
 /// Service name constant for upgrade operator.
-pub(crate) const UPGRADE_OPERATOR_SERVICE: &str = upgrade_group!("operator-upgrade");
+pub(crate) const UPGRADE_OPERATOR_SERVICE: &str = "operator-upgrade";
 /// Service port constant for upgrade operator.
 pub(crate) const UPGRADE_OPERATOR_SERVICE_PORT: i32 = 8080;
 /// Service internal port constant for upgrade operator.
@@ -51,3 +43,7 @@ pub(crate) const UPGRADE_OPERATOR_INTERNAL_PORT: i32 = 8080;
 pub(crate) const UPGRADE_IMAGE: &str = "openebs/mayastor-operator-upgrade:develop";
 /// The service port for upgrade operator.
 pub const UPGRADE_OPERATOR_HTTP_PORT: &str = "http";
+/// Defines the Label select for mayastor
+pub(crate) const API_REST_LABEL_SELECTOR: &str = "app=api-rest";
+/// Defines the default release name
+pub(crate) const DEFAULT_RELEASE_NAME: &str = "mayastor";


### PR DESCRIPTION
As suggested by @tiagolobocastro , we nee to read the release name present as  label `helm-release` and use that name to create the upgarde resources.

I just used `ashish` and release name and the o/p looks like 
```
NAME                                       READY   STATUS    RESTARTS   AGE
ashish-agent-core-79cd9d4747-jwh6s         2/2     Running   0          11m
ashish-agent-ha-node-mv65c                 1/1     Running   0          11m
ashish-agent-ha-node-tdgtk                 1/1     Running   0          11m
ashish-agent-ha-node-z857z                 1/1     Running   0          11m
ashish-api-rest-5675f5767d-pc6zv           1/1     Running   0          11m
ashish-csi-controller-f84cd68f4-kvf5q      3/3     Running   0          11m
ashish-csi-node-q7wh7                      2/2     Running   0          11m
ashish-csi-node-s9qht                      2/2     Running   0          11m
ashish-csi-node-x6grf                      2/2     Running   0          11m
ashish-etcd-0                              1/1     Running   0          11m
ashish-etcd-1                              1/1     Running   0          11m
ashish-etcd-2                              1/1     Running   0          11m
ashish-io-engine-bhsn6                     2/2     Running   0          11m
ashish-io-engine-fqc6p                     2/2     Running   0          11m
ashish-io-engine-nwc47                     2/2     Running   0          11m
ashish-loki-0                              1/1     Running   0          11m
ashish-obs-callhome-7dbd5cb9b6-pj9zn       1/1     Running   0          11m
ashish-operator-diskpool-dd9d7974b-8ltnn   1/1     Running   0          11m
ashish-operator-upgrade-6b7b5548fd-qg6bb   1/1     Running   0          10m
```


Signed-off-by: sinhaashish <ashi.sinha.87@gmail.com>