### PR TITLE
feat(call-home): use version_info crate to generate git version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "utils",
 ]
 
 [[package]]
@@ -4124,19 +4125,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4146,9 +4147,9 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4158,9 +4159,9 @@ checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4170,9 +4171,9 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4182,15 +4183,15 @@ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4200,9 +4201,9 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"

--- a/call-home/Cargo.toml
+++ b/call-home/Cargo.toml
@@ -32,3 +32,4 @@ chrono = "0.4.22"
 rand = "0.8.5"
 mktemp = "0.4.1"
 humantime = "2.1.0"
+utils = { path = "../dependencies/control-plane/utils/utils-lib" }

--- a/call-home/src/common/constants.rs
+++ b/call-home/src/common/constants.rs
@@ -2,6 +2,7 @@ use std::{
     env,
     path::{Path, PathBuf},
 };
+use utils::version_info;
 
 /// PRODUCT is the name of the project for which this call-home component is deployed.
 pub(crate) const PRODUCT: &str = "Mayastor";
@@ -63,5 +64,11 @@ pub(crate) fn call_home_frequency() -> std::time::Duration {
         .unwrap()
 }
 
-/// Release version
-pub(crate) const RELEASE_VERSION: &str = "2.0.1";
+/// Returns the git tag version (if tag is found) or simply returns the commit hash (12 characters).
+pub(crate) fn release_version() -> String {
+    let version_info = version_info!();
+    match version_info.version_tag {
+        Some(tag) => tag,
+        None => version_info.commit_hash,
+    }
+}

--- a/call-home/src/main.rs
+++ b/call-home/src/main.rs
@@ -18,9 +18,10 @@ use tokio::time::sleep;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 use url::Url;
+use utils::{package_description, version_info_str};
 
 #[derive(Parser)]
-#[clap(author, version, about)]
+#[clap(name = package_description!(), version = version_info_str!())]
 struct CliArgs {
     /// An URL endpoint to the control plane's rest endpoint.
     #[clap(short, long, default_value = "http://mayastor-api-rest:8081")]
@@ -50,7 +51,7 @@ async fn main() {
 
 async fn run() -> anyhow::Result<()> {
     let args = CliArgs::args();
-    let version = RELEASE_VERSION.to_string();
+    let version = release_version();
     let endpoint = args.endpoint;
     let namespace = digest(args.namespace);
 

--- a/call-home/src/transmitter/client.rs
+++ b/call-home/src/transmitter/client.rs
@@ -40,7 +40,7 @@ impl Receiver {
             .client
             .post(&self.url)
             .header("CAStor-Cluster-Id", &self.cluster_id)
-            .header("CAStor-Version", RELEASE_VERSION)
+            .header("CAStor-Version", release_version())
             .header("CAStor-Report-Type", "health_report")
             .header("CAStor-Product", PRODUCT)
             .header("CAStor-Time", Utc::now().to_string())


### PR DESCRIPTION
This ports the changes from #125 for release/2.0 branch