### PR TITLE
ci: allow patch version different when publishing

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -40,7 +40,7 @@ base:
         command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-agent-core 50051; do date; echo "Waiting for agent-core-grpc services..."; sleep 1; done;']
       - name: etcd-probe
         image: busybox:latest
-        command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-etcd {{ .Values.etcd.service.port }}; do date; echo "Waiting for etcd..."; sleep 1; done;']
+        command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-etcd {{.Values.etcd.service.port}}; do date; echo "Waiting for etcd..."; sleep 1; done;']
   initHaNodeContainers:
     enabled: true
     containers:
@@ -52,7 +52,7 @@ base:
     containers:
       - name: etcd-probe
         image: busybox:latest
-        command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-etcd {{ .Values.etcd.service.port }}; do date; echo "Waiting for etcd..."; sleep 1; done;']
+        command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-etcd {{.Values.etcd.service.port}}; do date; echo "Waiting for etcd..."; sleep 1; done;']
   # docker-secrets required to pull images if the container registry from image.Registry is protected
   imagePullSecrets:
     # -- Enable imagePullSecrets for pulling our container images

--- a/scripts/helm/publish-chart-yaml.sh
+++ b/scripts/helm/publish-chart-yaml.sh
@@ -49,7 +49,7 @@ branch_chart_version()
   elif [ "$RELEASE_V" != "${CHECK_BRANCH}" ]; then
     if [ "$(semver validate "$RELEASE_V")" == "valid" ]; then
       echo "$RELEASE_V"
-    elif  [ "$(semver validate "$RELEASE_V.0")" == "valid" ]; then
+    elif [ "$(semver validate "$RELEASE_V.0")" == "valid" ]; then
       echo "$RELEASE_V.0"
     else
       die "Cannot determine Chart version from branch: $CHECK_BRANCH"
@@ -217,8 +217,8 @@ echo "APP_TAG: $APP_TAG"
 echo "CHART_VERSION: $CHART_VERSION"
 echo "CHART_APP_VERSION: $CHART_APP_VERSION"
 
-# Allow only for a semver difference of at most prerelease
-allowed_diff=("" "prerelease")
+# Allow only for a semver difference of at most patch
+allowed_diff=("" "patch" "prerelease")
 
 diff="$(semver diff "$CHART_VERSION" "$CHART_APP_VERSION")"
 if ! [[ " ${allowed_diff[*]} " =~ " $diff " ]]; then

--- a/scripts/helm/test-publish-chart-yaml.sh
+++ b/scripts/helm/test-publish-chart-yaml.sh
@@ -235,11 +235,11 @@ CHART_APP_VERSION=2.0.0-a.0
 EXPECT_FAIL=1
 test_one "Chart Version and appVersion must match"
 
-APP_TAG=2.0.1
+APP_TAG=2.1.0
 CHART_VERSION=2.0.0
 CHART_APP_VERSION=2.0.0
 EXPECT_FAIL=1
-test_one "Chart Versions and app tag must not differ more than prerelease"
+test_one "Chart Versions and app tag must not differ more than patch"
 
 APP_TAG=2.0.0-b.1
 CHART_VERSION=2.0.0


### PR DESCRIPTION
style: remove spaces for etcd port within init containers

This should help fix linter errors on openebs/charts

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

ci: allow patch version different when publishing

This will allows to publish 2.0.x where x > 0
TODO: add check for previous tag so we can restrict to bumps of 1 as otherwise
the current script would allows us to publish v2.0.9 for example!

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>