### PR TITLE
chore: switch grpc api version to v1

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -241,7 +241,7 @@ csi:
 mayastor:
   # logLevel for the core crate and other dependent crates
   logLevel: info,io_engine=info
-  api: "v0"
+  api: "v1"
   target:
     nvmf:
       # NVMF target interface (ip, mac, name or subnet)


### PR DESCRIPTION
Update values.yaml so that the default
version of the grpc API is now v1 from v0