### PR TITLE
fix(upgrade-job): refactor data-plane upgrade

### DIFF
--- a/k8s/upgrade-job/src/common/constants.rs
+++ b/k8s/upgrade-job/src/common/constants.rs
@@ -19,6 +19,9 @@ pub(crate) const IO_ENGINE_LABEL: &str = "app=io-engine";
 /// This is the shared Pod label of the <helm-release>-agent-core Deployment.
 pub(crate) const AGENT_CORE_LABEL: &str = "app=agent-core";
 
+/// This is the shared label across the helm chart components which carries the chart version.
+pub(crate) const CHART_VERSION_LABEL_KEY: &str = "openebs.io/version";
+
 /// This is the label set on a storage API Node resource when a 'Node Drain' is issued.
 pub(crate) const DRAIN_FOR_UPGRADE: &str = "mayastor-upgrade";
 

--- a/k8s/upgrade-job/src/helm/upgrade.rs
+++ b/k8s/upgrade-job/src/helm/upgrade.rs
@@ -2,8 +2,8 @@ use crate::{
     common::{
         constants::{CORE_CHART_NAME, UMBRELLA_CHART_NAME},
         error::{
-            HelmUpgradeOptionsAbsent, InvalidUpgradePath, NoInputHelmChartDir, NotAKnownHelmChart,
-            RegexCompile, Result,
+            HelmUpgradeOptionsAbsent, InstalledVersionSameAsUpgradeVersion, InvalidUpgradePath,
+            NoInputHelmChartDir, NotAKnownHelmChart, RegexCompile, Result,
         },
     },
     helm::{client::HelmReleaseClient, values::generate_values_args},
@@ -138,6 +138,10 @@ impl HelmUpgradeBuilder {
         let from_version = upgrade::path::version_from_release_chart(chart)?;
         let upgrade_path_is_valid =
             upgrade::path::is_valid(chart_variant.clone(), &from_version, &to_version)?;
+        ensure!(
+            to_version.ne(&from_version),
+            InstalledVersionSameAsUpgradeVersion
+        );
         ensure!(upgrade_path_is_valid, InvalidUpgradePath);
 
         // Generate args to pass to the `helm upgrade` command.
@@ -184,11 +188,11 @@ impl HelmUpgrade {
             .upgrade(self.release_name, self.chart_dir, Some(self.extra_args))
     }
 
-    pub(crate) fn installed_version(&self) -> String {
+    pub(crate) fn upgrade_from_version(&self) -> String {
         self.from_version.to_string()
     }
 
-    pub(crate) fn to_version(&self) -> String {
+    pub(crate) fn upgrade_to_version(&self) -> String {
         self.to_version.to_string()
     }
 }

--- a/k8s/upgrade-job/src/upgrade/data_plane.rs
+++ b/k8s/upgrade-job/src/upgrade/data_plane.rs
@@ -1,26 +1,35 @@
 use crate::{
     common::{
-        constants::{AGENT_CORE_LABEL, DRAIN_FOR_UPGRADE, IO_ENGINE_LABEL, PRODUCT},
+        constants::{
+            AGENT_CORE_LABEL, CHART_VERSION_LABEL_KEY, DRAIN_FOR_UPGRADE, IO_ENGINE_LABEL, PRODUCT,
+        },
         error::{
-            DrainStorageNode, EmptyPodNodeName, EmptyPodSpec, EmptyPodUid, ListPodsWithLabel,
-            PodDelete, PodUidIsNone, Result, StorageNodeUncordon, ValidatingPodReadyStatus,
+            DrainStorageNode, EmptyPodNodeName, EmptyPodSpec, EmptyStorageNodeSpec, GetStorageNode,
+            ListPodsWithLabel, ListPodsWithLabelAndField, PodDelete, Result, StorageNodeUncordon,
+            TooManyIoEnginePods,
         },
         kube_client::KubeClientSet,
         rest_client::RestClientSet,
     },
-    upgrade::utils::{all_pods_are_ready, is_draining, is_rebuilding},
+    upgrade::utils::{all_pods_are_ready, is_rebuilding},
 };
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{DeleteParams, ListParams, ObjectList},
     ResourceExt,
 };
-use snafu::{ensure, ResultExt};
+use openapi::models::CordonDrainState;
+use snafu::ResultExt;
 use std::time::Duration;
 use utils::{API_REST_LABEL, ETCD_LABEL};
 
 /// Upgrade data plane by controlled restart of io-engine pods
-pub(crate) async fn upgrade_data_plane(namespace: String, rest_endpoint: String) -> Result<()> {
+pub(crate) async fn upgrade_data_plane(
+    namespace: String,
+    rest_endpoint: String,
+    upgrade_from_version: String,
+    upgrade_to_version: String,
+) -> Result<()> {
     let k8s_client = KubeClientSet::builder()
         .with_namespace(namespace.clone())
         .build()
@@ -28,16 +37,24 @@ pub(crate) async fn upgrade_data_plane(namespace: String, rest_endpoint: String)
 
     let rest_client = RestClientSet::new_with_url(rest_endpoint)?;
 
-    let io_engine_listparam = ListParams::default().labels(IO_ENGINE_LABEL);
+    let yet_to_upgrade_io_engine_label_selector =
+        format!("{IO_ENGINE_LABEL},{CHART_VERSION_LABEL_KEY}={upgrade_from_version}");
+    let io_engine_listparam =
+        ListParams::default().labels(yet_to_upgrade_io_engine_label_selector.as_str());
     let namespace = namespace.clone();
+
+    // Validate the control plane pod is up and running before we start.
+    verify_control_plane_is_running(namespace.clone(), &k8s_client, &upgrade_to_version).await?;
+
     let initial_io_engine_pod_list: ObjectList<Pod> = k8s_client
         .pods_api()
         .list(&io_engine_listparam)
         .await
         .context(ListPodsWithLabel {
-            label: IO_ENGINE_LABEL.to_string(),
+            label: yet_to_upgrade_io_engine_label_selector,
             namespace: namespace.clone(),
         })?;
+
     for pod in initial_io_engine_pod_list.iter() {
         // Fetch the node name on which the io-engine pod is running
         let node_name = pod
@@ -68,46 +85,86 @@ pub(crate) async fn upgrade_data_plane(namespace: String, rest_endpoint: String)
         );
 
         // Issue node drain command
-        issue_node_drain(node_name, &rest_client).await?;
-
-        // Wait for node drain to complete across the cluster.
-        wait_node_drain(node_name, &rest_client).await?;
+        drain_storage_node(node_name, &rest_client).await?;
 
         // Wait for any rebuild to complete.
         wait_for_rebuild(node_name, &rest_client).await?;
 
         // restart the data plane pod
-        restart_data_plane(node_name, pod, &k8s_client).await?;
+        delete_data_plane_pod(node_name, pod, &k8s_client).await?;
 
         // Uncordon the drained node
         uncordon_node(node_name, &rest_client).await?;
 
         // validate the new pod is up and running
-        verify_data_plane_pod_is_running(node_name, namespace.clone(), &k8s_client).await?;
+        verify_data_plane_pod_is_running(
+            node_name,
+            namespace.clone(),
+            &upgrade_to_version,
+            &k8s_client,
+        )
+        .await?;
 
         // Validate the control plane pod is up and running
-        is_control_plane_running(namespace.clone(), &k8s_client).await?;
+        verify_control_plane_is_running(namespace.clone(), &k8s_client, &upgrade_to_version)
+            .await?;
     }
     Ok(())
 }
 
 /// Uncordon storage Node.
-async fn uncordon_node(node_name: &str, rest_client: &RestClientSet) -> Result<()> {
-    rest_client
-        .nodes_api()
-        .delete_node_cordon(node_name, DRAIN_FOR_UPGRADE)
-        .await
-        .context(StorageNodeUncordon {
-            node_name: node_name.to_string(),
-        })?;
+async fn uncordon_node(node_id: &str, rest_client: &RestClientSet) -> Result<()> {
+    let drain_label_for_upgrade: String = DRAIN_FOR_UPGRADE.to_string();
+    let sleep_duration = Duration::from_secs(1_u64);
+    loop {
+        let storage_node =
+            rest_client
+                .nodes_api()
+                .get_node(node_id)
+                .await
+                .context(GetStorageNode {
+                    node_id: node_id.to_string(),
+                })?;
 
-    tracing::info!(node.name = node_name, "{PRODUCT} Node is uncordoned");
+        match storage_node
+            .into_body()
+            .spec
+            .ok_or(
+                EmptyStorageNodeSpec {
+                    node_id: node_id.to_string(),
+                }
+                .build(),
+            )?
+            .cordondrainstate
+        {
+            Some(CordonDrainState::drainedstate(drain_state))
+                if drain_state.drainlabels.contains(&drain_label_for_upgrade) =>
+            {
+                rest_client
+                    .nodes_api()
+                    .delete_node_cordon(node_id, DRAIN_FOR_UPGRADE)
+                    .await
+                    .context(StorageNodeUncordon {
+                        node_id: node_id.to_string(),
+                    })?;
 
-    Ok(())
+                tracing::info!(node.id = %node_id,
+                    label = %DRAIN_FOR_UPGRADE,
+                    "Removed drain label from {PRODUCT} Node"
+                );
+            }
+            _ => return Ok(()),
+        }
+        tokio::time::sleep(sleep_duration).await;
+    }
 }
 
 /// Issue delete command on dataplane pods.
-async fn restart_data_plane(node_name: &str, pod: &Pod, k8s_client: &KubeClientSet) -> Result<()> {
+async fn delete_data_plane_pod(
+    node_name: &str,
+    pod: &Pod,
+    k8s_client: &KubeClientSet,
+) -> Result<()> {
     // Deleting the io-engine pod
     let pod_name = pod.name_any();
     tracing::info!(
@@ -127,77 +184,20 @@ async fn restart_data_plane(node_name: &str, pod: &Pod, k8s_client: &KubeClientS
     Ok(())
 }
 
-/// Wait for the data plane pod to come up on the given node.
-async fn wait_node_drain(node_name: &str, rest_client: &RestClientSet) -> Result<()> {
-    while is_draining(rest_client).await? {
-        tracing::info!(node.name = %node_name, "Waiting for {} node drain completion", PRODUCT);
-        tokio::time::sleep(Duration::from_secs(10_u64)).await;
-    }
-    Ok(())
-}
-
 /// Wait for all the node drain process to complete.
 async fn verify_data_plane_pod_is_running(
     node_name: &str,
     namespace: String,
+    upgrade_to_version: &String,
     k8s_client: &KubeClientSet,
 ) -> Result<()> {
-    let field_selector = format!("spec.nodeName={node_name}");
-    let io_engine_listparam = ListParams::default()
-        .labels(IO_ENGINE_LABEL)
-        .fields(field_selector.as_str());
-    let initial_io_engine_pod_list: ObjectList<Pod> = k8s_client
-        .pods_api()
-        .list(&io_engine_listparam)
-        .await
-        .context(ListPodsWithLabel {
-            label: IO_ENGINE_LABEL.to_string(),
-            namespace: namespace.clone(),
-        })?;
-
-    let mut io_engine_pod_uid: Option<&str> = None;
-
-    for pod in initial_io_engine_pod_list.iter() {
-        let node = pod
-            .spec
-            .as_ref()
-            .ok_or(
-                EmptyPodSpec {
-                    name: pod.name_any(),
-                    namespace: namespace.clone(),
-                }
-                .build(),
-            )?
-            .node_name
-            .as_ref()
-            .ok_or(
-                EmptyPodNodeName {
-                    name: pod.name_any(),
-                    namespace: namespace.clone(),
-                }
-                .build(),
-            )?
-            .as_str();
-
-        // get pod uid running on this node
-        if node == node_name {
-            io_engine_pod_uid = Some(
-                pod.metadata.uid.as_ref().ok_or(
-                    EmptyPodUid {
-                        name: pod.name_any(),
-                        namespace: namespace.clone(),
-                    }
-                    .build(),
-                )?,
-            );
-            break;
-        }
-    }
-    let pod_uid = io_engine_pod_uid.ok_or(PodUidIsNone.build())?;
+    let duration = Duration::from_secs(5_u64);
     // Validate the new pod is up and running
-    while !is_data_plane_pod_running(node_name, pod_uid, namespace.clone(), k8s_client).await? {
-        tracing::info!(node.name = %node_name, "Waiting for data plane pod to come to running state");
-        tokio::time::sleep(Duration::from_secs(10_u64)).await;
+    tracing::info!(node.name = %node_name, "Waiting for data-plane Pod to come to Ready state...");
+    while !data_plane_pod_is_running(node_name, namespace.clone(), upgrade_to_version, k8s_client)
+        .await?
+    {
+        tokio::time::sleep(duration).await;
     }
     Ok(())
 }
@@ -214,150 +214,134 @@ async fn wait_for_rebuild(node_name: &str, rest_client: &RestClientSet) -> Resul
 }
 
 /// Issue the node drain command on the node.
-async fn issue_node_drain(node_name: &str, rest_client: &RestClientSet) -> Result<()> {
-    rest_client
-        .nodes_api()
-        .put_node_drain(node_name, DRAIN_FOR_UPGRADE)
+async fn drain_storage_node(node_id: &str, rest_client: &RestClientSet) -> Result<()> {
+    let drain_label_for_upgrade: String = DRAIN_FOR_UPGRADE.to_string();
+    let sleep_duration = Duration::from_secs(5_u64);
+    loop {
+        let storage_node =
+            rest_client
+                .nodes_api()
+                .get_node(node_id)
+                .await
+                .context(GetStorageNode {
+                    node_id: node_id.to_string(),
+                })?;
+
+        match storage_node
+            .into_body()
+            .spec
+            .ok_or(
+                EmptyStorageNodeSpec {
+                    node_id: node_id.to_string(),
+                }
+                .build(),
+            )?
+            .cordondrainstate
+        {
+            Some(CordonDrainState::drainingstate(drain_state))
+                if drain_state.drainlabels.contains(&drain_label_for_upgrade) =>
+            {
+                tracing::info!(node.id = %node_id, "Waiting for {PRODUCT} Node drain to complete...");
+                // Wait for node drain to complete.
+                tokio::time::sleep(sleep_duration).await;
+            }
+            Some(CordonDrainState::drainedstate(drain_state))
+                if drain_state.drainlabels.contains(&drain_label_for_upgrade) =>
+            {
+                tracing::info!(node.id = %node_id, "Drain completed for {PRODUCT} Node");
+                return Ok(());
+            }
+            _ => {
+                rest_client
+                    .nodes_api()
+                    .put_node_drain(node_id, DRAIN_FOR_UPGRADE)
+                    .await
+                    .context(DrainStorageNode {
+                        node_id: node_id.to_string(),
+                    })?;
+
+                tracing::info!(node.id = %node_id, "Drain started for {PRODUCT} Node");
+            }
+        }
+    }
+}
+
+/// Validate if io-engine DaemonSet Pod is running.
+async fn data_plane_pod_is_running(
+    node: &str,
+    namespace: String,
+    upgrade_to_version: &String,
+    k8s_client: &KubeClientSet,
+) -> Result<bool> {
+    let node_name_pod_field = format!("spec.nodeName={node}");
+    let pod_label = format!("{IO_ENGINE_LABEL},{CHART_VERSION_LABEL_KEY}={upgrade_to_version}");
+    let io_engine_listparam = ListParams::default()
+        .labels(pod_label.as_str())
+        .fields(node_name_pod_field.as_str());
+
+    let pod_list: ObjectList<Pod> = k8s_client
+        .pods_api()
+        .list(&io_engine_listparam)
         .await
-        .context(DrainStorageNode {
-            node_name: node_name.to_string(),
+        .context(ListPodsWithLabelAndField {
+            label: pod_label,
+            field: node_name_pod_field,
+            namespace: namespace.clone(),
         })?;
 
-    tracing::info!(node.name = %node_name, "Drain started for {PRODUCT} Node");
+    if pod_list.items.is_empty() {
+        return Ok(false);
+    }
+
+    if pod_list.items.len() != 1 {
+        TooManyIoEnginePods { node_name: node }.fail()?;
+    }
+
+    Ok(all_pods_are_ready(pod_list))
+}
+
+async fn verify_control_plane_is_running(
+    namespace: String,
+    k8s_client: &KubeClientSet,
+    upgrade_to_version: &String,
+) -> Result<()> {
+    let duration = Duration::from_secs(3_u64);
+    while !control_plane_is_running(namespace.clone(), k8s_client, upgrade_to_version).await? {
+        tokio::time::sleep(duration).await;
+    }
 
     Ok(())
 }
 
-/// Validate if io-engine DaemonSet Pod is running.
-async fn is_data_plane_pod_running(
-    node: &str,
-    old_io_engine_pod_uid: &str,
+/// Validate if control-plane pods are running -- etcd, agent-core, api-rest.
+async fn control_plane_is_running(
     namespace: String,
     k8s_client: &KubeClientSet,
+    upgrade_to_version: &String,
 ) -> Result<bool> {
-    let mut data_plane_pod_running = false;
-    let field_selector = format!("spec.nodeName={node}");
-    let io_engine_listparam = ListParams::default()
-        .labels(IO_ENGINE_LABEL)
-        .fields(field_selector.as_str());
-    let initial_io_engine_pod_list: ObjectList<Pod> = k8s_client
-        .pods_api()
-        .list(&io_engine_listparam)
-        .await
-        .context(ListPodsWithLabel {
-            label: IO_ENGINE_LABEL.to_string(),
-            namespace: namespace.clone(),
-        })?;
-
-    for pod in initial_io_engine_pod_list.iter() {
-        // Fetch the node name on which the io-engine pod is running
-        let node_name = pod
-            .spec
-            .as_ref()
-            .ok_or(
-                EmptyPodSpec {
-                    name: pod.name_any(),
-                    namespace: namespace.clone(),
-                }
-                .build(),
-            )?
-            .node_name
-            .as_ref()
-            .ok_or(
-                EmptyPodNodeName {
-                    name: pod.name_any(),
-                    namespace: namespace.clone(),
-                }
-                .build(),
-            )?
-            .as_str();
-
-        // skip if the the node name is not the same as the one on which pod needs to be restarted.
-        if node != node_name {
-            continue;
-        } else {
-            // uid of io engine pod on the same node.
-            let new_io_engine_pod_uid = pod.metadata.uid.as_ref().ok_or(
-                EmptyPodUid {
-                    name: pod.name_any(),
-                    namespace: namespace.clone(),
-                }
-                .build(),
-            )?;
-
-            // validating that the pod uid on the node is same or not
-            // if same, that means that pod has not been started yet
-            // and new data plane pod is not up and running.
-            if old_io_engine_pod_uid.eq(new_io_engine_pod_uid) {
-                let pod_name = pod.name_any();
-                tracing::warn!(node.name = %node, pod.name = %pod_name, "Pod has not been deleted yet");
-                data_plane_pod_running = false;
-            }
-
-            match pod
-                .status
-                .as_ref()
-                .and_then(|status| status.conditions.as_ref())
-            {
-                Some(conditions) => {
-                    for condition in conditions {
-                        if condition.type_.eq("Ready") {
-                            if condition.status.eq("True") {
-                                data_plane_pod_running = true;
-                                let pod_name = pod.name_any();
-                                tracing::info!(node.name = %node, pod.name = %pod_name, "Pod is Ready");
-                                break;
-                            }
-                            data_plane_pod_running = false;
-                        } else {
-                            continue;
-                        }
-                    }
-                }
-                None => {
-                    data_plane_pod_running = false;
-                }
-            }
-        }
-    }
-    Ok(data_plane_pod_running)
-}
-
-/// Validate if control-plane pods are running -- etcd, agent-core, api-rest.
-async fn is_control_plane_running(namespace: String, k8s_client: &KubeClientSet) -> Result<()> {
+    let agent_core_selector_label =
+        format!("{AGENT_CORE_LABEL},{CHART_VERSION_LABEL_KEY}={upgrade_to_version}");
     let pod_list: ObjectList<Pod> = k8s_client
         .pods_api()
-        .list(&ListParams::default().labels(AGENT_CORE_LABEL))
+        .list(&ListParams::default().labels(agent_core_selector_label.as_str()))
         .await
         .context(ListPodsWithLabel {
             label: AGENT_CORE_LABEL.to_string(),
             namespace: namespace.clone(),
         })?;
-    let core_result = all_pods_are_ready(pod_list);
-    ensure!(
-        core_result.0,
-        ValidatingPodReadyStatus {
-            name: core_result.1,
-            namespace: core_result.2,
-        }
-    );
+    let core_is_ready = all_pods_are_ready(pod_list);
 
+    let api_rest_selector_label =
+        format!("{API_REST_LABEL},{CHART_VERSION_LABEL_KEY}={upgrade_to_version}");
     let pod_list: ObjectList<Pod> = k8s_client
         .pods_api()
-        .list(&ListParams::default().labels(API_REST_LABEL))
+        .list(&ListParams::default().labels(api_rest_selector_label.as_str()))
         .await
         .context(ListPodsWithLabel {
             label: API_REST_LABEL.to_string(),
             namespace: namespace.clone(),
         })?;
-    let rest_result = all_pods_are_ready(pod_list);
-    ensure!(
-        rest_result.0,
-        ValidatingPodReadyStatus {
-            name: rest_result.1,
-            namespace: rest_result.2,
-        }
-    );
+    let rest_is_ready = all_pods_are_ready(pod_list);
 
     let pod_list: ObjectList<Pod> = k8s_client
         .pods_api()
@@ -367,14 +351,7 @@ async fn is_control_plane_running(namespace: String, k8s_client: &KubeClientSet)
             label: ETCD_LABEL.to_string(),
             namespace: namespace.clone(),
         })?;
-    let etcd_result = all_pods_are_ready(pod_list);
-    ensure!(
-        etcd_result.0,
-        ValidatingPodReadyStatus {
-            name: etcd_result.1,
-            namespace: etcd_result.2,
-        }
-    );
+    let etcd_is_ready = all_pods_are_ready(pod_list);
 
-    Ok(())
+    Ok(core_is_ready && rest_is_ready && etcd_is_ready)
 }


### PR DESCRIPTION
- add 'wait forever' retry logic for long running tasks
- use field-selector for picking out io-engine pods belonging to a specific node
- add a check for control-plane health before starting out with data-plane upgrade
- handle cases for node drain failure: drain label already exists, check drain status for upgrade-specific drain label and cordon label
- handle case for node uncordon failure: avoid uncordon if uncordon label does not exist
- Add event to mark the start of the upgrade
- Added and modified log messages for data plane
- Added a failure case for when the to_version and the from_version are the same.