### PR TITLE
fix(upgrade-job): add '--set' flags for thin provisioning

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -52,9 +52,9 @@ $ helm install my-release openebs/mayastor
 
 | Key | Description | Default |
 |-----|-------------|:-------:|
-| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;capacity.&ZeroWidthSpace;thin.&ZeroWidthSpace;pool_commitment | The allowed pool commitment limit when dealing with thin provisioned volumes. Example: If the commitment is 250 and the pool is 10GiB we can overcommit the pool up to 25GiB (create 2 10GiB and 1 5GiB volume) but no further. | `"250%"` |
-| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;capacity.&ZeroWidthSpace;thin.&ZeroWidthSpace;volume_commitment | When creating replicas for an existing volume, each replica pool must have at least this much free space percentage of the volume size. Example: if this value is 40, the pool has 40GiB free, then the max volume size allowed to be created on the pool is 100GiB. | `"40%"` |
-| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;capacity.&ZeroWidthSpace;thin.&ZeroWidthSpace;volume_commitment_initial | Same as the `volume_commitment` argument, but applicable only when creating replicas for a new volume. | `"40%"` |
+| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;capacity.&ZeroWidthSpace;thin.&ZeroWidthSpace;poolCommitment | The allowed pool commitment limit when dealing with thin provisioned volumes. Example: If the commitment is 250 and the pool is 10GiB we can overcommit the pool up to 25GiB (create 2 10GiB and 1 5GiB volume) but no further. | `"250%"` |
+| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;capacity.&ZeroWidthSpace;thin.&ZeroWidthSpace;volumeCommitment | When creating replicas for an existing volume, each replica pool must have at least this much free space percentage of the volume size. Example: if this value is 40, the pool has 40GiB free, then the max volume size allowed to be created on the pool is 100GiB. | `"40%"` |
+| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;capacity.&ZeroWidthSpace;thin.&ZeroWidthSpace;volumeCommitmentInitial | Same as the `volumeCommitment` argument, but applicable only when creating replicas for a new volume. | `"40%"` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;logLevel | Log level for the core service | `"info"` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for core agents | `"1000m"` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;memory | Memory limits for core agents | `"128Mi"` |

--- a/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
+++ b/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
@@ -47,9 +47,9 @@ spec:
             - "--cache-period={{ .Values.base.cache_poll_period }}"{{ if .Values.base.jaeger.enabled }}
             - "--jaeger={{ .Values.base.jaeger.agent.name }}:{{ .Values.base.jaeger.agent.port }}"{{ end }}
             - "--grpc-server-addr=0.0.0.0:50051"
-            - "--pool-commitment={{ .Values.agents.core.capacity.thin.pool_commitment }}"
-            - "--volume-commitment-initial={{ .Values.agents.core.capacity.thin.volume_commitment_initial }}"
-            - "--volume-commitment={{ .Values.agents.core.capacity.thin.volume_commitment }}"
+            - "--pool-commitment={{ .Values.agents.core.capacity.thin.poolCommitment }}"
+            - "--volume-commitment-initial={{ .Values.agents.core.capacity.thin.volumeCommitmentInitial }}"
+            - "--volume-commitment={{ .Values.agents.core.capacity.thin.volumeCommitment }}"
           ports:
             - containerPort: 50051
           env:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -134,15 +134,15 @@ agents:
         # -- The allowed pool commitment limit when dealing with thin provisioned volumes.
         # Example: If the commitment is 250 and the pool is 10GiB we can overcommit the pool
         # up to 25GiB (create 2 10GiB and 1 5GiB volume) but no further.
-        pool_commitment: "250%"
+        poolCommitment: "250%"
         # -- When creating replicas for an existing volume, each replica pool must have at least
         # this much free space percentage of the volume size.
         # Example: if this value is 40, the pool has 40GiB free, then the max volume size allowed
         # to be created on the pool is 100GiB.
