### PR TITLE
DiskPool Metrics Exporter - add committed size in bytes

### DIFF
--- a/exporter/src/pool/bin/main.rs
+++ b/exporter/src/pool/bin/main.rs
@@ -9,7 +9,7 @@ use exporter::pool::{
         grpc_client::{GrpcClient, GrpcContext, Timeouts},
         ApiVersion,
     },
-    collector::pools_collector::PoolsCollector,
+    collector::pools_collector::{get_node_name, PoolsCollector},
     config::ExporterConfig,
     error::ExporterError,
 };
@@ -26,6 +26,7 @@ fn initialize_exporter(args: &Cli) {
 async fn initialize_client(api_version: ApiVersion) -> Result<GrpcClient, ExporterError> {
     let timeout = Timeouts::new(Duration::from_secs(1), Duration::from_secs(5));
     let pod_ip = get_pod_ip()?;
+    let _ = get_node_name()?;
     let endpoint = Uri::builder()
         .scheme("https")
         .authority(format!("{pod_ip}:10124"))
@@ -99,6 +100,7 @@ async fn main() -> Result<(), String> {
     HttpServer::new(app)
         .bind(ExporterConfig::get_config().metrics_endpoint())
         .unwrap()
+        .workers(1)
         .run()
         .await
         .expect("Port should be free to expose the metrics");

--- a/exporter/src/pool/client/pool.rs
+++ b/exporter/src/pool/client/pool.rs
@@ -13,6 +13,7 @@ pub struct Pool {
     used: u64,
     capacity: u64,
     state: u64,
+    committed: u64,
 }
 
 impl Pool {
@@ -29,6 +30,11 @@ impl Pool {
     /// Get total capacity of the pool.
     pub fn capacity(&self) -> u64 {
         self.capacity
+    }
+
+    /// Get the pool commitment in bytes.
+    pub fn committed(&self) -> u64 {
+        self.committed
     }
 
     /// Get state of the pool.
@@ -57,6 +63,7 @@ impl From<rpc::io_engine::Pool> for Pool {
             used: value.used,
             capacity: value.capacity,
             state: value.state as u64,
+            committed: value.used,
         }
     }
 }
@@ -68,6 +75,7 @@ impl From<rpc::v1::pool::Pool> for Pool {
             used: value.used,
             capacity: value.capacity,
             state: value.state as u64,
+            committed: value.committed,
         }
     }
 }


### PR DESCRIPTION
chore: update controller dependency

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

feat(exporter/diskpool): add committed size in bytes

This is useful for thin provisioning to determine if a pool is overcommitted.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>