### PR TITLE
feat(volume group): enable extra create metadata injection by csi-provisioner

### DIFF
--- a/chart/templates/mayastor/csi/csi-controller-deployment.yaml
+++ b/chart/templates/mayastor/csi/csi-controller-deployment.yaml
@@ -40,6 +40,7 @@ spec:
             - "--feature-gates=Topology=true"
             - "--strict-topology=false"
             - "--default-fstype=ext4"
+            - "--extra-create-metadata" # This is needed for volume group feature to work
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
`--extra-create-metadata`: Enables the injection of extra PVC and PV metadata as parameters when calling `CreateVolume` on the driver (keys: `"csi.storage.k8s.io/pvc/name"`, `"csi.storage.k8s.io/pvc/namespace"`, `"csi.storage.k8s.io/pv/name"`). 

This is needed for generating the unique name for the `volume group`. If this is not enabled for whatever reason, we would not trigger `volume group feature` and `would just warn and continue` with normal creation process. 