### PR TITLE
feat(upgrade): add time stamp to tag for testing envt

### DIFF
--- a/k8s/upgrade/src/constant.rs
+++ b/k8s/upgrade/src/constant.rs
@@ -37,15 +37,20 @@ pub(crate) fn upgrade_obj_suffix() -> String {
 }
 
 /// Fetch the image tag for upgrade job's pod.
-pub(crate) fn get_image_version_tag() -> String {
-    let version = release_version();
-    match version {
-        Some(upgrade_job_image_tag) => upgrade_job_image_tag,
-        None => UPGRADE_JOB_IMAGE_TAG.to_string(),
+pub(crate) fn get_image_version_tag(image_tag: Option<&String>) -> String {
+    match image_tag {
+        Some(tag) => tag.to_string(),
+        None => {
+            let version = release_version();
+            match version {
+                Some(upgrade_job_image_tag) => upgrade_job_image_tag,
+                None => UPGRADE_JOB_IMAGE_TAG.to_string(),
+            }
+        }
     }
 }
 
-/// Returns the git tag version (if tag is found) or simply returns the commit hash (12 characters).
+/// Returns the git tag version (if tag is found)
 pub(crate) fn release_version() -> Option<String> {
     let version_info = version_info!();
     version_info.version_tag


### PR DESCRIPTION
In the testing environment the images are pushed with timestamp. Since the upgrade image were not time stamped , the testing environment used older images,

A new flag `image_tag` needs to be passed if users wants to use a custom tag
```
ashish@vm:~/code/rust/mayastor-extensions(image-for-develop)$ curl <<CI_REGISTRY_URL>>/v2/openebs/mayastor-upgrade-job/tags/list | jq . | grep "release"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1816  100  1816    0     0   9634      0 --:--:-- --:--:-- --:--:--  9659
    "release-2.1-2023-04-16-11-54-07",
    "release-2.1-2023-04-18-00-07-11",
    "release-2.1-2023-04-24-08-58-13",
    "release-2.1-2023-04-17-14-37-17",
    "release-2.1-2023-04-24-00-07-09",
    "release-2.1-2023-04-29-00-51-14",
    "release-2.1-2023-04-20-00-07-13",
    "release-2.1-2023-04-20-12-52-20",
    "release-2.1-2023-04-15-00-51-10",
    "release-2.1-2023-04-21-00-07-13",
    "release-2.1-2023-04-19-00-07-09",
    "release-2.1-2023-04-22-00-51-12",
    "release-2.1-2023-04-25-00-07-13",
    "release-2.1",
    "release-2.1-2023-04-26-00-07-12",
    "release-2.1-2023-04-27-00-07-11",
```
At present the testing is using the image tag as `release-2.1` and 
Same is the case with develop branch as well.


@w3aman @blaisedias @rohan2794  you need to fetch the latest build tag and pass it  using`--image_tag`  flag like `--image_tag release-2.1-2023-04-27-00-07-11` so  that the upgrade job takes the image which has the same tag as passed by user.





