### PR TITLE
feat(upgrade-job): support for continuous eventing for the upgrade duration

### DIFF
--- a/k8s/upgrade-job/src/common/error.rs
+++ b/k8s/upgrade-job/src/common/error.rs
@@ -374,29 +374,18 @@ pub(crate) enum Error {
     #[snafu(display("Mandatory options for EventRecorder were not given"))]
     HelmUpgradeOptionsAbsent,
 
+    /// Error for failures in generating semver::Value from a &str input.
     #[snafu(display("Failed to parse {} as a valid semver: {}", version_string, source))]
     SemverParse {
         source: semver::Error,
         version_string: String,
     },
 
-    #[snafu(display(
-        "'{}' chart is not a subchart of '{}' chart",
-        CORE_CHART_NAME,
-        UMBRELLA_CHART_NAME
-    ))]
-    CoreNotASubchartOfUmbrella,
-
-    #[snafu(display(
-        "Upgrade for {} chart v{} is not supported",
-        UMBRELLA_CHART_NAME,
-        version
-    ))]
-    UmbrellaChartVersionInvalid { version: String },
-
+    /// Error for when the detected upgrade path for PRODUCT is not supported.
     #[snafu(display("The upgrade path is invalid"))]
     InvalidUpgradePath,
 
+    /// Error in serializing crate::event::event_recorder::EventNote to JSON string.
     #[snafu(display("Failed to serialize event note {:?}: {}", note, source))]
     SerializeEventNote {
         source: serde_json::Error,
@@ -415,6 +404,11 @@ pub(crate) enum Error {
     /// Error for when the thin-provisioning option are absent, but still tried to fetch it.
     #[snafu(display("The agents.core.capacity yaml object is absent amongst the helm values"))]
     ThinProvisioningOptionsAbsent,
+
+    /// Error when trying to send Events through the tokio::sync::channel::Sender<Event>
+    /// synchronisation tool.
+    #[snafu(display("Failed to send Event over the channel"))]
+    EventChannelSend,
 }
 /// A wrapper type to remove repeated Result<T, Error> returns.
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;

--- a/k8s/upgrade-job/src/helm/client.rs
+++ b/k8s/upgrade-job/src/helm/client.rs
@@ -196,7 +196,9 @@ impl HelmReleaseClient {
             release_name,
             chart_dir,
             "-n",
-            self.namespace.as_str()
+            self.namespace.as_str(),
+            "--timeout",
+            "15m"
         ];
 
         // Extra args


### PR DESCRIPTION
This includes this behavior:
- Events are now published from a separate tokio::task.
- Events are now re-published every 20 min, if no new event is generated. This let's a user probe for the latest event, in case an event is lost to the k8s events' expiration duration of 1 hour.

Also increases helm upgrade timeout to 15 min (from the default 5m).

Also, removes some unused errors and fixes serde container attribute for renaming struct members to camelCase.

P. S.: I deleted the Cargo.lock and regenerated it with `cargo build`.