### PR TITLE
feat(upgrade-job): support for upgrade to openebs-3.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -591,7 +591,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -757,7 +757,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.13",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -774,7 +774,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1131,7 +1131,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1999,7 +1999,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2820,7 +2820,7 @@ checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3072,9 +3072,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.13"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3157,7 +3157,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3282,7 +3282,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.16",
 ]
 
 [[package]]

--- a/k8s/upgrade-job/src/common/constants.rs
+++ b/k8s/upgrade-job/src/common/constants.rs
@@ -21,8 +21,11 @@ pub(crate) const CHART_VERSION_LABEL_KEY: &str = "openebs.io/version";
 pub(crate) const DRAIN_FOR_UPGRADE: &str = "mayastor-upgrade";
 
 /// This is the allowed upgrade to-version/to-version-range for the Umbrella chart.
-pub(crate) const TO_UMBRELLA_SEMVER: &str = "3.6.0";
+pub(crate) const TO_UMBRELLA_SEMVER: &str = "3.7.0";
 
-/// This version set will be only allowed to upgrade to TO_UMBRELLA_SEMVER above. This range applies
-/// to the Umbrella chart.
-pub(crate) const FROM_UMBRELLA_SEMVER: &str = ">=3.4.0, <=3.5.0";
+/// This is the user docs URL for the Umbrella chart.
+pub(crate) const UMBRELLA_CHART_UPGRADE_DOCS_URL: &str =
+    "https://openebs.io/docs/user-guides/upgrade#mayastor-upgrade";
+
+/// This defines the range of helm chart versions for the 2.1 release of the Core helm chart.
+pub(crate) const TWO_DOT_ONE: &str = ">=2.1.0-rc.0, <=2.1.0";

--- a/k8s/upgrade-job/src/common/error.rs
+++ b/k8s/upgrade-job/src/common/error.rs
@@ -1,5 +1,8 @@
 use crate::{
-    common::constants::{CHART_VERSION_LABEL_KEY, CORE_CHART_NAME, PRODUCT, UMBRELLA_CHART_NAME},
+    common::constants::{
+        CHART_VERSION_LABEL_KEY, CORE_CHART_NAME, PRODUCT, TO_UMBRELLA_SEMVER, UMBRELLA_CHART_NAME,
+        UMBRELLA_CHART_UPGRADE_DOCS_URL,
+    },
     events::event_recorder::EventNote,
 };
 use snafu::Snafu;
@@ -413,15 +416,6 @@ pub(crate) enum Error {
     #[snafu(display("Failed to send Event over the channel"))]
     EventChannelSend,
 
-    /// Error for when the 'chart' member of a crate::helm::client::HelmReleaseElement cannot be
-    /// split at the first occurrence of '-', e.g. <chart-name>-2.1.0-rc8.
-    #[snafu(display(
-        "Failed to split helm chart name '{}', at the first occurrence of '{}'",
-        chart_name,
-        delimiter
-    ))]
-    HelmChartNameSplit { chart_name: String, delimiter: char },
-
     /// Error for when the no value for version label is found on the helm chart.
     #[snafu(display(
         "Failed to get the value of the {} label in Pod {} in Namespace {}",
@@ -439,9 +433,68 @@ pub(crate) enum Error {
     ))]
     NoNamespaceInPod { pod_name: String, context: String },
 
-    /// Error for when the priorityClassName option is absent, but still tried to fetch it.
-    #[snafu(display("The priorityClassName yaml object is absent amongst the helm values"))]
-    PriorityClassOptionAbsent,
+    /// Error for the Umbrella chart is not upgraded.
+    #[snafu(display(
+        "The {} helm chart is not upgraded to version {}: Upgrade for helm chart {} is not \
+        supported, refer to the instructions at {} to upgrade your release of the {} helm \
+        chart to version {}",
+        UMBRELLA_CHART_NAME,
+        TO_UMBRELLA_SEMVER,
+        UMBRELLA_CHART_NAME,
+        UMBRELLA_CHART_UPGRADE_DOCS_URL,
+        UMBRELLA_CHART_NAME,
+        TO_UMBRELLA_SEMVER,
+    ))]
+    UmbrellaChartNotUpgraded,
+
+    /// Error for when the helm upgrade for the Core chart does not have a chart directory.
+    #[snafu(display(
+        "The {} helm chart could not be upgraded as input chart directory is absent",
+        CORE_CHART_NAME
+    ))]
+    CoreChartUpgradeNoneChartDir,
+
+    /// Error for when the Storage REST API Deployment is absent.
+    #[snafu(display(
+        "Found no {} REST API Deployments in the namespace {} with labelSelector {}",
+        PRODUCT,
+        namespace,
+        label_selector
+    ))]
+    NoRestDeployment {
+        namespace: String,
+        label_selector: String,
+    },
+
+    /// Error for when the CHART_VERSION_LABEL_KEY is missing amongst the labels in a Deployment.
+    #[snafu(display(
+        "A label with the key {} was not found for Deployment {} in namespace {}",
+        CHART_VERSION_LABEL_KEY,
+        deployment_name,
+        namespace
+    ))]
+    NoVersionLabelInDeployment {
+        deployment_name: String,
+        namespace: String,
+    },
+
+    /// Error for when a Kubernetes API request for GET-ing a list of Deployments filtered by
+    /// label(s) fails.
+    #[snafu(display(
+        "Failed to list Deployments with label {} in namespace {}: {}",
+        label_selector,
+        namespace,
+        source
+    ))]
+    ListDeploymentsWithLabel {
+        source: kube::Error,
+        namespace: String,
+        label_selector: String,
+    },
+
+    /// Error for when the helm upgrade run is that of an invalid chart configuration.
+    #[snafu(display("Invalid helm upgrade request"))]
+    InvalidHelmUpgrade,
 }
 
 /// A wrapper type to remove repeated Result<T, Error> returns.

