### PR TITLE
feat(k8s/upgrade-job): add wait for all event-publishes 

### DIFF
--- a/k8s/upgrade-job/src/common/constants.rs
+++ b/k8s/upgrade-job/src/common/constants.rs
@@ -8,11 +8,6 @@ pub(crate) const UMBRELLA_CHART_NAME: &str = "openebs";
 /// This is the name of the Helm chart of this project.
 pub(crate) const CORE_CHART_NAME: &str = "mayastor";
 
-/// This is the name of the event reporter. This code should be running inside a Kubernetes Pod
-/// which will post events. The reporter for those events will be set using the value of this
-/// constant.
-pub(crate) const KUBE_EVENT_REPORTER_NAME: &str = "mayastor-upgrade-job";
-
 /// This is the shared Pod label of the <helm-release>-io-engine DaemonSet.
 pub(crate) const IO_ENGINE_LABEL: &str = "app=io-engine";
 

--- a/k8s/upgrade-job/src/common/error.rs
+++ b/k8s/upgrade-job/src/common/error.rs
@@ -409,6 +409,17 @@ pub(crate) enum Error {
     /// synchronisation tool.
     #[snafu(display("Failed to send Event over the channel"))]
     EventChannelSend,
+
+    /// Error when trying to send a unit type through the channel as acknowledgement for completed
+    /// event publishes.
+    #[snafu(display(
+        "Failed to send acknowledgement of completed Event publishes over the channel: {}",
+        source
+    ))]
+    EventFinalAcknowledgementSend {
+        source: tokio::sync::mpsc::error::SendError<()>,
+    },
 }
+
 /// A wrapper type to remove repeated Result<T, Error> returns.
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;

--- a/k8s/upgrade-job/src/helm/client.rs
+++ b/k8s/upgrade-job/src/helm/client.rs
@@ -9,7 +9,7 @@ use k8s_openapi::serde;
 use serde::Deserialize;
 use snafu::{ensure, ResultExt};
 use std::{process::Command, str};
-use tracing::{debug, info};
+use tracing::debug;
 
 /// This struct is used to deserialize the output of `helm list -n <namespace> --deployed -o yaml`.
 #[derive(Clone, Deserialize)]
@@ -230,8 +230,6 @@ impl HelmReleaseClient {
                     .to_string()
             }
         );
-
-        info!("Helm upgrade successful!");
 
         Ok(())
     }

--- a/k8s/upgrade-job/src/helm/upgrade.rs
+++ b/k8s/upgrade-job/src/helm/upgrade.rs
@@ -14,6 +14,7 @@ use semver::Version;
 
 use snafu::{ensure, ResultExt};
 use std::path::PathBuf;
+use tracing::info;
 
 /// This is the helm chart variant of the helm chart installed in the cluster.
 /// The PRODUCT may be installed using either of these options, but never both.
@@ -184,8 +185,14 @@ impl HelmUpgrade {
 
     /// Use the HelmReleaseClient's upgrade method to upgrade the installed helm release.
     pub(crate) fn run(self) -> Result<()> {
+        info!("Starting helm upgrade...");
+
         self.client
-            .upgrade(self.release_name, self.chart_dir, Some(self.extra_args))
+            .upgrade(self.release_name, self.chart_dir, Some(self.extra_args))?;
+
+        info!("Helm upgrade successful!");
+
+        Ok(())
     }
 
     pub(crate) fn upgrade_from_version(&self) -> String {

--- a/k8s/upgrade-job/src/main.rs
+++ b/k8s/upgrade-job/src/main.rs
@@ -8,7 +8,7 @@ use crate::{
 use clap::Parser;
 
 use opts::CliArgs;
-use tracing::info;
+use tracing::{error, info};
 use upgrade::upgrade;
 use utils::{
     raw_version_str,
@@ -26,12 +26,12 @@ async fn main() -> Result<()> {
     init_logging();
 
     let opts = parse_cli_args().await.map_err(|error| {
-        tracing::error!(%error, "Failed to upgrade {PRODUCT}");
+        error!(%error, "Failed to upgrade {PRODUCT}");
         error
     })?;
 
     upgrade(&opts).await.map_err(|error| {
-        tracing::error!(%error, "Failed to upgrade {PRODUCT}");
+        error!(%error, "Failed to upgrade {PRODUCT}");
         flush_traces();
         error
     })

--- a/k8s/upgrade-job/src/upgrade.rs
+++ b/k8s/upgrade-job/src/upgrade.rs
@@ -1,8 +1,5 @@
 use crate::{
-    common::{
-        constants::{KUBE_EVENT_REPORTER_NAME, PRODUCT},
-        error::Result,
-    },
+    common::{constants::PRODUCT, error::Result},
     events::event_recorder::EventRecorder,
     helm::upgrade::HelmUpgrade,
     opts::CliArgs,
@@ -33,7 +30,6 @@ pub(crate) async fn upgrade(opts: &CliArgs) -> Result<()> {
     let event = EventRecorder::builder()
         .with_pod_name(&opts.pod_name())
         .with_namespace(&opts.namespace())
-        .with_reporter_name(KUBE_EVENT_REPORTER_NAME.to_string())
         .with_from_version(from_version.clone())
         .with_to_version(to_version.clone())
         .build()
@@ -99,5 +95,6 @@ pub(crate) async fn upgrade(opts: &CliArgs) -> Result<()> {
         .publish_normal(format!("Successfully upgraded {PRODUCT}"), "Successful")
         .await?;
 
+    event.shutdown_worker().await;
     Ok(())
 }


### PR DESCRIPTION
Presently, the drop implementation for EventRecorder cancels the event loop task before all of the events could be pulished. This change adds a channel to receive an acknowledgement message, after closing the primary event channel.

No cancellation is done, the worker should exit on the next line after the acknowledgement.

Additionally, adds/modifies some logs.