### PR TITLE
Cherry-pick #177

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -52,6 +52,9 @@ $ helm install my-release openebs/mayastor
 
 | Key | Description | Default |
 |-----|-------------|:-------:|
+| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;capacity.&ZeroWidthSpace;thin.&ZeroWidthSpace;pool_commitment | The allowed pool commitment limit when dealing with thin provisioned volumes. Example: If the commitment is 250 and the pool is 10GiB we can overcommit the pool up to 25GiB (create 2 10GiB and 1 5GiB volume) but no further. | `"250%"` |
+| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;capacity.&ZeroWidthSpace;thin.&ZeroWidthSpace;volume_commitment | When creating replicas for an existing volume, each replica pool must have at least this much free space percentage of the volume size. Example: if this value is 40, the pool has 40GiB free, then the max volume size allowed to be created on the pool is 100GiB. | `"40%"` |
+| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;capacity.&ZeroWidthSpace;thin.&ZeroWidthSpace;volume_commitment_initial | Same as the `volume_commitment` argument, but applicable only when creating replicas for a new volume. | `"40%"` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;logLevel | Log level for the core service | `"info"` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for core agents | `"1000m"` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;memory | Memory limits for core agents | `"128Mi"` |

--- a/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
+++ b/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
@@ -47,6 +47,9 @@ spec:
             - "--cache-period={{ .Values.base.cache_poll_period }}"{{ if .Values.base.jaeger.enabled }}
             - "--jaeger={{ .Values.base.jaeger.agent.name }}:{{ .Values.base.jaeger.agent.port }}"{{ end }}
             - "--grpc-server-addr=0.0.0.0:50051"
+            - "--pool-commitment={{ .Values.agents.core.capacity.thin.pool_commitment }}"
+            - "--volume-commitment-initial={{ .Values.agents.core.capacity.thin.volume_commitment_initial }}"
+            - "--volume-commitment={{ .Values.agents.core.capacity.thin.volume_commitment }}"
           ports:
             - containerPort: 50051
           env:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -129,6 +129,20 @@ agents:
   core:
     # -- Log level for the core service
     logLevel: info
+    capacity:
+      thin:
+        # -- The allowed pool commitment limit when dealing with thin provisioned volumes.
+        # Example: If the commitment is 250 and the pool is 10GiB we can overcommit the pool
+        # up to 25GiB (create 2 10GiB and 1 5GiB volume) but no further.
+        pool_commitment: "250%"
+        # -- When creating replicas for an existing volume, each replica pool must have at least
+        # this much free space percentage of the volume size.
+        # Example: if this value is 40, the pool has 40GiB free, then the max volume size allowed
+        # to be created on the pool is 100GiB.
+        volume_commitment: "40%"
+        # -- Same as the `volume_commitment` argument, but applicable only when creating replicas
+        # for a new volume.
+        volume_commitment_initial: "40%"
     resources:
       limits:
         # -- Cpu limits for core agents


### PR DESCRIPTION
chore(submodules): update control-plane dependency

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

feat(capacity/thin): add core-agent thin tweaks

Allows to control the pool and volume commitment at a cluster level.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>