### PR TITLE
fix(upgrade): remove labels carrying the chart version from LabelSelectors for Services, Deployments, DaemonSets, StatefulSets

### DIFF
--- a/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
+++ b/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
@@ -12,7 +12,6 @@ spec:
     matchLabels:
       app: agent-core
       {{ include "label_prefix" . }}/release: {{ .Release.Name }}
-      {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
   template:
     metadata:
       labels:

--- a/chart/templates/mayastor/agents/core/agent-core-service.yaml
+++ b/chart/templates/mayastor/agents/core/agent-core-service.yaml
@@ -11,7 +11,6 @@ spec:
   selector:
     app: agent-core
     {{ include "label_prefix" . }}/release: {{ .Release.Name }}
-    {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
   ports:
     - name: grpc
       port: 50051

--- a/chart/templates/mayastor/agents/ha/ha-node-daemonset.yaml
+++ b/chart/templates/mayastor/agents/ha/ha-node-daemonset.yaml
@@ -12,7 +12,6 @@ spec:
     matchLabels:
       app: agent-ha-node
       {{ include "label_prefix" . }}/release: {{ .Release.Name }}
-      {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:

--- a/chart/templates/mayastor/apis/api-rest-deployment.yaml
+++ b/chart/templates/mayastor/apis/api-rest-deployment.yaml
@@ -12,7 +12,6 @@ spec:
     matchLabels:
       app: api-rest
       {{ include "label_prefix" . }}/release: {{ .Release.Name }}
-      {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
   template:
     metadata:
       labels:

--- a/chart/templates/mayastor/apis/api-rest-service.yaml
+++ b/chart/templates/mayastor/apis/api-rest-service.yaml
@@ -11,7 +11,6 @@ spec:
   selector:
     app: api-rest
     {{ include "label_prefix" . }}/release: {{ .Release.Name }}
-    {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
   ports:
     - port: 8080
       name: https

--- a/chart/templates/mayastor/csi/csi-controller-deployment.yaml
+++ b/chart/templates/mayastor/csi/csi-controller-deployment.yaml
@@ -12,7 +12,6 @@ spec:
     matchLabels:
       app: csi-controller
       {{ include "label_prefix" . }}/release: {{ .Release.Name }}
-      {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
   template:
     metadata:
       labels:

--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -14,7 +14,6 @@ spec:
     matchLabels:
       app: csi-node
       {{ include "label_prefix" . }}/release: {{ .Release.Name }}
-      {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -11,7 +11,6 @@ spec:
     matchLabels:
       app: io-engine
       {{ include "label_prefix" . }}/release: {{ .Release.Name }}
-      {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
   updateStrategy:
     type: OnDelete
   minReadySeconds: 10

--- a/chart/templates/mayastor/metrics/metrics-exporter-pool-service.yaml
+++ b/chart/templates/mayastor/metrics/metrics-exporter-pool-service.yaml
@@ -17,5 +17,4 @@ spec:
   selector:
     app: io-engine
     {{ include "label_prefix" . }}/release: {{ .Release.Name }}
-    {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
 {{- end }}

--- a/chart/templates/mayastor/obs/obs-callhome-deployment.yaml
+++ b/chart/templates/mayastor/obs/obs-callhome-deployment.yaml
@@ -13,7 +13,6 @@ spec:
     matchLabels:
       app: obs-callhome
       {{ include "label_prefix" . }}/release: {{ .Release.Name }}
-      {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
   template:
     metadata:
       labels:

--- a/chart/templates/mayastor/operators/operator-diskpool-deployment.yaml
+++ b/chart/templates/mayastor/operators/operator-diskpool-deployment.yaml
@@ -12,7 +12,6 @@ spec:
     matchLabels:
       app: operator-diskpool
       {{ include "label_prefix" . }}/release: {{ .Release.Name }}
-      {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
**Why is this change required?**

v1.LabelSelectors cannot be patched during helm upgrade, hence it should only carry labels which don't change across helm chart versions.

Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>