### PR TITLE
fix: make darwin images statically linked

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -26,10 +26,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: cachix/install-nix-action@v17
+      - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos
-      - run: nix-build -A utils.release.${{ matrix.target }}.kubectl-plugin --arg incremental false
+          extra_nix_config: extra-platforms = aarch64-darwin
+      - run: |
+          nix-build -A utils.release.${{ matrix.target }}.kubectl-plugin --arg incremental false ${{ matrix.system }}
       - uses: actions/upload-artifact@v3
         with:
           name: kubectl-mayastor-${{ matrix.arch }}-${{ matrix.target }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,7 +99,6 @@ pipeline {
         sh 'nix-shell --run "./dependencies/control-plane/scripts/rust/generate-openapi-bindings.sh"'
         sh 'nix-shell --run "cargo fmt --all -- --check"'
         sh 'nix-shell --run "cargo clippy --all-targets -- -D warnings"'
-        sh 'nix-shell --run "black ."'
       }
     }
     stage('test') {

--- a/call-home/src/main.rs
+++ b/call-home/src/main.rs
@@ -76,7 +76,10 @@ async fn run() -> anyhow::Result<()> {
         })?;
 
     // Generate Mayastor REST client.
-    let config = Configuration::new(endpoint, time::Duration::from_secs(30), None, None, true)
+    let config = Configuration::builder()
+        .with_timeout(time::Duration::from_secs(30))
+        .with_tracing(true)
+        .build_url(endpoint)
         .map_err(|error| anyhow::anyhow!("failed to create openapi configuration: {:?}", error))?;
     let client = openapi::clients::tower::ApiClient::new(config);
 

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,10 @@
-{ allInOne ? true, incremental ? false, img_tag ? "" }:
+{ system ? null, allInOne ? true, incremental ? false, img_tag ? "" }:
 let
   sources = import ./nix/sources.nix;
+  hostSystem = (import sources.nixpkgs { }).hostPlatform.system;
   pkgs = import sources.nixpkgs {
     overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix { inherit allInOne incremental img_tag; }) ];
+    system = if system != null then system else hostSystem;
   };
 in
 pkgs

--- a/k8s/plugin/Cargo.toml
+++ b/k8s/plugin/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [features]
 default = [ "rls" ]
 rls = [ "openapi/tower-client-rls", "rest-plugin/rls" ]
-tls = [ "openapi/tower-client-tls", "rest-plugin/rls" ]
+tls = [ "openapi/tower-client-tls", "rest-plugin/tls" ]
 
 
 [dependencies]

--- a/nix/pkgs/extensions/cargo-project.nix
+++ b/nix/pkgs/extensions/cargo-project.nix
@@ -68,7 +68,8 @@ let
     "dependencies/control-plane/common"
     "dependencies/control-plane/utils"
     "dependencies/control-plane/rpc"
-    "dependencies/control-plane/k8s" # remove when we purge proxy+support from ctrlplane
+    "dependencies/control-plane/k8s/forward"
+    "dependencies/control-plane/k8s/operators"
     "k8s"
   ];
   src = whitelistSource ../../../. src_list;

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -4,7 +4,7 @@
 
 { dockerTools, lib, extensions, busybox, gnupg, kubernetes-helm-wrapped, runCommand, img_tag ? "" }:
 let
