### PR TITLE
fix: Correct etcd storage class helm values

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -109,7 +109,7 @@ $ helm install my-release openebs/mayastor
 | etcd.&ZeroWidthSpace;persistence.&ZeroWidthSpace;enabled | If true, use a Persistent Volume Claim. If false, use emptyDir. | `true` |
 | etcd.&ZeroWidthSpace;persistence.&ZeroWidthSpace;reclaimPolicy | PVC's reclaimPolicy | `"Delete"` |
 | etcd.&ZeroWidthSpace;persistence.&ZeroWidthSpace;size | Volume size | `"2Gi"` |
-| etcd.&ZeroWidthSpace;persistence.&ZeroWidthSpace;storageClass | Will define which storageClass to use in etcd's StatefulSets a `manual` storageClass will provision a hostpath PV on the same node an empty storageClass will use the default StorageClass on the cluster | `""` |
+| etcd.&ZeroWidthSpace;persistence.&ZeroWidthSpace;storageClassName | Will define which storageClass to use in etcd's StatefulSets a `manual` storageClass will provision a hostpath PV on the same node an empty storageClass will use the default StorageClass on the cluster | `""` |
 | etcd.&ZeroWidthSpace;podAntiAffinityPreset | Pod anti-affinity preset Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity | `"hard"` |
 | etcd.&ZeroWidthSpace;removeMemberOnContainerTermination | Use a PreStop hook to remove the etcd members from the etcd cluster on container termination Ignored if lifecycleHooks is set or replicaCount=1 | `false` |
 | etcd.&ZeroWidthSpace;replicaCount | Number of replicas of etcd | `3` |

--- a/chart/templates/etcd/storage/localpv.yaml
+++ b/chart/templates/etcd/storage/localpv.yaml
@@ -1,5 +1,5 @@
 ---
-{{ if and .Values.etcd.persistence.enabled (eq .Values.etcd.persistence.storageClass "manual") }}
+{{ if and .Values.etcd.persistence.enabled (eq .Values.etcd.persistence.storageClassName "manual") }}
 {{- range $index, $end := until (.Values.etcd.replicaCount | int) }}
 apiVersion: v1
 kind: PersistentVolume

--- a/chart/templates/loki-stack/storage/localpv.yaml
+++ b/chart/templates/loki-stack/storage/localpv.yaml
@@ -1,6 +1,5 @@
 ---
-
-{{ if and (eq ( index .Values "loki-stack" "loki" "persistence" "storageClassName" ) "manual") ( index .Values "loki-stack" "loki" "persistence" "enabled" ) }}
+{{ if and .Values.loki-stack.persistence.enabled (eq .Values.loki-stack.persistence.storageClassName "manual") }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -342,7 +342,7 @@ etcd:
     # -- Will define which storageClass to use in etcd's StatefulSets
     # a `manual` storageClass will provision a hostpath PV on the same node
     # an empty storageClass will use the default StorageClass on the cluster
-    storageClass: ""
+    storageClassName: ""
     # -- Volume size
     size: 2Gi
     # -- PVC's reclaimPolicy


### PR DESCRIPTION
Docs [here](https://mayastor.gitbook.io/introduction/quickstart/deploy-mayastor#installation-via-helm) say the following:

> Installing Mayastor via the Helm chart sets the StorageClass as 'default' for Loki and etcd StatefulSets. This will work in clusters which have a StorageClass named 'default'. If there is no 'default' StorageClass in the cluster, storage provisioning will fail for Loki and etcd. In such cases, one can change the StorageClass to 'manual' which will provision a PersistentVolume of type hostPath. To do this, make the following changes in the values.yaml file:
> * loki.persistence.storageClassName: manual
> * etcd.persistence.storageClassName: manual

This PR updates the `etcd` storageclass value to correlate with that as well as be consistent with the Loki value. 

Related: https://github.com/openebs/mayastor-docs/pull/123