### PR TITLE
chore: add config for reactor freeze detection

### DIFF
--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -88,7 +88,8 @@ spec:
         - "--ptpl-dir=/var/local/io-engine/ptpl/"{{ end }}
         - "--api-versions={{ .Values.mayastor.api }}"{{ if .Values.mayastor.target.nvmf.iface }}
         - "-T={{ .Values.mayastor.target.nvmf.iface }}"{{ end }}{{ if .Values.mayastor.envcontext }}
-        - "--env-context=--{{ .Values.mayastor.envcontext }}"{{ end }}
+        - "--env-context=--{{ .Values.mayastor.envcontext }}"{{ end }}{{ if .Values.mayastor.reactorFreezeDetection.enabled }}
+        - "--reactor-freeze-detection"{{ end }}
         command:
         - io-engine
         securityContext:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -246,9 +246,12 @@ mayastor:
       # Reservations Persist Through Power Loss State
       ptpl: true
   # Pass additional arguments to the Environment Abstraction Layer.
-  # as a workaorund for mayastor io-engine on Intel Xeon E-2278G CPU @ 3.40GHz 
+  # as a workaorund for mayastor io-engine on Intel Xeon E-2278G CPU @ 3.40GHz
   # Example: --set {product}.envcontext=iova-mode=pa
   envcontext: ""
+  # Pass additional command line arguments to io-engine container
+  reactorFreezeDetection:
+    enabled: false
   cpuCount: "2"
   # node selectors to designate mayastor nodes for diskpool creation
   # Note that if multi-arch images support 'kubernetes.io/arch: amd64'


### PR DESCRIPTION
Modify io-engine-daemonset.yaml to optionally add the
reactor freeze detection command line argument
for mayastor io-engine
