### PR TITLE
feat(upgrade): add version validation in plugin

### DIFF
--- a/console-logger/src/console.rs
+++ b/console-logger/src/console.rs
@@ -12,8 +12,8 @@ pub fn info(message: &str, data: &str) {
 /// Print error on console.
 pub fn error(message: &str, data: &str) {
     eprintln!(
-        "{} \n {} ",
-        Cyan.bold().italic().paint(message),
+        "{} \n{} ",
+        Red.bold().italic().paint(message),
         Red.bold().italic().paint(data)
     );
 }

--- a/k8s/upgrade/src/constant.rs
+++ b/k8s/upgrade/src/constant.rs
@@ -44,7 +44,7 @@ pub(crate) fn get_image_version_tag() -> String {
     }
 }
 
-/// Returns the git tag version (if tag is found) or simply returns the commit hash (12 characters).
+/// Returns the git tag version (if tag is found).
 pub(crate) fn release_version() -> Option<String> {
     let version_info = version_info!();
     version_info.version_tag
@@ -68,9 +68,11 @@ pub(crate) fn upgrade_event_selector(release_name: &str, component_name: &str) -
     let name_value = format!("{release_name}-{component_name}-{tag}");
     format!("{kind},{name_key}={name_value}")
 }
-
+/// Installed release name.
 pub(crate) const HELM_RELEASE_NAME_LABEL: &str = "openebs.io/release";
-
+/// Installed release version.
+pub(crate) const HELM_RELEASE_VERSION_LABEL: &str = "openebs.io/version";
+/// Default image repository.
 pub(crate) const DEFAULT_IMAGE_REGISTRY: &str = "docker.io";
 /// The upgrade job will use the UPGRADE_JOB_IMAGE_NAME image (below) with this tag.
 pub(crate) const UPGRADE_JOB_IMAGE_TAG: &str = "develop";
@@ -104,3 +106,5 @@ pub(crate) const AGENT_CORE_POD_LABEL: &str = "app=agent-core";
 pub(crate) const API_REST_POD_LABEL: &str = "app=api-rest";
 /// UPGRADE_EVENT_REASON is the reason field in upgrade job.
 pub(crate) const UPGRADE_EVENT_REASON: &str = "MayastorUpgrade";
+/// VALID_UPGRADE_PATHS is path for valid upgrades.
+pub(crate) const VALID_UPGRADE_PATHS: &str = "v2.0.0:v2.1.0;v2.0.1:v2.1.0;";

--- a/k8s/upgrade/src/error.rs
+++ b/k8s/upgrade/src/error.rs
@@ -72,6 +72,7 @@ pub enum Error {
     /// No message in upgrade event.
     #[error("No Message present in event.")]
     MessageInEventNotPresent,
+
     /// No upgrade event present.
     #[error("No upgrade event present.")]
     UpgradeEventNotPresent,
@@ -111,6 +112,22 @@ pub enum Error {
     /// Error for when the image format is invalid.
     #[error("Failed to find a valid image in Deployment.")]
     ReferenceDeploymentInvalidImage,
+
+    /// No installed version label.
+    #[error("No label for version present.")]
+    VersionLabelNotPresent,
+
+    /// Source and target version are same.
+    #[error("Source and target version are same.")]
+    SourceTargetVersionSame,
+
+    /// Not a valid source version for upgrade.
+    #[error("Not a valid source version for upgrade.")]
+    NotAValidSourceForUpgrade,
+
+    /// Not a valid UpgradePath.
+    #[error("Not a valid upgrade path.")]
+    NotAValidUpgradePath,
 }
 
 impl From<anyhow::Error> for Error {

--- a/k8s/upgrade/src/user_prompt.rs
+++ b/k8s/upgrade/src/user_prompt.rs
@@ -38,3 +38,15 @@ pub const UPGRADE_DRY_RUN_SUMMARY: &str =
 /// Information about successful start of upgrade process.
 pub const UPGRADE_JOB_STARTED: &str =
     "\nThe upgrade has started. You can see the recent upgrade status using 'get upgrade-status` command.";
+
+/// Source and target version are same.
+pub const SOURCE_TARGET_VERSION_SAME: &str =
+    "\nThe upgrade cannot proceed as target version is same as source version.\nVersion:";
+
+/// Source and target version are same.
+pub const NOT_A_VALID_UPGRADE_PATH: &str =
+    "\nNot a valid upgrade path.\nThe valid upgrade path are:";
+
+/// Not a valid source for upgrade.
+pub const NOT_A_VALID_SOURCE_FOR_UPGRADE: &str =
+    "\nNot a valid source for upgrade. \nThe valid upgrade path are:";


### PR DESCRIPTION
The code for upgrade path validation is present in k8s upgrade job, but this PR add the validation in plugin so that the user can see the output while running the upgrade command. 
This also adheres to the BDD

This PR adds the validation on the below condition:
- Upgrade won't start if the the source version is invalid
- Upgrade won't start if the the upgrade path is invalid.
- Upgrade won't start if the the source and target version are same.

The valid upgrade path being 
v2.0.0 -> v2.1.0
v2.0.1 -> v2.1.0