### PR TITLE
ci(gha): update nix action to v20

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos
           extra_nix_config: extra-platforms = aarch64-darwin


### PR DESCRIPTION
Not quite sure why this started failing.. anyways updating nix action to 20 fixes it.