### PR TITLE
fix(gha/binaries): build on tag push

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,6 +1,8 @@
 name: Release Artifacts
 on:
   push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+**'
     branches:
       - 'release/**'
       - 'develop'


### PR DESCRIPTION
Tag was not being included on kubectl-binary which causes upgrade to deploy job container using branch rather than the release tag.