### PR TITLE
feat(io-engine/cores): add missing core list

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -106,6 +106,7 @@ $ helm install my-release openebs/mayastor
 | etcd.&ZeroWidthSpace;persistence.&ZeroWidthSpace;reclaimPolicy | PVC's reclaimPolicy | `"Delete"` |
 | etcd.&ZeroWidthSpace;persistence.&ZeroWidthSpace;size | Volume size | `"2Gi"` |
 | etcd.&ZeroWidthSpace;persistence.&ZeroWidthSpace;storageClass | Will define which storageClass to use in etcd's StatefulSets a `manual` storageClass will provision a hostpath PV on the same node an empty storageClass will use the default StorageClass on the cluster | `""` |
+| etcd.&ZeroWidthSpace;podAntiAffinityPreset | Pod anti-affinity preset Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity | `"hard"` |
 | etcd.&ZeroWidthSpace;removeMemberOnContainerTermination | Use a PreStop hook to remove the etcd members from the etcd cluster on container termination Ignored if lifecycleHooks is set or replicaCount=1 | `false` |
 | etcd.&ZeroWidthSpace;replicaCount | Number of replicas of etcd | `3` |
 | image.&ZeroWidthSpace;pullPolicy | ImagePullPolicy for our images | `"Always"` |

--- a/chart/README.md
+++ b/chart/README.md
@@ -112,9 +112,10 @@ $ helm install my-release openebs/mayastor
 | image.&ZeroWidthSpace;registry | Image registry to pull our product images | `"docker.io"` |
 | image.&ZeroWidthSpace;repo | Image registry's namespace | `"openebs"` |
 | image.&ZeroWidthSpace;tag | Release tag for our images | `"develop"` |
-| io_engine.&ZeroWidthSpace;cpuCount | The number of cpu that each io-engine instance will bind to. | `"2"` |
+| io_engine.&ZeroWidthSpace;coreList | If not empty, overrides the cpuCount and explicitly sets the list of cores. Example: --set='io_engine.coreList={30,31}' | `[]` |
+| io_engine.&ZeroWidthSpace;cpuCount | The number of cores that each io-engine instance will bind to. | `"2"` |
 | io_engine.&ZeroWidthSpace;envcontext | Pass additional arguments to the Environment Abstraction Layer. Example: --set {product}.envcontext=iova-mode=pa | `""` |
-| io_engine.&ZeroWidthSpace;logLevel | Log level for the io-engine service | `"info,io_engine=info"` |
+| io_engine.&ZeroWidthSpace;logLevel | Log level for the io-engine service | `"info"` |
 | io_engine.&ZeroWidthSpace;nodeSelector | Node selectors to designate storage nodes for diskpool creation Note that if multi-arch images support 'kubernetes.io/arch: amd64' should be removed. | <pre>{<br>"kubernetes.io/arch":"amd64",<br>"openebs.io/engine":"mayastor"<br>}</pre> |
 | io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for the io-engine | `""` |
 | io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;hugepages2Mi | Hugepage size available on the nodes | `"2Gi"` |

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -98,14 +98,38 @@ Usage:
     {{- end }}
 {{- end -}}
 
-{{/* Generate CPU list specification based on CPU count (-l param of mayastor) */}}
+{{/* Generate Core list specification (-l param of io-engine) */}}
 {{- define "cpuFlag" -}}
