### PR TITLE
build(helm/upgrade): prepare chart before packing container

### DIFF
--- a/nix/pkgs/extensions/cargo-project.nix
+++ b/nix/pkgs/extensions/cargo-project.nix
@@ -60,7 +60,6 @@ let
     "console-logger"
     "operators"
     "call-home"
-    "scripts"
     "dependencies/control-plane/openapi/Cargo.toml"
     "dependencies/control-plane/openapi/build.rs"
     "dependencies/control-plane/control-plane/plugin"
@@ -114,7 +113,7 @@ let
   builder = if incremental then build_with_naersk else build_with_default;
 in
 {
-  inherit PROTOC PROTOC_INCLUDE version src;
+  inherit PROTOC PROTOC_INCLUDE version src whitelistSource;
 
   build = { buildType, cargoBuildFlags ? [ ] }:
     if allInOne then

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -2,14 +2,15 @@
 # avoid dependency on docker tool chain. Though the maturity of OCI
 # builder in nixpkgs is questionable which is why we postpone this step.
 
-{ dockerTools, lib, extensions, busybox, gnupg, kubernetes-helm-wrapped, runCommand, img_tag ? "" }:
+{ dockerTools, lib, extensions, busybox, gnupg, kubernetes-helm-wrapped, semver-tool, yq-go, runCommand, img_tag ? "" }:
 let
-  helm_chart_src = builtins.filterSource (path: type: true) ../../../chart;
+  whitelistSource = extensions.project-builder.whitelistSource;
+  helm_chart = whitelistSource ../../.. [ "chart" "scripts/helm" ];
   image_suffix = { "release" = ""; "debug" = "-debug"; "coverage" = "-coverage"; };
+  tag = if img_tag != "" then img_tag else extensions.version;
   build-extensions-image = { pname, buildType, package, extraCommands ? '''', contents ? [ ], config ? { } }:
     dockerTools.buildImage {
-      inherit extraCommands;
-      tag = if img_tag != "" then img_tag else extensions.version;
+      inherit extraCommands tag;
       created = "now";
       name = "openebs/mayastor-${pname}${image_suffix.${buildType}}";
       contents = [ package ] ++ contents;
@@ -29,14 +30,32 @@ let
       };
     };
   };
+  tagged_helm_chart = runCommand "tagged_helm_chart"
+    {
+      nativeBuildInputs = [ kubernetes-helm-wrapped helm_chart semver-tool yq-go ];
+    } ''
+    mkdir -p build && cp -drf ${helm_chart}/* build
+
+    chmod +w build/scripts/helm
+    chmod +w build/chart
+    chmod +w build/chart/*.yaml
+    patchShebangs build/scripts/helm/publish-chart-yaml.sh
+
+    # if tag is not semver just keep whatever is checked-in
+    # todo: handle this properly?
+    if [ "$(semver validate "tag")" == "valid" ]; then
+      CHART_FILE=build/chart/Chart.yaml build/scripts/helm/publish-chart-yaml.sh --app-tag ${tag} --override-index ""
+    fi
+    chmod -w build/chart
+    chmod -w build/chart/*.yaml
+
+    mkdir -p $out && cp -drf --preserve=mode build/chart $out/chart
+  '';
   build-upgrade-operator-image = { buildType }:
     build-extensions-image rec{
       inherit buildType;
       package = extensions.${buildType}.operators.upgrade;
-      contents = [ helm_chart_src kubernetes-helm-wrapped busybox ];
-      extraCommands = ''
-        mkdir -p chart && cp -drf --preserve=mode ${helm_chart_src}/* chart/
-      '';
+      contents = [ kubernetes-helm-wrapped busybox tagged_helm_chart ];
       pname = package.pname;
       config = {
         ExposedPorts = {


### PR DESCRIPTION
As things stand the tree is always pointing to the stable helm version, eg: 2.1.0 
When building upgrade images for pre-releases or patches we need to patch the chart so that it may point to the correct version.
This is done using the same publish script that is used to publish the chart to the helm repo.

If we're building without a tag then for now we simply ignore this..