-        volume_commitment: "40%"
-        # -- Same as the `volume_commitment` argument, but applicable only when creating replicas
+        volumeCommitment: "40%"
+        # -- Same as the `volumeCommitment` argument, but applicable only when creating replicas
         # for a new volume.
-        volume_commitment_initial: "40%"
+        volumeCommitmentInitial: "40%"
     resources:
       limits:
         # -- Cpu limits for core agents

--- a/k8s/upgrade-job/src/common/error.rs
+++ b/k8s/upgrade-job/src/common/error.rs
@@ -411,6 +411,10 @@ pub(crate) enum Error {
         "The installed helm chart version is the same as the target upgrade version"
     ))]
     InstalledVersionSameAsUpgradeVersion,
+
+    /// Error for when the thin-provisioning option are absent, but still tried to fetch it.
+    #[snafu(display("The agents.core.capacity yaml object is absent amongst the helm values"))]
+    ThinProvisioningOptionsAbsent,
 }
 /// A wrapper type to remove repeated Result<T, Error> returns.
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;

--- a/k8s/upgrade-job/src/helm/chart.rs
+++ b/k8s/upgrade-job/src/helm/chart.rs
@@ -1,3 +1,4 @@
+use crate::common::error::{Result, ThinProvisioningOptionsAbsent};
 use semver::Version;
 use serde::Deserialize;
 
@@ -43,6 +44,22 @@ impl UmbrellaValues {
     pub(crate) fn io_engine_log_level(&self) -> &str {
         self.core.io_engine_log_level()
     }
+
+    pub(crate) fn core_capacity_is_absent(&self) -> bool {
+        self.core.core_capacity_is_absent()
+    }
+
+    pub(crate) fn core_thin_pool_commitment(&self) -> Result<String> {
+        self.core.core_thin_pool_commitment()
+    }
+
+    pub(crate) fn core_thin_volume_commitment(&self) -> Result<String> {
+        self.core.core_thin_volume_commitment()
+    }
+
+    pub(crate) fn core_thin_volume_commitment_initial(&self) -> Result<String> {
+        self.core.core_thin_volume_commitment_initial()
+    }
 }
 
 /// This is used to deserialize the values.yaml of the Core chart.
