### PR TITLE
feat(call-home): use version_info crate to generate git version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "utils",
 ]
 
 [[package]]

--- a/call-home/Cargo.toml
+++ b/call-home/Cargo.toml
@@ -14,7 +14,7 @@ kube = { version = "0.78.0", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.17.0", features = ["v1_20"] }
 futures = "0.3.26"
 tokio = { version = "1.25.0", features = ["full"] }
-clap = { version = "4.1.4", features = ["cargo", "derive"] }
+clap = { version = "4.1.8", features = ["cargo", "derive", "string"] }
 serde_json = "1.0.93"
 serde_yaml = "0.9.17"
 serde = { version = "1.0.152", features = ["derive"] }
@@ -32,3 +32,4 @@ chrono = "0.4.23"
 rand = "0.8.5"
 tempfile = "3.3.0"
 humantime = "2.1.0"
+utils = { path = "../dependencies/control-plane/utils/utils-lib" }

--- a/call-home/src/common/constants.rs
+++ b/call-home/src/common/constants.rs
@@ -2,6 +2,7 @@ use std::{
     env,
     path::{Path, PathBuf},
 };
+use utils::version_info;
 
 /// PRODUCT is the name of the project for which this call-home component is deployed.
 pub(crate) const PRODUCT: &str = "Mayastor";
@@ -63,5 +64,11 @@ pub(crate) fn call_home_frequency() -> std::time::Duration {
         .unwrap()
 }
 
-/// Release version
-pub(crate) const RELEASE_VERSION: &str = "2.0.1";
+/// Returns the git tag version (if tag is found) or simply returns the commit hash (12 characters).
+pub(crate) fn release_version() -> String {
+    let version_info = version_info!();
+    match version_info.version_tag {
+        Some(tag) => tag,
+        None => version_info.commit_hash,
+    }
+}

--- a/call-home/src/main.rs
+++ b/call-home/src/main.rs
@@ -18,16 +18,17 @@ use tokio::time::sleep;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 use url::Url;
+use utils::{package_description, version_info_str};
 
 #[derive(Parser)]
-#[clap(author, version, about)]
+#[command(name = package_description!(), version = version_info_str!())]
 struct CliArgs {
     /// An URL endpoint to the control plane's rest endpoint.
-    #[clap(short, long, default_value = "http://mayastor-api-rest:8081")]
+    #[arg(short, long, default_value = "http://mayastor-api-rest:8081")]
     endpoint: Url,
 
     /// The namespace we are supposed to operate in.
-    #[clap(short, long, default_value = "mayastor")]
+    #[arg(short, long, default_value = "mayastor")]
     namespace: String,
 }
 impl CliArgs {
@@ -50,7 +51,7 @@ async fn main() {
 
 async fn run() -> anyhow::Result<()> {
     let args = CliArgs::args();
-    let version = RELEASE_VERSION.to_string();
+    let version = release_version();
     let endpoint = args.endpoint;
     let namespace = digest(args.namespace);
 

--- a/call-home/src/transmitter/client.rs
+++ b/call-home/src/transmitter/client.rs
@@ -40,7 +40,7 @@ impl Receiver {
             .client
             .post(&self.url)
             .header("CAStor-Cluster-Id", &self.cluster_id)
-            .header("CAStor-Version", RELEASE_VERSION)
+            .header("CAStor-Version", release_version())
             .header("CAStor-Report-Type", "health_report")
             .header("CAStor-Product", PRODUCT)
             .header("CAStor-Time", Utc::now().to_string())


### PR DESCRIPTION
This change uses the version_info crate from the openebs/mayastor-dependencies repo (via dependencies/control-plane git submodule's dependency) to generate the version for the call-home payload and the HTTP header.

This uses the git tag, if present, otherwise defaults to the commit hash for the HEAD commit of the repo branch.