### PR TITLE
feat(upgrade): rectify image tag

### DIFF
--- a/k8s/upgrade/src/upgrade_resources/upgrade.rs
+++ b/k8s/upgrade/src/upgrade_resources/upgrade.rs
@@ -1,6 +1,6 @@
 use crate::{
     constant::{
-        get_image_tag, upgrade_event_selector, upgrade_image_concat, upgrade_name_concat,
+        get_image_version_tag, upgrade_event_selector, upgrade_image_concat, upgrade_name_concat,
         AGENT_CORE_POD_LABEL, API_REST_LABEL_SELECTOR, API_REST_POD_LABEL, DEFAULT_IMAGE_REGISTRY,
         DEFAULT_RELEASE_NAME, HELM_RELEASE_NAME_LABEL, IO_ENGINE_POD_LABEL, UPGRADE_EVENT_REASON,
         UPGRADE_JOB_CLUSTERROLEBINDING_NAME_SUFFIX, UPGRADE_JOB_CLUSTERROLE_NAME_SUFFIX,
@@ -515,7 +515,7 @@ impl UpgradeResources {
         } else {
             match action {
                 Actions::Create => {
-                    let upgrade_job_image_tag = get_image_tag();
+                    let upgrade_job_image_tag = get_image_version_tag();
                     let rest_deployment = get_deployment_for_rest(ns).await?;
                     let img = ImageProperties::try_from(rest_deployment)?;
                     let upgrade_deploy = objects::upgrade_job(


### PR DESCRIPTION
Since the image tag was modified to append to upgrade resource names , the image in pod was wrong. as below
`docker.io/openebs/mayastor-upgrade-job:vv2-1-0`
This PR resolves this problem

Even the upgrade resources had the name like `mayastor-upgrade-role-vv2-1-0` , this is also resolved to `mayastor-upgrade-role-v2-1-0` 