@@ -53,6 +70,8 @@ pub(crate) struct CoreValues {
     image: Image,
     /// This is the yaml object which contains the configuration for the io-engine DaemonSet.
     io_engine: IoEngine,
+
+    agents: Agents,
 }
 
 impl CoreValues {
@@ -64,6 +83,22 @@ impl CoreValues {
     /// This is a getter for the io-engine DaemonSet Pods' logLevel.
     pub(crate) fn io_engine_log_level(&self) -> &str {
         self.io_engine.log_level()
+    }
+
+    pub(crate) fn core_capacity_is_absent(&self) -> bool {
+        self.agents.core_capacity_is_absent()
+    }
+
+    pub(crate) fn core_thin_pool_commitment(&self) -> Result<String> {
+        self.agents.core_thin_pool_commitment()
+    }
+
+    pub(crate) fn core_thin_volume_commitment(&self) -> Result<String> {
+        self.agents.core_thin_volume_commitment()
+    }
+
+    pub(crate) fn core_thin_volume_commitment_initial(&self) -> Result<String> {
+        self.agents.core_thin_volume_commitment_initial()
     }
 }
 
@@ -95,5 +130,104 @@ impl IoEngine {
     /// This is a getter for the io-engine DaemonSet Pod's tracing logLevel.
     pub(crate) fn log_level(&self) -> &str {
         self.log_level.as_str()
+    }
+}
+
+#[derive(Deserialize)]
+pub(crate) struct Agents {
+    core: Core,
+}
+
+impl Agents {
+    pub(crate) fn core_capacity_is_absent(&self) -> bool {
+        self.core.capacity_is_absent()
+    }
+
+    pub(crate) fn core_thin_pool_commitment(&self) -> Result<String> {
+        self.core.thin_pool_commitment()
+    }
+
+    pub(crate) fn core_thin_volume_commitment(&self) -> Result<String> {
+        self.core.thin_volume_commitment()
+    }
+
+    pub(crate) fn core_thin_volume_commitment_initial(&self) -> Result<String> {
+        self.core.thin_volume_commitment_initial()
+    }
+}
+
+#[derive(Deserialize)]
+pub(crate) struct Core {
+    capacity: Option<Capacity>,
+}
+
+impl Core {
+    pub(crate) fn capacity_is_absent(&self) -> bool {
+        self.capacity.is_none()
+    }
+
+    pub(crate) fn thin_pool_commitment(&self) -> Result<String> {
+        Ok(self
+            .capacity
+            .as_ref()
+            .ok_or(ThinProvisioningOptionsAbsent.build())?
+            .thin_pool_commitment())
+    }
+
+    pub(crate) fn thin_volume_commitment(&self) -> Result<String> {
+        Ok(self
+            .capacity
+            .as_ref()
+            .ok_or(ThinProvisioningOptionsAbsent.build())?
+            .thin_volume_commitment())
+    }
+
+    pub(crate) fn thin_volume_commitment_initial(&self) -> Result<String> {
+        Ok(self
+            .capacity
+            .as_ref()
+            .ok_or(ThinProvisioningOptionsAbsent.build())?
+            .thin_volume_commitment_initial())
+    }
+}
+
+#[derive(Clone, Deserialize)]
+pub(crate) struct Capacity {
+    thin: Thin,
+}
+
+impl Capacity {
+    pub(crate) fn thin_pool_commitment(&self) -> String {
+        self.thin.pool_commitment()
+    }
+
+    pub(crate) fn thin_volume_commitment(&self) -> String {
+        self.thin.volume_commitment()
+    }
+
+    pub(crate) fn thin_volume_commitment_initial(&self) -> String {
+        self.thin.volume_commitment_initial()
+    }
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+pub(crate) struct Thin {
+    pool_commitment: String,
+    volume_commitment: String,
+    volume_commitment_initial: String,
+}
+
+impl Thin {
+    pub(crate) fn pool_commitment(&self) -> String {
+        self.pool_commitment.clone()
+    }
+
+    pub(crate) fn volume_commitment(&self) -> String {
+        self.volume_commitment.clone()
+    }
+
+    pub(crate) fn volume_commitment_initial(&self) -> String {
+        self.volume_commitment_initial.clone()
     }
 }

--- a/k8s/upgrade/src/upgrade_resources/objects.rs
+++ b/k8s/upgrade/src/upgrade_resources/objects.rs
@@ -10,8 +10,8 @@ use crate::{
 use k8s_openapi::api::{
     batch::v1::{Job, JobSpec},
     core::v1::{
-        Container, ContainerPort, EnvVar, EnvVarSource, ExecAction, ObjectFieldSelector, PodSpec,
-        PodTemplateSpec, Probe, ServiceAccount,
+        Container, EnvVar, EnvVarSource, ExecAction, ObjectFieldSelector, PodSpec, PodTemplateSpec,
+        Probe, ServiceAccount,
     },
     rbac::v1::{ClusterRole, ClusterRoleBinding, PolicyRule, RoleRef, Subject},
 };
@@ -305,11 +305,6 @@ pub(crate) fn upgrade_job(
                         image: Some(upgrade_image),
                         image_pull_policy,
                         name: UPGRADE_JOB_CONTAINER_NAME.to_string(),
-                        ports: Some(vec![ContainerPort {
-                            container_port: 8080,
-                            name: Some("http".to_string()),
-                            ..Default::default()
-                        }]),
                         env: Some(vec![
                             EnvVar {
                                 name: "RUST_LOG".to_string(),


### PR DESCRIPTION
This adds '--set' flags for thin_provisioning helm chart options. These are required because these are not present in 2.0.x helm charts, and a `helm upgrade` command along with the `--reuse-values` flag wil result in a nil pointer error for the helm binary. 