### PR TITLE
feat: enable setting priorityClassName references

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -137,7 +137,7 @@ $ helm install my-release openebs/mayastor
 | loki-stack.&ZeroWidthSpace;promtail.&ZeroWidthSpace;enabled | Enables promtail for scraping logs from nodes | `true` |
 | loki-stack.&ZeroWidthSpace;promtail.&ZeroWidthSpace;tolerations | Disallow promtail from running on the master node | `[]` |
 | nodeSelector | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ Note that if multi-arch images support 'kubernetes.io/arch: amd64' should be removed and set 'nodeSelector' to empty '{}' as default value. | <pre>{<br>"kubernetes.io/arch":"amd64"<br>}</pre> |
-| priorityClassName |Pod scheduling priority ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/ | `""` |
+| priorityClassName | Pod scheduling priority ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/ | `""` |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;enabled | Enable callhome | `true` |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;logLevel | Log level for callhome | `"info"` |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for callhome | `"100m"` |

--- a/chart/README.md
+++ b/chart/README.md
@@ -137,6 +137,7 @@ $ helm install my-release openebs/mayastor
 | loki-stack.&ZeroWidthSpace;promtail.&ZeroWidthSpace;enabled | Enables promtail for scraping logs from nodes | `true` |
 | loki-stack.&ZeroWidthSpace;promtail.&ZeroWidthSpace;tolerations | Disallow promtail from running on the master node | `[]` |
 | nodeSelector | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ Note that if multi-arch images support 'kubernetes.io/arch: amd64' should be removed and set 'nodeSelector' to empty '{}' as default value. | <pre>{<br>"kubernetes.io/arch":"amd64"<br>}</pre> |
+| priorityClassName |Pod scheduling priority ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/ | `""` |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;enabled | Enable callhome | `true` |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;logLevel | Log level for callhome | `"info"` |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for callhome | `"100m"` |
@@ -148,4 +149,3 @@ $ helm install my-release openebs/mayastor
 | operators.&ZeroWidthSpace;pool.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;memory | Memory limits for diskpool operator | `"32Mi"` |
 | operators.&ZeroWidthSpace;pool.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;cpu | Cpu requests for diskpool operator | `"50m"` |
 | operators.&ZeroWidthSpace;pool.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;memory | Memory requests for diskpool operator | `"16Mi"` |
-

--- a/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
+++ b/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
@@ -25,11 +25,11 @@ spec:
         {{- include "base_pull_secrets" . }}
       initContainers:
         {{- include "base_init_core_containers" . }}
+      priorityClassName: {{ default "system-cluster-critical" .Values.priorityClassName }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
       tolerations: {{- toYaml .Values.earlyEvictionTolerations | nindent 8}}
-      priorityClassName: system-cluster-critical # Priority class provided by k8s by default.
       containers:
         - name: agent-core
           resources:

--- a/chart/templates/mayastor/agents/ha/ha-node-daemonset.yaml
+++ b/chart/templates/mayastor/agents/ha/ha-node-daemonset.yaml
@@ -31,6 +31,9 @@ spec:
         {{- include "base_init_ha_node_containers" . }}
       imagePullSecrets:
         {{- include "base_pull_secrets" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       nodeSelector:
         {{- if .Values.nodeSelector }}
         {{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/chart/templates/mayastor/apis/api-rest-deployment.yaml
+++ b/chart/templates/mayastor/apis/api-rest-deployment.yaml
@@ -24,11 +24,11 @@ spec:
         {{- include "base_pull_secrets" . }}
       initContainers:
         {{- include "base_init_containers" . }}
+      priorityClassName: {{ default "system-cluster-critical" .Values.priorityClassName }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
       tolerations: {{- toYaml .Values.earlyEvictionTolerations | nindent 8 }}
-      priorityClassName: system-cluster-critical # Priority class provided by k8s by default.
       containers:
         - name: api-rest
           resources:

--- a/chart/templates/mayastor/csi/csi-controller-deployment.yaml
+++ b/chart/templates/mayastor/csi/csi-controller-deployment.yaml
@@ -28,6 +28,9 @@ spec:
       initContainers:
         {{- include "jaeger_agent_init_container" . }}
         {{- include "rest_agent_init_container" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
@@ -89,4 +92,3 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir:
-

--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -31,6 +31,9 @@ spec:
       hostNetwork: true
       imagePullSecrets:
         {{- include "base_pull_secrets" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       nodeSelector:
         {{- if .Values.nodeSelector }}
         {{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -28,6 +28,9 @@ spec:
       # To resolve services in the namespace
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector: {{- .Values.io_engine.nodeSelector | toYaml | nindent 8 }}
+      {{- if .Values.io_engine.priorityClassName }}
+      priorityClassName: {{ .Values.io_engine.priorityClassName }}
+      {{- end }}
       initContainers:
         {{- include "base_init_containers" . }}
       containers:

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -28,8 +28,8 @@ spec:
       # To resolve services in the namespace
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector: {{- .Values.io_engine.nodeSelector | toYaml | nindent 8 }}
-      {{- if .Values.io_engine.priorityClassName }}
-      priorityClassName: {{ .Values.io_engine.priorityClassName }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
       initContainers:
         {{- include "base_init_containers" . }}

--- a/chart/templates/mayastor/obs/obs-callhome-deployment.yaml
+++ b/chart/templates/mayastor/obs/obs-callhome-deployment.yaml
@@ -23,6 +23,9 @@ spec:
       serviceAccount: {{ .Release.Name }}-service-account
       imagePullSecrets:
         {{- include "base_pull_secrets" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}

--- a/chart/templates/mayastor/operators/operator-diskpool-deployment.yaml
+++ b/chart/templates/mayastor/operators/operator-diskpool-deployment.yaml
@@ -25,6 +25,9 @@ spec:
         {{- include "base_pull_secrets" . }}
       initContainers:
         {{- include "base_init_containers" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,6 +25,10 @@ image:
 nodeSelector:
   kubernetes.io/arch: amd64
 
+# -- Pod scheduling priority
+# ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+priorityClassName: ""
+
 earlyEvictionTolerations:
   - effect: NoExecute
     key: node.kubernetes.io/unreachable
@@ -284,6 +288,9 @@ io_engine:
   nodeSelector:
     openebs.io/engine: mayastor
     kubernetes.io/arch: amd64
+  # -- Pod scheduling priority
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
   resources:
     limits:
       # -- Cpu limits for the io-engine

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -288,9 +288,6 @@ io_engine:
   nodeSelector:
     openebs.io/engine: mayastor
     kubernetes.io/arch: amd64
-  # -- Pod scheduling priority
-  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-  priorityClassName: ""
   resources:
     limits:
       # -- Cpu limits for the io-engine


### PR DESCRIPTION
Enable setting `priorityClassName` reference for scheduling https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/

This is critical for scheduling workloads that are significantly reliant upon within the cluster.