### PR TITLE
ci: pin nix to 2.12

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -28,6 +28,7 @@ jobs:
           submodules: recursive
       - uses: cachix/install-nix-action@v18
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.12.0/install
           nix_path: nixpkgs=channel:nixos
           extra_nix_config: extra-platforms = aarch64-darwin
       - uses: cachix/cachix-action@v12


### PR DESCRIPTION
See https://github.com/NixOS/nix/issues/7624
Should resolve the GHA build failures.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>