--- a/k8s/upgrade-job/src/common/kube_client.rs
+++ b/k8s/upgrade-job/src/common/kube_client.rs
@@ -1,5 +1,8 @@
 use crate::common::error::{K8sClientGeneration, KubeClientSetBuilderNs, Result};
-use k8s_openapi::api::core::v1::{Namespace, Pod};
+use k8s_openapi::api::{
+    apps::v1::Deployment,
+    core::v1::{Namespace, Pod},
+};
 use kube::{api::Api, Client};
 use snafu::ResultExt;
 
@@ -31,7 +34,8 @@ impl KubeClientSetBuilder {
         return Ok(KubeClientSet {
             client: client.clone(),
             pods_api: Api::namespaced(client.clone(), namespace.as_str()),
-            namespaces_api: Api::all(client),
+            namespaces_api: Api::all(client.clone()),
+            deployments_api: Api::namespaced(client, namespace.as_str()),
         });
     }
 }
@@ -41,6 +45,7 @@ pub(crate) struct KubeClientSet {
     client: Client,
     pods_api: Api<Pod>,
     namespaces_api: Api<Namespace>,
+    deployments_api: Api<Deployment>,
 }
 
 impl KubeClientSet {
@@ -55,6 +60,11 @@ impl KubeClientSet {
     /// Generate the Namespace api client.
     pub(crate) fn namespaces_api(&self) -> &Api<Namespace> {
         &self.namespaces_api
+    }
+
+    /// Generate the Deployment api client.
+    pub(crate) fn deployments_api(&self) -> &Api<Deployment> {
+        &self.deployments_api
     }
 
     /// Get a clone of the kube::Client.

--- a/k8s/upgrade-job/src/helm/chart.rs
+++ b/k8s/upgrade-job/src/helm/chart.rs
@@ -1,4 +1,4 @@
-use crate::common::error::{PriorityClassOptionAbsent, Result, ThinProvisioningOptionsAbsent};
+use crate::common::error::{Result, ThinProvisioningOptionsAbsent};
 use semver::Version;
 use serde::Deserialize;
 
@@ -8,7 +8,6 @@ pub(crate) struct Chart {
     /// This is the name of the helm chart.
     name: String,
     /// This is the version of the helm chart.
-    #[serde(deserialize_with = "Version::deserialize")]
     version: Version,
 }
 
@@ -24,52 +23,6 @@ impl Chart {
     }
 }
 
-/// This is used to deserialize the values.yaml file of the Umbrella chart.
-#[derive(Deserialize)]
-pub(crate) struct UmbrellaValues {
-    /// The Umbrella chart embeds the values options of the Core chart in a yaml object with the
-    /// same name as the name of the Core chart. The Core chart is a dependency-chart for the
-    /// Umbrella chart.
-    #[serde(rename(deserialize = "mayastor"))]
-    core: CoreValues,
-}
-
-impl UmbrellaValues {
-    /// This is a getter for the container image tag of the Umbrella chart.
-    pub(crate) fn image_tag(&self) -> &str {
-        self.core.image_tag()
-    }
-
-    /// This is the logLevel of the io-engine DaemonSet Pods.
-    pub(crate) fn io_engine_log_level(&self) -> &str {
-        self.core.io_engine_log_level()
-    }
-
-    pub(crate) fn core_capacity_is_absent(&self) -> bool {
-        self.core.core_capacity_is_absent()
-    }
-
-    pub(crate) fn core_thin_pool_commitment(&self) -> Result<String> {
-        self.core.core_thin_pool_commitment()
-    }
-
-    pub(crate) fn core_thin_volume_commitment(&self) -> Result<String> {
-        self.core.core_thin_volume_commitment()
-    }
-
-    pub(crate) fn core_thin_volume_commitment_initial(&self) -> Result<String> {
-        self.core.core_thin_volume_commitment_initial()
-    }
-
-    pub(crate) fn priority_class_name_is_absent(&self) -> bool {
-        self.core.priority_class_name_is_absent()
-    }
-
-    pub(crate) fn priority_class_name(&self) -> Result<String> {
-        self.core.priority_class_name()
-    }
-}
-
 /// This is used to deserialize the values.yaml of the Core chart.
 #[derive(Deserialize)]
 pub(crate) struct CoreValues {
@@ -80,9 +33,6 @@ pub(crate) struct CoreValues {
     io_engine: IoEngine,
     /// This is the .agents yaml object in the helm value.yaml.
     agents: Agents,
-    /// This is the priorityClassName override helm value.
-    #[serde(rename(deserialize = "priorityClassName"))]
-    priority_class_name: Option<String>,
 }
 
 impl CoreValues {
@@ -110,20 +60,6 @@ impl CoreValues {
 
     pub(crate) fn core_thin_volume_commitment_initial(&self) -> Result<String> {
         self.agents.core_thin_volume_commitment_initial()
-    }
-
-    /// The priorityClassName values key may be absent from the to_chart, and this function asserts
-    /// this condition.
-    pub(crate) fn priority_class_name_is_absent(&self) -> bool {
-        self.priority_class_name.is_none()
-    }
-
-    pub(crate) fn priority_class_name(&self) -> Result<String> {
-        Ok(self
-            .priority_class_name
-            .as_ref()
-            .ok_or(PriorityClassOptionAbsent.build())?
-            .clone())
     }
 }
 

--- a/k8s/upgrade-job/src/helm/upgrade.rs
+++ b/k8s/upgrade-job/src/helm/upgrade.rs
@@ -1,9 +1,10 @@
 use crate::{
     common::{
-        constants::{CORE_CHART_NAME, UMBRELLA_CHART_NAME},
+        constants::{CORE_CHART_NAME, TO_UMBRELLA_SEMVER, UMBRELLA_CHART_NAME},
         error::{
-            HelmUpgradeOptionsAbsent, InvalidUpgradePath, NoInputHelmChartDir, NotAKnownHelmChart,
-            RegexCompile, Result,
+            CoreChartUpgradeNoneChartDir, HelmUpgradeOptionsAbsent, InvalidHelmUpgrade,
+            InvalidUpgradePath, NoInputHelmChartDir, NotAKnownHelmChart, RegexCompile, Result,
+            UmbrellaChartNotUpgraded,
         },
     },
     helm::{client::HelmReleaseClient, values::generate_values_args},
@@ -30,14 +31,13 @@ pub(crate) enum HelmChart {
 pub(crate) struct HelmUpgradeBuilder {
     release_name: Option<String>,
     namespace: Option<String>,
-    umbrella_chart_dir: Option<PathBuf>,
     core_chart_dir: Option<PathBuf>,
     upgrade_path_file: PathBuf,
     skip_upgrade_path_validation: bool,
 }
 
 impl HelmUpgradeBuilder {
-    /// This is a builder option to add the Namespace of the helm chart to be upgrade.
+    /// This is a builder option to add the Namespace of the helm chart to be upgraded.
     #[must_use]
     pub(crate) fn with_namespace<J>(mut self, ns: J) -> Self
     where
@@ -59,15 +59,8 @@ impl HelmUpgradeBuilder {
 
     /// This is a builder option to set the directory path of the Umbrella helm chart CLI option.
     #[must_use]
-    pub(crate) fn with_umbrella_chart_dir(mut self, dir: Option<PathBuf>) -> Self {
-        self.umbrella_chart_dir = dir;
-        self
-    }
-
-    /// This is a builder option to set the directory path of the Umbrella helm chart CLI option.
-    #[must_use]
-    pub(crate) fn with_core_chart_dir(mut self, dir: Option<PathBuf>) -> Self {
-        self.core_chart_dir = dir;
+    pub(crate) fn with_core_chart_dir(mut self, dir: PathBuf) -> Self {
+        self.core_chart_dir = Some(dir);
         self
     }
 
@@ -88,20 +81,37 @@ impl HelmUpgradeBuilder {
         self
     }
 
-    /// This adds buiilds the HelmUpgrade object.
-    pub(crate) fn build(self) -> Result<HelmUpgrade> {
+    /// This builds the HelmUpgrade object.
+    pub(crate) async fn build(self) -> Result<HelmUpgrade> {
         ensure!(
             self.release_name.is_some() && self.namespace.is_some(),
             HelmUpgradeOptionsAbsent
         );
-
         let release_name = self.release_name.clone().unwrap();
+        let namespace = self.namespace.clone().unwrap();
+
         // Generate HelmReleaseClient.
         let client = HelmReleaseClient::builder()
-            .with_namespace(self.namespace.clone().unwrap())
+            .with_namespace(namespace.clone())
             .build()?;
+
         // Get HelmReleaseElement object for the release specified in CLI options.
         let chart = client.release_info(release_name.clone())?.chart();
+
+        // The version of the Core helm chart (installed as a the parent chart or as a dependent
+        // chart) which is installed in the cluster.
+        let from_version: Version =
+            upgrade::path::version_from_rest_deployment_label(namespace.as_str()).await?;
+
+        // The version of the Core chart which we are (maybe) going to.
+        let chart_dir: PathBuf = self.core_chart_dir.ok_or(
+            NoInputHelmChartDir {
+                chart_name: CORE_CHART_NAME.to_string(),
+            }
+            .build(),
+        )?;
+        let chart_yaml_path = chart_dir.join("Chart.yaml");
+        let to_version: Version = upgrade::path::version_from_chart_yaml_file(chart_yaml_path)?;
 
         // Define regular expression to pick out the chart name from the
         // <chart-name>-<chart-version> string.
@@ -110,27 +120,22 @@ impl HelmUpgradeBuilder {
         let core_chart_regex =
             format!(r"^({CORE_CHART_NAME}-[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)$");
 
-        // Assign HelmChart variant and validate directory path input for the said
-        // variant's chart based on the 'chart' member of the HelmReleaseElement.
+        // Validate if already upgraded for Umbrella chart, and prepare for upgrade for Core chart.
         let chart_variant: HelmChart;
-        let chart_dir: PathBuf;
-        // Case: HelmChart::Umbrella.
-        if Regex::new(umbrella_chart_regex.as_str())
+        let mut already_upgraded = false;
+        let mut core_chart_dir: Option<String> = None;
+        let mut core_chart_extra_args: Option<Vec<String>> = None;
+
+        if Regex::new(umbrella_chart_regex.as_str()) // Case: HelmChart::Umbrella.
             .context(RegexCompile {
                 expression: umbrella_chart_regex.clone(),
             })?
             .is_match(chart.as_str())
         {
             chart_variant = HelmChart::Umbrella;
-            match self.umbrella_chart_dir {
-                Some(umbrella_dir) => chart_dir = umbrella_dir,
-                None => {
-                    return NoInputHelmChartDir {
-                        chart_name: UMBRELLA_CHART_NAME.to_string(),
-                    }
-                    .fail()
-                }
-            }
+
+            already_upgraded = to_version.eq(&from_version);
+            ensure!(already_upgraded, UmbrellaChartNotUpgraded);
         } else if Regex::new(core_chart_regex.as_str()) // Case: HelmChart::Core.
             .context(RegexCompile {
                 expression: core_chart_regex.clone(),
@@ -138,59 +143,44 @@ impl HelmUpgradeBuilder {
             .is_match(chart.as_str())
         {
             chart_variant = HelmChart::Core;
-            match self.core_chart_dir {
-                Some(core_dir) => chart_dir = core_dir,
-                None => {
-                    return NoInputHelmChartDir {
-                        chart_name: CORE_CHART_NAME.to_string(),
-                    }
-                    .fail()
-                }
+
+            // Skip upgrade-path validation and allow all upgrades for the Core helm chart, if the
+            // flag is set.
+            if !self.skip_upgrade_path_validation {
+                // Check for already upgraded
+                already_upgraded = to_version.eq(&from_version);
+
+                let upgrade_path_is_valid =
+                    upgrade::path::is_valid_for_core_chart(&from_version, self.upgrade_path_file)?;
+                ensure!(
+                    upgrade_path_is_valid || already_upgraded,
+                    InvalidUpgradePath
+                );
             }
+
+            // Generate args to pass to the `helm upgrade` command.
+            let values_yaml_path = chart_dir.join("values.yaml");
+            let upgrade_args: Vec<String> = generate_values_args(
+                &from_version,
+                values_yaml_path,
+                &client,
+                release_name.clone(),
+            )?;
+
+            core_chart_dir = Some(chart_dir.to_string_lossy().to_string());
+            core_chart_extra_args = Some(upgrade_args);
         } else {
             // Case: Helm chart release is not a known helm chart installation.
             return NotAKnownHelmChart { chart_name: chart }.fail();
         }
 
-        let mut chart_yaml_path = chart_dir.clone();
-        chart_yaml_path.push("Chart.yaml");
-        let to_version = upgrade::path::version_from_chart_yaml_file(chart_yaml_path)?;
-        let from_version = upgrade::path::version_from_release_chart(chart)?;
-        let invalid_upgrades = upgrade::path::invalid_upgrade_path(self.upgrade_path_file)?;
-
-        // Check for already upgraded
-        let already_upgraded = to_version.eq(&from_version);
-        ensure!(!already_upgraded, InvalidUpgradePath);
-
-        if !self.skip_upgrade_path_validation {
-            let upgrade_path_is_valid = upgrade::path::is_valid(
-                chart_variant.clone(),
-                &from_version,
-                &to_version,
-                invalid_upgrades,
-            )?;
-            ensure!(upgrade_path_is_valid, InvalidUpgradePath);
-        }
-
-        // Generate args to pass to the `helm upgrade` command.
-        let mut values_yaml_path = chart_dir.clone();
-        values_yaml_path.push("values.yaml");
-        let mut upgrade_args: Vec<String> = generate_values_args(
-            chart_variant,
-            values_yaml_path,
-            &client,
-            release_name.clone(),
-        )?;
-        // To roll back to previous release, in case helm upgrade fails, also
-        // to wait for all Pods, PVCs to come to a ready state.
-        upgrade_args.push("--atomic".to_string());
-
         Ok(HelmUpgrade {
+            chart_variant,
             already_upgraded,
-            chart_dir: chart_dir.to_string_lossy().to_string(),
+            core_chart_dir,
             release_name,
             client,
-            extra_args: upgrade_args,
+            core_chart_extra_args,
             from_version,
             to_version,
         })
@@ -199,11 +189,12 @@ impl HelmUpgradeBuilder {
 
 /// This type can generate and execute the `helm upgrade` command.
 pub(crate) struct HelmUpgrade {
+    chart_variant: HelmChart,
     already_upgraded: bool,
-    chart_dir: String,
+    core_chart_dir: Option<String>,
     release_name: String,
     client: HelmReleaseClient,
-    extra_args: Vec<String>,
+    core_chart_extra_args: Option<Vec<String>>,
     from_version: Version,
     to_version: Version,
 }
@@ -216,18 +207,38 @@ impl HelmUpgrade {
 
     /// Use the HelmReleaseClient's upgrade method to upgrade the installed helm release.
     pub(crate) fn run(self) -> Result<()> {
-        if self.already_upgraded {
-            info!(
-                "Skipping helm upgrade, as the version of the installed helm chart is the same \
-                as that of this upgrade-job's helm chart"
-            );
-            return Ok(());
-        }
+        match self.chart_variant {
+            HelmChart::Umbrella if self.already_upgraded => {
+                info!(
+                    "Verified that {UMBRELLA_CHART_NAME} helm chart release '{}' has version {TO_UMBRELLA_SEMVER}",
+                    self.release_name.as_str()
+                );
+            }
+            HelmChart::Umbrella if !self.already_upgraded => {
+                // It should be impossible to hit this error.
+                return UmbrellaChartNotUpgraded.fail();
+            }
+            HelmChart::Core if self.already_upgraded => {
+                info!(
+                    "Skipping helm upgrade, as the version of the installed helm chart is the same \
+                    as that of this upgrade-job's helm chart"
+                );
+            }
+            HelmChart::Core if !self.already_upgraded => {
+                // It should be impossible to hit this error.
+                let chart_dir = self
+                    .core_chart_dir
+                    .ok_or(CoreChartUpgradeNoneChartDir.build())?;
 
-        info!("Starting helm upgrade...");
-        self.client
-            .upgrade(self.release_name, self.chart_dir, Some(self.extra_args))?;
-        info!("Helm upgrade successful!");
+                info!("Starting helm upgrade...");
+                self.client
+                    .upgrade(self.release_name, chart_dir, self.core_chart_extra_args)?;
+                info!("Helm upgrade successful!");
+            }
+            _ => {
+                return InvalidHelmUpgrade.fail();
+            }
+        }
 
         Ok(())
     }

--- a/k8s/upgrade-job/src/helm/values.rs
+++ b/k8s/upgrade-job/src/helm/values.rs
@@ -1,21 +1,21 @@
 use crate::{
     common::{
-        constants::{CORE_CHART_NAME, TO_UMBRELLA_SEMVER},
-        error::{OpeningFile, Result, U8VectorToString, YamlParseFromFile, YamlParseFromSlice},
+        constants::TWO_DOT_ONE,
+        error::{
+            OpeningFile, Result, SemverParse, U8VectorToString, YamlParseFromFile,
+            YamlParseFromSlice,
+        },
     },
-    helm::{
-        chart::{CoreValues, UmbrellaValues},
-        client::HelmReleaseClient,
-        upgrade::HelmChart,
-    },
+    helm::{chart::CoreValues, client::HelmReleaseClient},
 };
-
+use semver::{Version, VersionReq};
 use snafu::ResultExt;
 use std::{fs::File, path::PathBuf, str};
 
+// TODO: Refactor this function to infer the flags based on the locally available helm chart.
 /// This compiles all of the helm values options to be passed during the helm chart upgrade.
 pub(crate) fn generate_values_args(
-    chart_variant: HelmChart,
+    from_version: &Version,
     values_yaml_path: PathBuf,
     client: &HelmReleaseClient,
     release_name: String,
@@ -23,236 +23,126 @@ pub(crate) fn generate_values_args(
     let to_values_yaml = File::open(values_yaml_path.as_path()).context(OpeningFile {
         filepath: values_yaml_path.clone(),
     })?;
+    let to_values: CoreValues =
+        serde_yaml::from_reader(to_values_yaml).context(YamlParseFromFile {
+            filepath: values_yaml_path,
+        })?;
 
     let from_values_yaml = client.get_values_as_yaml::<String, String>(release_name, None)?;
     let from_values_yaml_string = str::from_utf8(from_values_yaml.as_slice())
         .context(U8VectorToString)?
         .to_string();
+    let from_values: CoreValues =
+        serde_yaml::from_slice(from_values_yaml.as_slice()).context(YamlParseFromSlice {
+            input_yaml: from_values_yaml_string,
+        })?;
+
     // Helm chart flags -- reuse all values, except for the image tag. For new values,
     // use from installed-release's values, if present, else use defaults from to-chart.
-    // Includes capacity for the "--atomic" flag.
-    let mut upgrade_args: Vec<String> = Vec::with_capacity(21);
+    let mut upgrade_args: Vec<String> = Vec::with_capacity(18);
 
+    let version_two_dot_one = VersionReq::parse(TWO_DOT_ONE).context(SemverParse {
+        version_string: TWO_DOT_ONE.to_string(),
+    })?;
+    if version_two_dot_one.matches(from_version) {
+        let io_engine_key = "io_engine";
+        let log_level_key = "logLevel";
+        let log_level_to_replace = "info,io_engine=info";
+        let thin_key = "agents.core.capacity.thin";
+        let thin_volume_commitment_key = "volumeCommitment";
+        let thin_pool_commitment_key = "poolCommitment";
+        let thin_volume_commitment_init_key = "volumeCommitmentInitial";
+
+        if from_values.io_engine_log_level().eq(log_level_to_replace)
+            && to_values.io_engine_log_level().ne(log_level_to_replace)
+        {
+            upgrade_args.push("--set".to_string());
+
+            let io_engine_log_level_arg: String = format!(
+                "{io_engine_key}.{log_level_key}={}",
+                to_values.io_engine_log_level()
+            );
+
+            // helm upgrade .. --set image.tag=<version> --set image.repoTags.controlPlane=
+            // --set image.repoTags.dataPlane= --set image.repoTags.extensions= --set
+            // io-engine.loglevel=info
+            upgrade_args.push(io_engine_log_level_arg);
+        }
+
+        // Empty values for these three for charts which do not have
+        // them on their values will result in a helm nil pointer error.
+        if from_values.core_capacity_is_absent() {
+            upgrade_args.push("--set".to_string());
+            let core_thin_pool_commitment_val = to_values.core_thin_pool_commitment()?;
+            let core_thin_pool_commitment_arg =
+                format!("{thin_key}.{thin_pool_commitment_key}={core_thin_pool_commitment_val}");
+            // helm upgrade .. --set agents.core.capacity.thin.poolCommitment=<value>
+            upgrade_args.push(core_thin_pool_commitment_arg);
+
+            upgrade_args.push("--set".to_string());
+            let core_thin_vol_commitment_val = to_values.core_thin_volume_commitment()?;
+            let core_thin_vol_commitment_arg =
+                format!("{thin_key}.{thin_volume_commitment_key}={core_thin_vol_commitment_val}");
+            // helm upgrade .. --set agents.core.capacity.thin.volumeCommitment=<value>
+            upgrade_args.push(core_thin_vol_commitment_arg);
+
+            upgrade_args.push("--set".to_string());
+            let core_thin_vol_commitment_initial_val =
+                to_values.core_thin_volume_commitment_initial()?;
+            let core_thin_vol_commitment_initial_arg = format!(
+                "{thin_key}.{thin_volume_commitment_init_key}={core_thin_vol_commitment_initial_val}"
+            );
+            // helm upgrade .. --set agents.core.capacity.thin.volumeCommitmentInitial=<value>
+            upgrade_args.push(core_thin_vol_commitment_initial_arg);
+        }
+    }
+
+    // Default 'set' flags.
     let image_key = "image";
     let tag_key = "tag";
     let repo_tags_key = "repoTags";
     let repo_tags_cp_key = "controlPlane";
     let repo_tags_dp_key = "dataPlane";
     let repo_tags_e_key = "extensions";
-    let io_engine_key = "io_engine";
-    let log_level_key = "logLevel";
-    let log_level_to_replace = "info,io_engine=info";
-    let thin_key = "agents.core.capacity.thin";
-    let thin_volume_commitment_key = "volumeCommitment";
-    let thin_pool_commitment_key = "poolCommitment";
-    let thin_volume_commitment_init_key = "volumeCommitmentInitial";
-    let priority_class_name_key = "priorityClassName";
-    match chart_variant {
-        HelmChart::Umbrella => {
-            upgrade_args.push("--set".to_string());
-            let to_values: UmbrellaValues =
-                serde_yaml::from_reader(to_values_yaml).context(YamlParseFromFile {
-                    filepath: values_yaml_path,
-                })?;
-            let image_tag_arg = format!(
-                "{CORE_CHART_NAME}.{image_key}.{tag_key}={}",
-                to_values.image_tag()
-            );
-            // helm upgrade .. --set <core-chart>.image.tag=<version>
-            upgrade_args.push(image_tag_arg);
 
-            // RepoTags fields will be set to empty strings. This is required because we are trying
-            // to get to crate::common::constants::TO_UMBRELLA_SEMVER completely, without setting
-            // versions for repo-specific components.
-            // Also, the default template function uses the CORE_CHART_NAME.image.repoTags.* values,
-            // and leaving them empty will result in a nil pointer error in helm.
-            upgrade_args.push("--set".to_string());
-            let repo_tag_ctrl_plane_arg: String =
-                format!("{CORE_CHART_NAME}.{image_key}.{repo_tags_key}.{repo_tags_cp_key}=");
-            // helm upgrade .. --set <core-chart>.image.tag=<version> --set
-            // <core-chart>.image.repoTags.controlPlane=
-            upgrade_args.push(repo_tag_ctrl_plane_arg);
-            upgrade_args.push("--set".to_string());
-            let repo_tag_data_plane_arg: String =
-                format!("{CORE_CHART_NAME}.{image_key}.{repo_tags_key}.{repo_tags_dp_key}=");
-            // helm upgrade .. --set <core-chart>.image.tag=<version> --set
-            // <core-chart>.image.repoTags.controlPlane= --set
-            // <core-chart>.image.repoTags.dataPlane=
-            upgrade_args.push(repo_tag_data_plane_arg);
-            upgrade_args.push("--set".to_string());
-            let repo_tag_e_arg: String =
-                format!("{CORE_CHART_NAME}.{image_key}.{repo_tags_key}.{repo_tags_e_key}=");
-            // helm upgrade .. --set <core-chart>.image.tag=<version> --set
-            // <core-chart>.image.repoTags.controlPlane= --set
-            // <core-chart>.image.repoTags.dataPlane= --set <core-chart>.image.repoTags.extensions=
-            upgrade_args.push(repo_tag_e_arg);
+    upgrade_args.push("--set".to_string());
 
-            let from_values: UmbrellaValues = serde_yaml::from_slice(from_values_yaml.as_slice())
-                .context(YamlParseFromSlice {
-                input_yaml: from_values_yaml_string,
-            })?;
-            if from_values.io_engine_log_level().eq(log_level_to_replace)
-                && to_values.io_engine_log_level().ne(log_level_to_replace)
-            {
-                upgrade_args.push("--set".to_string());
-                let io_engine_log_level_arg: String = format!(
-                    "{CORE_CHART_NAME}.{io_engine_key}.{log_level_key}={}",
-                    to_values.io_engine_log_level()
-                );
-                // helm upgrade .. --set <core-chart>.image.tag=<version> --set
-                // <core-chart>.image.repoTags.controlPlane= --set
-                // <core-chart>.image.repoTags.dataPlane= --set
-                // <core-chart>.image.repoTags.extensions= --set <core-chart>.
-                // io-engine.loglevel=info
-                upgrade_args.push(io_engine_log_level_arg);
-            }
+    let image_tag_arg = format!("{image_key}.{tag_key}={}", to_values.image_tag());
 
-            // Empty values for these three for charts which do not have
-            // them on their values will result in a helm nil pointer error.
-            if from_values.core_capacity_is_absent() {
-                upgrade_args.push("--set".to_string());
-                let core_thin_pool_commitment_val = to_values.core_thin_pool_commitment()?;
-                let core_thin_pool_commitment_arg = format!(
-                    "{CORE_CHART_NAME}.{thin_key}.{thin_pool_commitment_key}={core_thin_pool_commitment_val}"
-                );
-                // helm upgrade .. --set
-                // <core-chart>.agents.core.capacity.thin.poolCommitment=<value>
-                upgrade_args.push(core_thin_pool_commitment_arg);
+    // helm upgrade .. --set image.tag=<version>
+    upgrade_args.push(image_tag_arg);
 
-                upgrade_args.push("--set".to_string());
-                let core_thin_vol_commitment_val = to_values.core_thin_volume_commitment()?;
-                let core_thin_vol_commitment_arg = format!(
-                    "{CORE_CHART_NAME}.{thin_key}.{thin_volume_commitment_key}={core_thin_vol_commitment_val}"
-                );
-                // helm upgrade .. --set
-                // <core-chart>.agents.core.capacity.thin.volumeCommitment=<value>
-                upgrade_args.push(core_thin_vol_commitment_arg);
+    // RepoTags fields will be set to empty strings. This is required because we are trying
+    // to get to crate::common::constants::TO_CORE_SEMVER completely, without setting
+    // versions for repo-specific components.
+    // Also, the default template function uses the image.repoTags.* values, and leaving
+    // them empty will result in a nil pointer error in helm.
+    upgrade_args.push("--set".to_string());
+    let repo_tag_ctrl_plane_arg: String =
+        format!("{image_key}.{repo_tags_key}.{repo_tags_cp_key}=");
+    // helm upgrade .. --set <core-chart>.image.tag=<version> --set
+    // <core-chart>.image.repoTags.controlPlane=
+    upgrade_args.push(repo_tag_ctrl_plane_arg);
+    upgrade_args.push("--set".to_string());
+    let repo_tag_data_plane_arg: String =
+        format!("{image_key}.{repo_tags_key}.{repo_tags_dp_key}=");
+    // helm upgrade .. --set image.tag=<version> --set image.repoTags.controlPlane= --set
+    // image.repoTags.dataPlane=
+    upgrade_args.push(repo_tag_data_plane_arg);
+    upgrade_args.push("--set".to_string());
+    let repo_tag_e_arg: String = format!("{image_key}.{repo_tags_key}.{repo_tags_e_key}=");
+    // helm upgrade .. --set image.tag=<version> --set image.repoTags.controlPlane= --set
+    // image.repoTags.dataPlane= --set image.repoTags.extensions=
+    upgrade_args.push(repo_tag_e_arg);
 
-                upgrade_args.push("--set".to_string());
-                let core_thin_vol_commitment_initial_val =
-                    to_values.core_thin_volume_commitment_initial()?;
-                let core_thin_vol_commitment_initial_arg = format!(
-                    "{CORE_CHART_NAME}.{thin_key}.{thin_volume_commitment_init_key}={core_thin_vol_commitment_initial_val}"
-                );
-                // helm upgrade .. --set
-                // <core-chart>.agents.core.capacity.thin.volumeCommitmentInitial=<value>
-                upgrade_args.push(core_thin_vol_commitment_initial_arg);
-            }
-
-            if from_values.priority_class_name_is_absent() {
-                upgrade_args.push("--set".to_string());
-                let priority_class_name_val = to_values.priority_class_name()?;
-                let priority_class_name_arg = format!(
-                    "{CORE_CHART_NAME}.{priority_class_name_key}={priority_class_name_val}"
-                );
-
-                // helm upgrade .. --set <core-chart>.priorityClassName=<priority-class-name>
-                upgrade_args.push(priority_class_name_arg);
-            }
-
-            // helm upgrade .. --set release.version=<umbrella-chart-semver>
-            upgrade_args.push("--set".to_string());
-            let umbrella_release_arg: String = format!("release.version={TO_UMBRELLA_SEMVER}");
-            upgrade_args.push(umbrella_release_arg);
-        }
-        HelmChart::Core => {
-            upgrade_args.push("--set".to_string());
-
-            let to_values: CoreValues =
-                serde_yaml::from_reader(to_values_yaml).context(YamlParseFromFile {
-                    filepath: values_yaml_path,
-                })?;
-            let image_tag_arg = format!("{image_key}.{tag_key}={}", to_values.image_tag());
-
-            // helm upgrade .. --set image.tag=<version>
-            upgrade_args.push(image_tag_arg);
-
-            // RepoTags fields will be set to empty strings. This is required because we are trying
-            // to get to crate::common::constants::TO_CORE_SEMVER completely, without setting
-            // versions for repo-specific components.
-            // Also, the default template function uses the image.repoTags.* values, and leaving
-            // them empty will result in a nil pointer error in helm.
-            upgrade_args.push("--set".to_string());
-            let repo_tag_ctrl_plane_arg: String =
-                format!("{image_key}.{repo_tags_key}.{repo_tags_cp_key}=");
-            // helm upgrade .. --set <core-chart>.image.tag=<version> --set
-            // <core-chart>.image.repoTags.controlPlane=
-            upgrade_args.push(repo_tag_ctrl_plane_arg);
-            upgrade_args.push("--set".to_string());
-            let repo_tag_data_plane_arg: String =
-                format!("{image_key}.{repo_tags_key}.{repo_tags_dp_key}=");
-            // helm upgrade .. --set image.tag=<version> --set image.repoTags.controlPlane= --set
-            // image.repoTags.dataPlane=
-            upgrade_args.push(repo_tag_data_plane_arg);
-            upgrade_args.push("--set".to_string());
-            let repo_tag_e_arg: String = format!("{image_key}.{repo_tags_key}.{repo_tags_e_key}=");
-            // helm upgrade .. --set image.tag=<version> --set image.repoTags.controlPlane= --set
-            // image.repoTags.dataPlane= --set image.repoTags.extensions=
-            upgrade_args.push(repo_tag_e_arg);
-
-            let from_values: CoreValues = serde_yaml::from_slice(from_values_yaml.as_slice())
-                .context(YamlParseFromSlice {
-                    input_yaml: from_values_yaml_string,
-                })?;
-            if from_values.io_engine_log_level().eq(log_level_to_replace)
-                && to_values.io_engine_log_level().ne(log_level_to_replace)
-            {
-                upgrade_args.push("--set".to_string());
-
-                let io_engine_log_level_arg: String = format!(
-                    "{io_engine_key}.{log_level_key}={}",
-                    to_values.io_engine_log_level()
-                );
-
-                // helm upgrade .. --set image.tag=<version> --set image.repoTags.controlPlane=
-                // --set image.repoTags.dataPlane= --set image.repoTags.extensions= --set
-                // io-engine.loglevel=info
-                upgrade_args.push(io_engine_log_level_arg);
-            }
-
-            // Empty values for these three for charts which do not have
-            // them on their values will result in a helm nil pointer error.
-            if from_values.core_capacity_is_absent() {
-                upgrade_args.push("--set".to_string());
-                let core_thin_pool_commitment_val = to_values.core_thin_pool_commitment()?;
-                let core_thin_pool_commitment_arg = format!(
-                    "{thin_key}.{thin_pool_commitment_key}={core_thin_pool_commitment_val}"
-                );
-                // helm upgrade .. --set agents.core.capacity.thin.poolCommitment=<value>
-                upgrade_args.push(core_thin_pool_commitment_arg);
-
-                upgrade_args.push("--set".to_string());
-                let core_thin_vol_commitment_val = to_values.core_thin_volume_commitment()?;
-                let core_thin_vol_commitment_arg = format!(
-                    "{thin_key}.{thin_volume_commitment_key}={core_thin_vol_commitment_val}"
-                );
-                // helm upgrade .. --set agents.core.capacity.thin.volumeCommitment=<value>
-                upgrade_args.push(core_thin_vol_commitment_arg);
-
-                upgrade_args.push("--set".to_string());
-                let core_thin_vol_commitment_initial_val =
-                    to_values.core_thin_volume_commitment_initial()?;
-                let core_thin_vol_commitment_initial_arg = format!(
-                    "{thin_key}.{thin_volume_commitment_init_key}={core_thin_vol_commitment_initial_val}"
-                );
-                // helm upgrade .. --set agents.core.capacity.thin.volumeCommitmentInitial=<value>
-                upgrade_args.push(core_thin_vol_commitment_initial_arg);
-            }
-
-            if from_values.priority_class_name_is_absent() {
-                upgrade_args.push("--set".to_string());
-                let priority_class_name_val = to_values.priority_class_name()?;
-                let priority_class_name_arg =
-                    format!("{priority_class_name_key}={priority_class_name_val}");
-
-                // helm upgrade .. --set priorityClassName=<priority-class-name>
-                upgrade_args.push(priority_class_name_arg);
-            }
-        }
-    }
+    // Mandatory flags.
 
     // helm upgrade .. --reuse-values
     upgrade_args.push("--reuse-values".to_string());
+
+    // To roll back to previous release, in case helm upgrade fails, also
+    // to wait for all Pods, PVCs to come to a ready state.
+    upgrade_args.push("--atomic".to_string());
 
     Ok(upgrade_args)
 }

--- a/k8s/upgrade-job/src/main.rs
+++ b/k8s/upgrade-job/src/main.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{constants::PRODUCT, error::Result},
     opts::validators::{
-        validate_helm_chart_dirs, validate_helm_release, validate_helmv3_in_path,
+        validate_helm_chart_dir, validate_helm_release, validate_helmv3_in_path,
         validate_namespace, validate_rest_endpoint,
     },
 };
@@ -54,7 +54,7 @@ pub(crate) async fn parse_cli_args() -> Result<CliArgs> {
 
     validate_helmv3_in_path()?;
     validate_helm_release(opts.release_name(), opts.namespace())?;
-    validate_helm_chart_dirs(opts.umbrella_chart_dir(), opts.core_chart_dir())?;
+    validate_helm_chart_dir(opts.core_chart_dir())?;
 
     info!("Validated all inputs");
 

--- a/k8s/upgrade-job/src/opts.rs
+++ b/k8s/upgrade-job/src/opts.rs
@@ -23,23 +23,9 @@ pub(crate) struct CliArgs {
     #[arg(long)]
     release_name: String,
 
-    /// This is the Helm chart directory filepath for the umbrella helm chart variant.
-    #[arg(
-        long,
-        env = "UMBRELLA_CHART_DIR",
-        value_name = "DIR PATH",
-        required_unless_present = "core_chart_dir"
-    )]
-    umbrella_chart_dir: Option<PathBuf>,
-
     /// This is the Helm chart directory filepath for the core Helm chart variant.
-    #[arg(
-        long,
-        env = "CORE_CHART_DIR",
-        value_name = "DIR PATH",
-        required_unless_present = "umbrella_chart_dir"
-    )]
-    core_chart_dir: Option<PathBuf>,
+    #[arg(long, env = "CORE_CHART_DIR", value_name = "DIR PATH")]
+    core_chart_dir: PathBuf,
 
     /// This is the path to upgrade exception file.
     #[arg(
@@ -78,14 +64,8 @@ impl CliArgs {
         self.release_name.clone()
     }
 
-    /// This returns the Helm chart directory filepath for a
-    /// crate::helm::upgrade::HelmChart::Umbrella.
-    pub(crate) fn umbrella_chart_dir(&self) -> Option<PathBuf> {
-        self.umbrella_chart_dir.clone()
-    }
-
     /// This returns the Helm chart directory filepath for a crate::helm::upgrade::HelmChart::Core.
-    pub(crate) fn core_chart_dir(&self) -> Option<PathBuf> {
+    pub(crate) fn core_chart_dir(&self) -> PathBuf {
         self.core_chart_dir.clone()
     }
 

--- a/k8s/upgrade-job/src/upgrade.rs
+++ b/k8s/upgrade-job/src/upgrade.rs
@@ -20,11 +20,11 @@ pub(crate) async fn upgrade(opts: &CliArgs) -> Result<()> {
     let helm_upgrade = HelmUpgrade::builder()
         .with_namespace(opts.namespace())
         .with_release_name(opts.release_name())
-        .with_umbrella_chart_dir(opts.umbrella_chart_dir())
         .with_core_chart_dir(opts.core_chart_dir())
         .with_upgrade_path_file(opts.upgrade_exception_file())
         .with_skip_upgrade_path_validation(opts.skip_upgrade_path_validation())
-        .build()?;
+        .build()
+        .await?;
 
     let from_version = helm_upgrade.upgrade_from_version();
     let to_version = helm_upgrade.upgrade_to_version();


### PR DESCRIPTION
- remove support for upgrade for the openebs/openebs helm chart:
Previously the upgrade-job was outfitted with the tools to upgrade the
openebs/openebs helm chart. However, the upgrade assumed that the helm
chart only made use of mayastor and no other storage engine. This is a
convenient feature, until one of the other openebs/openebs subcharts
is upgraded. Then this openebs/openebs upgrade via this upgrade-job is
insufficient, as it only concerns itself with the changes of the mayastor
subchart. As an alternative, the upgrade documentation at openebs.io/docs
will furnish the instructions to enable a user to carry out the mayastor
upgrade alongside any other upgrade that the particular openebs/openebs
might require. The user is to upgrade the openebs/openebs helm chart, and
iff he has done so, this upgrade-job proceeds to carry out the 'data plane
upgrade', thus reaching an upgraded state for mayastor.
- add helm chart value 'set' flags for v2.1.0 and v2.2.0
- refactor upgrade to get the source helm chart version from the
REST API deployment label 'openebs.io/version' instead of the 'helm ls'
output
- remove the HashSet from the upgrade::path::UnsupportedVersions
and use the 'contains()' from the Vec instead.
- remove priorityClassName 'set' flags, as users with working global
priorityClassName should be able to just continue using it, instead of
being moved from the older default to the latest default"