### PR TITLE
add list of pods in dry run flag 

### DIFF
--- a/console-logger/src/console.rs
+++ b/console-logger/src/console.rs
@@ -1,8 +1,12 @@
 use nu_ansi_term::Color::{Cyan, Red};
 
 /// Print info on console.
-pub fn info(message: &str) {
-    println!("{}", Cyan.bold().italic().paint(message));
+pub fn info(message: &str, data: &str) {
+    println!(
+        "{} \n {} ",
+        Cyan.bold().italic().paint(message),
+        Cyan.bold().italic().paint(data)
+    );
 }
 
 /// Print warning on console.

--- a/k8s/plugin/src/main.rs
+++ b/k8s/plugin/src/main.rs
@@ -157,7 +157,10 @@ async fn execute(cli_args: CliArgs) {
                 .map_err(|_e| {
                     std::process::exit(1);
                 });
-                if !resources.dry_run {
+
+                if resources.dry_run {
+                    let _ = resources.dummy_apply(&cli_args.namespace).await;
+                } else {
                     resources.apply(&cli_args.namespace).await;
                 }
             }

--- a/k8s/upgrade/src/constant.rs
+++ b/k8s/upgrade/src/constant.rs
@@ -16,6 +16,17 @@ pub(crate) fn upgrade_name_concat(release_name: &str, component_name: &str) -> S
     format!("{release_name}-{component_name}")
 }
 
+/// Append the tag to image in upgrade.
+pub(crate) fn upgrade_image_concat(image_repo: &str, image_name: &str, image_tag: &str) -> String {
+    format!("{image_repo}/{image_name}:{image_tag}")
+}
+
+/// Upgrade job container image tag.
+pub(crate) const UPGRADE_JOB_IMAGE_TAG: &str = "develop";
+/// Upgrade job container image repository.
+pub(crate) const UPGRADE_JOB_IMAGE_REPO: &str = "openebs";
+/// Upgrade job container image name.
+pub(crate) const UPGRADE_JOB_IMAGE_NAME: &str = "mayastor-upgrade-job";
 /// Upgrade job name suffix.
 pub(crate) const UPGRADE_JOB_NAME_SUFFIX: &str = "upgrade";
 /// ServiceAccount name suffix for upgrade job.
@@ -28,11 +39,15 @@ pub(crate) const UPGRADE_JOB_CLUSTERROLEBINDING_NAME_SUFFIX: &str = "upgrade-rol
 pub(crate) const UPGRADE_BINARY_NAME: &str = "upgrade-job";
 /// Upgrade job container name.
 pub(crate) const UPGRADE_JOB_CONTAINER_NAME: &str = "mayastor-upgrade-job";
-/// Upgrade job container image.
-pub(crate) const UPGRADE_JOB_IMAGE: &str = "openebs/mayastor-upgrade-job:develop";
 /// Defines the Label select for mayastor REST API.
 pub(crate) const API_REST_LABEL_SELECTOR: &str = "app=api-rest";
 /// Defines the default helm chart release name.
 pub(crate) const DEFAULT_RELEASE_NAME: &str = "mayastor";
 /// Volumes with one replica
 pub(crate) const SINGLE_REPLICA_VOLUME: u8 = 1;
+/// IO_ENGINE_POD_LABEL is the Kubernetes Pod label set on mayastor-io-engine Pods.
+pub(crate) const IO_ENGINE_POD_LABEL: &str = "app=io-engine";
+/// AGENT_CORE_POD_LABEL is the Kubernetes Pod label set on mayastor-agent-core Pods.
+pub(crate) const AGENT_CORE_POD_LABEL: &str = "app=agent-core";
+/// API_REST_POD_LABEL is the Kubernetes Pod label set on mayastor-api-rest Pods.
+pub(crate) const API_REST_POD_LABEL: &str = "app=api-rest";

--- a/k8s/upgrade/src/lib.rs
+++ b/k8s/upgrade/src/lib.rs
@@ -1,10 +1,10 @@
-/// Module for upgrade related constants
+/// Module for upgrade related constants.
 pub mod constant;
-/// Validations before applying upgrade
+/// Validations before applying upgrade.
 pub mod preflight_validations;
 /// Library for upgrade module.
 pub mod upgrade_lib;
-/// Module for resources of upgrade
+/// Module for resources of upgrade.
 pub mod upgrade_resources;
-/// Module for user messages
+/// Module for user messages.
 pub mod user_prompt;

--- a/k8s/upgrade/src/preflight_validations.rs
+++ b/k8s/upgrade/src/preflight_validations.rs
@@ -14,7 +14,7 @@ pub async fn preflight_check(
     ignore_single_replica: bool,
     skip_replica_rebuild: bool,
 ) -> Result<(), error::Error> {
-    console_logger::info(user_prompt::UPGRADE_WARNING);
+    console_logger::info(user_prompt::UPGRADE_WARNING, "");
     // Initialise the REST client.
     let config = kube_proxy::ConfigBuilder::default_api_rest()
         .with_kube_config(kube_config_path.clone())

--- a/k8s/upgrade/src/user_prompt.rs
+++ b/k8s/upgrade/src/user_prompt.rs
@@ -9,3 +9,24 @@ pub const SINGLE_REPLICA_VOLUME_WARNING: &str =  "\nThe list below shows the sin
 
 /// Warning to users before doing an upgrade.
 pub const CORDONED_NODE_WARNING: &str =  "\nBelow are the list of cordoned nodes. Since there are some cordoned nodes, \nthe rebuild will happen on another nodes so please have enough available free space or else the rebuild will get stuck forever.";
+
+/// Info about the control plane pods.
+pub const CONTROL_PLANE_PODS_LIST: &str =
+    "\nList of control plane pods which will be restarted during upgrade.";
+
+/// Info about the data plane pods.
+pub const DATA_PLANE_PODS_LIST: &str =
+    "\nList of data plane pods which will be restarted during upgrade.";
+
+/// Info about the data plane pods.
+pub const DATA_PLANE_PODS_LIST_SKIP_RESTART: &str =
+    "\nList of data plane pods which need to be manually restarted to reflect upgrade as --skip-data-plane-restart flag is passed during upgrade.";
+
+/// Append the release name to k8s objects.
+pub(crate) fn upgrade_dry_run_summary(message: &str, tag: &str) -> String {
+    format!("{message} : {tag}")
+}
+
+/// Info about the data plane pods.
+pub const UPGRADE_DRY_RUN_SUMMARY: &str =
+    "\nFinally the cluster deployment will be upgraded to version";


### PR DESCRIPTION
The op is shown as 
```
ashish@vm:~/code/rust/mayastor-extensions(dry-run)$ ./target/debug/kubectl-mayastor  upgrade --dry-run

Volumes which make use of a single volume replica instance will be unavailable for some time during upgrade.
It is recommended that you do not create new volumes which make use of only one volume replica.


List of control plane pods which will be restarted during upgrade.
 mayastor-agent-core-f5978cfdc-6sz7q
mayastor-api-rest-744d8f54bc-xr7gk

List of data plane pods which will be restarted during upgrade.
 mayastor-io-engine-49xwm
mayastor-io-engine-bwtn6
mayastor-io-engine-d7v7v

Finally the cluster deployment will be upgrade to version: "develop"
```
and 
```
ashish@vm:~/code/rust/mayastor-extensions(dry-run)$ ./target/debug/kubectl-mayastor  upgrade --dry-run  --skip-data-plane-restart

Volumes which make use of a single volume replica instance will be unavailable for some time during upgrade.
It is recommended that you do not create new volumes which make use of only one volume replica.


List of control plane pods which will be restarted during upgrade.
 mayastor-agent-core-f5978cfdc-6sz7q
mayastor-api-rest-744d8f54bc-xr7gk

List of data plane pods which need to be manualy restarted to reflect upgrade as --skip-data-plane-restart flag is passed during upgrade .
 mayastor-io-engine-49xwm
mayastor-io-engine-bwtn6
mayastor-io-engine-d7v7v

Finally the cluster deployment will be upgrade to version: "develop"
```