-{{- range $i, $e := until (int .Values.io_engine.cpuCount) }}
-{{- if gt $i 0 }}
-    {{- printf "," }}
-{{- end }}
-{{- printf "%d" (add $i 1) }}
-{{- end }}
+{{- include "coreListUniq" . -}}
+{{- end -}}
+
+{{/* Get the number of cores from the coreList */}}
+{{- define "coreCount" -}}
+{{- include "coreListUniq" . | split "," | len -}}
+{{- end -}}
+
+{{/* Get a list of cores as a comma-separated list */}}
+{{- define "coreListUniq" -}}
+{{- if .Values.io_engine.coreList -}}
+{{- $cores_pre := .Values.io_engine.coreList -}}
+{{- if not (kindIs "slice" .Values.io_engine.coreList) -}}
+{{- $cores_pre = list $cores_pre -}}
+{{- end -}}
+{{- $cores := list -}}
+{{- range $index, $value := $cores_pre | uniq -}}
+{{- $value = $value | toString | replace " " "" }}
+{{- if eq ($value | int | toString) $value -}}
+{{-   $cores = append $cores $value -}}
+{{- end -}}
+{{- end -}}
+{{- $first := first $cores | required (print "At least one core must be specified in io_engine.coreList") -}}
+{{- $cores | join "," -}}
+{{- else -}}
+{{- if gt 1 .Values.io_engine.cpuCount -}}
+{{- fail ".Values.io_engine.cpuCount must be >= 1" -}}
+{{- end -}}
+{{- untilStep 1 (add 1 .Values.io_engine.cpuCount | int) 1 | join "," -}}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -75,7 +75,7 @@ spec:
         - "--nvme-core-io-timeout={{ .Values.csi.node.nvme.io_timeout }}"{{ end }}{{ if .Values.csi.node.nvme.ctrl_loss_tmo }}
         - "--nvme-ctrl-loss-tmo={{ .Values.csi.node.nvme.ctrl_loss_tmo }}"{{ end }}{{ if .Values.csi.node.nvme.keep_alive_tmo }}
         - "--nvme-keep-alive-tmo={{ .Values.csi.node.nvme.keep_alive_tmo }}"{{ end }}
-        - "--nvme-nr-io-queues={{ .Values.io_engine.cpuCount }}"
+        - "--nvme-nr-io-queues={{ include "coreCount" . }}"
         {{- range $key, $val := .Values.csi.node.topology.segments }}
         - "--node-selector={{ $key }}={{ $val }}"
         {{- end }}

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -109,11 +109,11 @@ spec:
           mountPath: /dev/hugepages
         resources:
           limits:
-            cpu: {{ .Values.io_engine.resources.limits.cpu | default .Values.io_engine.cpuCount | quote }}
+            cpu: {{ .Values.io_engine.resources.limits.cpu | default (include "coreCount" .) | quote }}
             memory: {{ .Values.io_engine.resources.limits.memory | quote }}
             hugepages-2Mi: {{ .Values.io_engine.resources.limits.hugepages2Mi | quote }}
           requests:
-            cpu: {{ .Values.io_engine.resources.requests.cpu | default .Values.io_engine.cpuCount | quote }}
+            cpu: {{ .Values.io_engine.resources.requests.cpu | default (include "coreCount" .) | quote }}
             memory: {{ .Values.io_engine.resources.requests.memory | quote }}
             hugepages-2Mi: {{ .Values.io_engine.resources.requests.hugepages2Mi | quote }}
         ports:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,7 +7,7 @@ image:
   tag: develop
   repoTags:
     # Note: Below image tag configuration is optional and typically should never be
-    #       used. Setting specific image tags for the different repositories proves useful 
+    #       used. Setting specific image tags for the different repositories proves useful
     #       for some integration testing scenarios. Use the 'tag' option above to set
     #       release/pre-release container image tags.
     #       The below tag values will be picked for images by default.
@@ -260,7 +260,7 @@ csi:
 
 io_engine:
   # -- Log level for the io-engine service
-  logLevel: info,io_engine=info
+  logLevel: info
   api: "v1"
   target:
     nvmf:
@@ -273,8 +273,11 @@ io_engine:
   envcontext: ""
   reactorFreezeDetection:
     enabled: false
-  # -- The number of cpu that each io-engine instance will bind to.
+  # -- The number of cores that each io-engine instance will bind to.
   cpuCount: "2"
+  # -- If not empty, overrides the cpuCount and explicitly sets the list of cores.
+  # Example: --set='io_engine.coreList={30,31}'
+  coreList: []
   # -- Node selectors to designate storage nodes for diskpool creation
   # Note that if multi-arch images support 'kubernetes.io/arch: amd64'
   # should be removed.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -362,9 +362,13 @@ etcd:
   # extra debug information on logs
   debug: false
   initialClusterState: "new"
-  # Pod anti-affinity preset
+
+  # -- Pod anti-affinity preset
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   podAntiAffinityPreset: "hard"
+  ## -- nodeSelector [object] Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  nodeSelector: {}
 
   # etcd service parameters defines how the etcd service is exposed
   service:


### PR DESCRIPTION
Allows specifying the exact list of cores.
Examples:
--set='io_engine.coreList=1'
--set='io_engine.coreList={1,2,3}'

Also adds validation to ensure the coreCount is always >= 1 and all cores are unique.