### PR TITLE
ci: bump timeout to 2 hours

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ String cron_schedule = mainBranches() ? "0 2 * * *" : ""
 pipeline {
   agent none
   options {
-    timeout(time: 1, unit: 'HOURS')
+    timeout(time: 2, unit: 'HOURS')
   }
   parameters {
     booleanParam(defaultValue: false, name: 'build_images')


### PR DESCRIPTION
With so many builds it takes ever more to get free agents. todo: add more build agents?

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>