### PR TITLE
chore(chart): raise memory limits for agent-core and agent-ha-cluster

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -54,12 +54,12 @@ $ helm install my-release openebs/mayastor
 |-----|-------------|:-------:|
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;logLevel | Log level for the core service | `"info"` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for core agents | `"1000m"` |
-| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;memory | Memory limits for core agents | `"32Mi"` |
+| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;memory | Memory limits for core agents | `"128Mi"` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;cpu | Cpu requests for core agents | `"500m"` |
-| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;memory | Memory requests for core agents | `"16Mi"` |
+| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;memory | Memory requests for core agents | `"32Mi"` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;cluster.&ZeroWidthSpace;logLevel | Log level for the ha cluster service | `"info"` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;cluster.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for ha cluster agent | `"100m"` |
-| agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;cluster.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;memory | Memory limits for ha cluster agent | `"32Mi"` |
+| agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;cluster.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;memory | Memory limits for ha cluster agent | `"64Mi"` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;cluster.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;cpu | Cpu requests for ha cluster agent | `"100m"` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;cluster.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;memory | Memory requests for ha cluster agent | `"16Mi"` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;node.&ZeroWidthSpace;logLevel | Log level for the ha node service | `"info"` |

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -124,12 +124,12 @@ agents:
         # -- Cpu limits for core agents
         cpu: "1000m"
         # -- Memory limits for core agents
-        memory: "32Mi"
+        memory: "128Mi"
       requests:
         # -- Cpu requests for core agents
         cpu: "500m"
         # -- Memory requests for core agents
-        memory: "16Mi"
+        memory: "32Mi"
   ha:
     enabled: true
     node:
@@ -154,7 +154,7 @@ agents:
           # -- Cpu limits for ha cluster agent
           cpu: "100m"
           # -- Memory limits for ha cluster agent
-          memory: "32Mi"
+          memory: "64Mi"
         requests:
           # -- Cpu requests for ha cluster agent
           cpu: "100m"


### PR DESCRIPTION
Changes:
- Raise memory limit for agent-core container to 128MiB
- Raise memory request for agent-core container to 32MiB
- Raise memory limit for HA cluster agent to 64MiB

Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>