-  helm_chart_src = builtins.filterSource (path: type: true ) ../../../chart;
+  helm_chart_src = builtins.filterSource (path: type: true) ../../../chart;
   image_suffix = { "release" = ""; "debug" = "-debug"; "coverage" = "-coverage"; };
   build-extensions-image = { pname, buildType, package, extraCommands ? '''', contents ? [ ], config ? { } }:
     dockerTools.buildImage {

--- a/nix/pkgs/utils/default.nix
+++ b/nix/pkgs/utils/default.nix
@@ -23,6 +23,9 @@ let
       ./dependencies/control-plane/scripts/rust/generate-openapi-bindings.sh --skip-git-diff
     fi
   '';
+  static_ssl = (pkgs.openssl.override {
+    static = true;
+  });
 
   components = { release ? false }: {
     windows-gnu = {
@@ -79,20 +82,33 @@ let
     # Can only be built on apple-darwin
     apple-darwin = rec {
       target = channel.makeRustTarget pkgs.pkgsStatic.hostPlatform;
-      x86_64-apple-darwin = channel.makeRustTarget pkgs.pkgsCross.x86_64-darwin.hostPlatform;
       naersk = naersk_package (channel.static {
         inherit target;
       });
-      check_assert = lib.asserts.assertMsg (target == x86_64-apple-darwin) "This may only be built on ${x86_64-apple-darwin}";
+      check_assert = lib.asserts.assertMsg (pkgs.hostPlatform.isDarwin == true) "This may only be built on darwin";
 
       kubectl-plugin = naersk.buildPackage {
         inherit release src version singleStep GIT_VERSION_LONG GIT_VERSION check_assert;
         name = "kubectl-plugin";
 
-        preBuild = preBuildOpenApi;
+        preBuild = preBuildOpenApi + ''
+          export OPENSSL_STATIC=1
+          export OPENSSL_LIB_DIR=${static_ssl.out}/lib
+          export OPENSSL_INCLUDE_DIR=${static_ssl.dev}/include
+        '';
         inherit LIBCLANG_PATH PROTOC PROTOC_INCLUDE;
         cargoBuildOptions = attrs: attrs ++ [ "-p" "kubectl-plugin" ];
-        nativeBuildInputs = with pkgs; [ clang openapi-generator which git openssl.dev ];
+        nativeBuildInputs = with pkgs; [
+          clang
+          openapi-generator
+          which
+          git
+          pkg-config
+          (libiconv.override {
+            enableStatic = true;
+            enableShared = false;
+          })
+        ];
         doCheck = false;
         usePureFromTOML = true;
 

--- a/operators/src/upgrade/config.rs
+++ b/operators/src/upgrade/config.rs
@@ -50,19 +50,16 @@ impl UpgradeOperatorConfig {
             error
         })?;
         let rest_endpoint = args.rest_endpoint;
-        let config_rest = Configuration::new(
-            rest_endpoint,
-            time::Duration::from_secs(30),
-            None,
-            None,
-            true,
-        )
-        .map_err(|error| Error::OpenapiClientConfigurationErr {
-            source: anyhow::anyhow!(
-                "Failed to create openapi configuration, Error: '{:?}'",
-                error
-            ),
-        })?;
+        let config_rest = Configuration::builder()
+            .with_timeout(time::Duration::from_secs(30))
+            .with_tracing(true)
+            .build_url(rest_endpoint)
+            .map_err(|error| Error::OpenapiClientConfigurationErr {
+                source: anyhow::anyhow!(
+                    "Failed to create openapi configuration, Error: '{:?}'",
+                    error
+                ),
+            })?;
         let rest_client = ApiClient::new(config_rest);
         let namespace = args.namespace;
         let chart_name = args.chart_name;

--- a/shell.nix
+++ b/shell.nix
@@ -14,9 +14,6 @@ let
   channel = import ./nix/lib/rust.nix { inherit sources; };
   rust_chan = channel.default_src;
   rust = rust_chan.${rust-profile};
-  # python environment for tests/bdd
-  pytest_inputs = python3.withPackages
-    (ps: with ps; [ virtualenv grpcio grpcio-tools black ]);
 in
 mkShell {
   name = "extensions-shell";
@@ -24,22 +21,22 @@ mkShell {
     cacert
     cargo-expand
     cargo-udeps
+    clang
     commitlint
     cowsay
     git
     kubernetes-helm-wrapped
-    clang
-    openapi-generator
-    libxfs
     llvmPackages.libclang
+    nixpkgs-fmt
+    openapi-generator
     openssl
     pkg-config
     pre-commit
-    pytest_inputs
     python3
     utillinux
     which
-  ] ++ pkgs.lib.optional (!norust) channel.default_src.nightly;
+  ] ++ pkgs.lib.optional (!norust) channel.default_src.nightly
+  ++ pkgs.lib.optional (system == "aarch64-darwin") darwin.apple_sdk.frameworks.Security;
 
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";

--- a/shell.nix
+++ b/shell.nix
@@ -35,6 +35,7 @@ mkShell {
     python3
     utillinux
     which
+    niv
   ] ++ pkgs.lib.optional (!norust) channel.default_src.nightly
   ++ pkgs.lib.optional (system == "aarch64-darwin") darwin.apple_sdk.frameworks.Security;
 


### PR DESCRIPTION
fix: make darwin images statically linked

Openssl and libiconv were dynamically linked, which won't work... as they were pointing
to the nix store path.
Sadly on darwin pkgsStatic is not really static:
https://github.com/NixOS/nixpkgs/issues/120862
So we have to build our own static openssl and libiconv, which can take sometime.
todo: use cachix to speed up most builds.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

feat(nix-shell): add support for aarch64-darwin

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
