### PR TITLE
feat(upgrade): list single volume replica before upgrade

### DIFF
--- a/console-logger/src/console.rs
+++ b/console-logger/src/console.rs
@@ -6,10 +6,10 @@ pub fn info(message: &str) {
 }
 
 /// Print warning on console.
-pub fn warn(data: &str, message: &str) {
+pub fn warn(message: &str, data: &str) {
     println!(
-        "{} {} ",
-        Red.bold().italic().paint(message),
-        Cyan.bold().italic().paint(data)
+        "{} \n {} ",
+        Cyan.bold().italic().paint(message),
+        Red.bold().italic().paint(data)
     );
 }

--- a/k8s/plugin/src/main.rs
+++ b/k8s/plugin/src/main.rs
@@ -166,11 +166,14 @@ async fn execute(cli_args: CliArgs) {
                 }
             },
             Operations::Upgrade(resources) => {
-                let _ignore = preflight_validations::preflight_check()
-                    .await
-                    .map_err(|_e| {
-                        std::process::exit(1);
-                    });
+                let _ignore = preflight_validations::preflight_check(
+                    cli_args.kube_config_path.clone(),
+                    cli_args.timeout,
+                )
+                .await
+                .map_err(|_e| {
+                    std::process::exit(1);
+                });
                 resources
                     .apply(
                         &cli_args.namespace,

--- a/k8s/upgrade/src/constant.rs
+++ b/k8s/upgrade/src/constant.rs
@@ -47,3 +47,5 @@ pub const UPGRADE_OPERATOR_HTTP_PORT: &str = "http";
 pub(crate) const API_REST_LABEL_SELECTOR: &str = "app=api-rest";
 /// Defines the default release name
 pub(crate) const DEFAULT_RELEASE_NAME: &str = "mayastor";
+/// Volumes with one replica
+pub(crate) const SINGLE_REPLICA_VOLUME: u8 = 1;

--- a/k8s/upgrade/src/lib.rs
+++ b/k8s/upgrade/src/lib.rs
@@ -2,6 +2,8 @@
 pub mod constant;
 /// Validations before applying upgrade
 pub mod preflight_validations;
+/// Library for upgrade module.
+pub mod upgrade_lib;
 /// Module for resources of upgrade
 pub mod upgrade_resources;
 /// Module for user messages

--- a/k8s/upgrade/src/preflight_validations.rs
+++ b/k8s/upgrade/src/preflight_validations.rs
@@ -1,26 +1,143 @@
-use crate::user_prompt;
-use operators::upgrade::{common::error, controller::reconciler};
+use crate::{
+    constant::SINGLE_REPLICA_VOLUME, upgrade_lib, upgrade_resources::upgrade::get_pvc_from_uuid,
+    user_prompt,
+};
+use openapi::models::CordonDrainState;
+use operators::upgrade::common::error;
+use std::{collections::HashSet, path::PathBuf};
+use tracing::error;
 
 /// Validation to be done before applying upgrade.
-pub async fn preflight_check() -> Result<(), error::Error> {
+pub async fn preflight_check(
+    kube_config_path: Option<PathBuf>,
+    timeout: humantime::Duration,
+) -> Result<(), error::Error> {
     console_logger::info(user_prompt::UPGRADE_WARNING);
-    rebuild_in_progress_validation().await?;
+    // Initialise the REST client.
+    let config = kube_proxy::ConfigBuilder::default_api_rest()
+        .with_kube_config(kube_config_path.clone())
+        .with_timeout(*timeout)
+        .build()
+        .await?;
+
+    let rest_client = upgrade_lib::RestClient::new_with_config(config);
+
+    rebuild_in_progress_validation(&rest_client).await?;
+
+    already_cordoned_nodes_validation(&rest_client).await?;
+
+    single_volume_replica_validation(&rest_client).await?;
+    Ok(())
+}
+
+/// Check for already cordoned node
+pub async fn already_cordoned_nodes_validation(
+    client: &upgrade_lib::RestClient,
+) -> Result<(), error::Error> {
+    let mut cordoned_nodes_list = Vec::new();
+    let nodes = client.nodes_api().get_nodes().await?;
+    let nodelist = nodes.into_body();
+    for node in nodelist {
+        let node_spec = match node.spec {
+            Some(node_spec) => node_spec,
+            None => return Err(error::Error::NodeSpecNotPresent { node: node.id }),
+        };
+        if matches!(
+            node_spec.cordondrainstate,
+            Some(CordonDrainState::cordonedstate(_))
+        ) {
+            cordoned_nodes_list.push(node.id);
+        }
+    }
+    if !cordoned_nodes_list.is_empty() {
+        console_logger::warn(
+            user_prompt::CORDONED_NODE_WARNING,
+            &cordoned_nodes_list.join("\n"),
+        );
+    }
+    Ok(())
+}
+
+/// Check single replica volumes.
+pub async fn single_volume_replica_validation(
+    client: &upgrade_lib::RestClient,
+) -> Result<(), error::Error> {
+    // let mut single_replica_volumes = Vec::new();
+    // The number of volumes to get per request.
+    let max_entries = 200;
+    let mut starting_token = Some(0_isize);
+    let mut volumes = Vec::with_capacity(max_entries as usize);
+
+    // The last paginated request will set the `starting_token` to `None`.
+    while starting_token.is_some() {
+        let vols = client
+            .volumes_api()
+            .get_volumes(max_entries, None, starting_token)
+            .await
+            .map_err(|error| {
+                error!(?error, "Failed to list volumes");
+                error
+            })?;
+
+        let v = vols.into_body();
+        let single_rep_vol_ids: Vec<String> = v
+            .entries
+            .into_iter()
+            .filter(|volume| volume.spec.num_replicas == SINGLE_REPLICA_VOLUME)
+            .map(|volume| volume.spec.uuid.to_string())
+            .collect();
+        volumes.extend(single_rep_vol_ids);
+        starting_token = v.next_token;
+    }
+
+    let data = get_pvc_from_uuid(HashSet::from_iter(volumes))
+        .await?
+        .join("\n");
+
+    console_logger::warn(user_prompt::SINGLE_REPLICA_VOLUME_WARNING, &data);
+    Ok(())
+}
+
+/// Prompt to user if any rebuild in progress.
+pub async fn rebuild_in_progress_validation(
+    client: &upgrade_lib::RestClient,
+) -> Result<(), error::Error> {
+    if rebuild_in_progress(client).await? {
+        console_logger::warn(user_prompt::REBUILD_WARNING, "");
+    }
     Ok(())
 }
 
 /// Check for rebuild in progress.
-pub async fn rebuild_in_progress_validation() -> Result<(), error::Error> {
-    match reconciler::is_rebuilding().await {
-        Ok(is_rebuilding) => {
-            if is_rebuilding {
-                console_logger::warn(user_prompt::REBUILD_WARNING, "");
-                std::process::exit(1);
+pub async fn rebuild_in_progress(client: &upgrade_lib::RestClient) -> Result<bool, error::Error> {
+    // The number of volumes to get per request.
+    let max_entries = 200;
+    let mut starting_token = Some(0_isize);
+
+    // The last paginated request will set the `starting_token` to `None`.
+    while starting_token.is_some() {
+        let vols = client
+            .volumes_api()
+            .get_volumes(max_entries, None, starting_token)
+            .await
+            .map_err(|error| {
+                error!(?error, "Failed to list volumes");
+                error
+            })?;
+
+        let volumes = vols.into_body();
+        starting_token = volumes.next_token;
+        for volume in volumes.entries {
+            if let Some(target) = &volume.state.target {
+                if target
+                    .children
+                    .iter()
+                    .any(|child| child.rebuild_progress.is_some())
+                {
+                    return Ok(true);
+                }
             }
         }
-        Err(error) => {
-            println!("Failed in fetching the rebuild status {error}");
-            return Err(error);
-        }
     }
-    Ok(())
+    Ok(false)
 }

--- a/k8s/upgrade/src/upgrade_lib.rs
+++ b/k8s/upgrade/src/upgrade_lib.rs
@@ -1,0 +1,25 @@
+use openapi::clients::tower::{self, Configuration};
+use std::ops::Deref;
+
+/// New-Type for a RestClient over the tower openapi client.
+#[derive(Clone, Debug)]
+pub struct RestClient {
+    client: tower::ApiClient,
+}
+
+impl Deref for RestClient {
+    type Target = tower::ApiClient;
+
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}
+
+impl RestClient {
+    /// Create new Rest Client from the given `Configuration`.
+    pub fn new_with_config(config: Configuration) -> RestClient {
+        Self {
+            client: tower::ApiClient::new(config),
+        }
+    }
+}

--- a/k8s/upgrade/src/user_prompt.rs
+++ b/k8s/upgrade/src/user_prompt.rs
@@ -1,5 +1,11 @@
 /// Warning to users before doing an upgrade.
-pub const UPGRADE_WARNING: &str =  "Volumes which make use of a single volume replica instance will be unavailable for some time during upgrade.\nIt is recommended that you do not create new volumes which make use of only one volume replica.";
+pub const UPGRADE_WARNING: &str =  "\nVolumes which make use of a single volume replica instance will be unavailable for some time during upgrade.\nIt is recommended that you do not create new volumes which make use of only one volume replica.";
 
 /// Warning to users before doing an upgrade.
-pub const REBUILD_WARNING: &str =  "The cluster is rebuilding replica of some volumes.\nPlease try after some time or skip this validation by retrying with '--ignore-rebuild` flag.";
+pub const REBUILD_WARNING: &str =  "\nThe cluster is rebuilding replica of some volumes.\nPlease try after some time or skip this validation by retrying with '--ignore-rebuild` flag.";
+
+/// Warning to users before doing an upgrade
+pub const SINGLE_REPLICA_VOLUME_WARNING: &str =  "\nThe list below shows the single replica volumes in cluster.\nThese single replica volumes may not be accessible during upgrade.\nTo skip this validation, please retry  with '--skip-single-replica-volume-validation` flag.";
+
+/// Warning to users before doing an upgrade.
+pub const CORDONED_NODE_WARNING: &str =  "\nBelow are the list of cordoned nodes. Since there are some cordoned nodes, \nthe rebuild will happen on another nodes so please have enough available free space or else the rebuild will get stuck forever.";

--- a/operators/src/upgrade/controller/reconciler.rs
+++ b/operators/src/upgrade/controller/reconciler.rs
@@ -572,12 +572,9 @@ pub async fn is_node_cordoned(node_name: &str) -> Result<bool, Error> {
 
 /// Function to check for any volume rebuild in progress across the cluster
 pub async fn is_rebuilding() -> Result<bool, Error> {
-    let mut is_rebuilding = false;
-
     // The number of volumes to get per request.
     let max_entries = 200;
     let mut starting_token = Some(0_isize);
-    let mut volumes = Vec::with_capacity(max_entries as usize);
 
     // The last paginated request will set the `starting_token` to `None`.
     while starting_token.is_some() {
@@ -591,24 +588,19 @@ pub async fn is_rebuilding() -> Result<bool, Error> {
                 error
             })?;
 
-        let v = vols.into_body();
-        volumes.extend(v.entries);
-        starting_token = v.next_token;
-    }
-
-    for volume in volumes.into_iter() {
-        is_rebuilding = if let Some(target) = &volume.state.target {
-            target
-                .children
-                .iter()
-                .any(|child| child.rebuild_progress.is_some())
-        } else {
-            false
-        };
-
-        if is_rebuilding {
-            break;
+        let volumes = vols.into_body();
+        starting_token = volumes.next_token;
+        for volume in volumes.entries {
+            if let Some(target) = &volume.state.target {
+                if target
+                    .children
+                    .iter()
+                    .any(|child| child.rebuild_progress.is_some())
+                {
+                    return Ok(true);
+                }
+            }
         }
     }
-    Ok(is_rebuilding)
+    Ok(false)
 }


### PR DESCRIPTION
The o/p of kubeclt-mayastor upgrade
``` 
ashish@vm:~/code/rust/mayastor-extensions(single-replica)$ ./target/debug/kubectl-mayastor  upgrade

Volumes which make use of a single volume replica instance will be unavailable for some time during upgrade.
It is recommended that you do not create new volumes which make use of only one volume replica.

Below are the list of cordoned nodes. Since there are some cordoned nodes,
 the rebuild will happen on another nodes so please have enough available free space or else the rebuild will get stuck forever.
 node-0-64716

The list below shows the single replica volumes in cluster.
These single replica volumes may not be accessible during upgrade.
To skip this validation, please retry  with '--skip-single-replica-volume-validation` flag.
 ms-volume-claim
```