### PR TITLE
feat(upgrade): read unsupported versions yaml file at compile time

### DIFF
--- a/k8s/plugin/src/main.rs
+++ b/k8s/plugin/src/main.rs
@@ -161,6 +161,7 @@ async fn execute(cli_args: CliArgs) {
                 )
                 .await
                 .map_err(|error| {
+                    eprintln!("{error}");
                     std::process::exit(error.into());
                 });
 

--- a/k8s/upgrade-job/src/common/error.rs
+++ b/k8s/upgrade-job/src/common/error.rs
@@ -136,6 +136,10 @@ pub(crate) enum Error {
         filepath: PathBuf,
     },
 
+    /// Error for when yaml could not be parsed from bytes.
+    #[snafu(display("Failed to parse unsupported versions yaml: {}", source))]
+    YamlParseBufferForUnsupportedVersion { source: serde_yaml::Error },
+
     /// Error for when the Helm chart installed in the cluster is not of the umbrella or core
     /// variant.
     #[snafu(display(

--- a/k8s/upgrade-job/src/helm/upgrade.rs
+++ b/k8s/upgrade-job/src/helm/upgrade.rs
@@ -32,7 +32,6 @@ pub(crate) struct HelmUpgradeBuilder {
     release_name: Option<String>,
     namespace: Option<String>,
     core_chart_dir: Option<PathBuf>,
-    upgrade_path_file: PathBuf,
     skip_upgrade_path_validation: bool,
 }
 
@@ -61,13 +60,6 @@ impl HelmUpgradeBuilder {
     #[must_use]
     pub(crate) fn with_core_chart_dir(mut self, dir: PathBuf) -> Self {
         self.core_chart_dir = Some(dir);
-        self
-    }
-
-    /// This is a builder option to set the path for the unsupported version yaml.
-    #[must_use]
-    pub(crate) fn with_upgrade_path_file(mut self, file: PathBuf) -> Self {
-        self.upgrade_path_file = file;
         self
     }
 
@@ -150,8 +142,7 @@ impl HelmUpgradeBuilder {
                 // Check for already upgraded
                 already_upgraded = to_version.eq(&from_version);
 
-                let upgrade_path_is_valid =
-                    upgrade::path::is_valid_for_core_chart(&from_version, self.upgrade_path_file)?;
+                let upgrade_path_is_valid = upgrade::path::is_valid_for_core_chart(&from_version)?;
                 ensure!(
                     upgrade_path_is_valid || already_upgraded,
                     InvalidUpgradePath

--- a/k8s/upgrade-job/src/opts.rs
+++ b/k8s/upgrade-job/src/opts.rs
@@ -27,14 +27,6 @@ pub(crate) struct CliArgs {
     #[arg(long, env = "CORE_CHART_DIR", value_name = "DIR PATH")]
     core_chart_dir: PathBuf,
 
-    /// This is the path to upgrade exception file.
-    #[arg(
-        long,
-        env = "UPGRADE_EXCEPTION_FILE_PATH",
-        default_value = "/k8s/upgrade/config/unsupported_versions.yaml"
-    )]
-    upgrade_exception_file: PathBuf,
-
     /// If not set, this skips the Kubernetes Pod restarts for the io-engine DaemonSet.
     #[arg(long, default_value_t = false)]
     skip_data_plane_restart: bool,
@@ -67,11 +59,6 @@ impl CliArgs {
     /// This returns the Helm chart directory filepath for a crate::helm::upgrade::HelmChart::Core.
     pub(crate) fn core_chart_dir(&self) -> PathBuf {
         self.core_chart_dir.clone()
-    }
-
-    /// This returns the path to find unsupported upgrade version yaml file.
-    pub(crate) fn upgrade_exception_file(&self) -> PathBuf {
-        self.upgrade_exception_file.clone()
     }
 
     /// This is a predicate to decide if <release-name>-io-engine Kubernetes DaemonSet Pods should

--- a/k8s/upgrade-job/src/upgrade.rs
+++ b/k8s/upgrade-job/src/upgrade.rs
@@ -21,7 +21,6 @@ pub(crate) async fn upgrade(opts: &CliArgs) -> Result<()> {
         .with_namespace(opts.namespace())
         .with_release_name(opts.release_name())
         .with_core_chart_dir(opts.core_chart_dir())
-        .with_upgrade_path_file(opts.upgrade_exception_file())
         .with_skip_upgrade_path_validation(opts.skip_upgrade_path_validation())
         .build()
         .await?;

--- a/k8s/upgrade/src/constant.rs
+++ b/k8s/upgrade/src/constant.rs
@@ -100,5 +100,5 @@ pub(crate) const API_REST_POD_LABEL: &str = "app=api-rest";
 pub(crate) const UPGRADE_EVENT_REASON: &str = "MayastorUpgrade";
 /// Installed release version.
 pub(crate) const HELM_RELEASE_VERSION_LABEL: &str = "openebs.io/version";
-/// File contating unsupported versions.
-pub(crate) const UNSUPPORTED_VERSION_FILE: &str = "k8s/upgrade/config/unsupported_versions.yaml";
+/// Upgrade to develop.
+pub(crate) const UPGRADE_TO_DEVELOP_BRANCH: &str = "develop";

--- a/k8s/upgrade/src/error.rs
+++ b/k8s/upgrade/src/error.rs
@@ -205,15 +205,16 @@ pub enum Error {
         filepath: PathBuf,
     },
 
+    /// Error for when yaml could not be parsed from bytes.
+    #[snafu(display("Failed to parse unsupported versions yaml: {}", source))]
+    YamlParseBufferForUnsupportedVersion { source: serde_yaml::Error },
+
     /// Error for failures in generating semver::Value from a &str input.
     #[snafu(display("Failed to parse {} as a valid semver: {}", version_string, source))]
     SemverParse {
         source: semver::Error,
         version_string: String,
     },
-
-    #[snafu(display("Failed to get current directory: {}", source))]
-    GetCurrentDirectory { source: std::io::Error },
 
     /// Source and target version are same.
     #[snafu(display("Source and target version are same for upgrade."))]
@@ -234,8 +235,8 @@ pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 impl From<Error> for i32 {
     fn from(err: Error) -> Self {
         match err {
-            Error::GetCurrentDirectory { .. } => 401,
-            Error::UpgradeEventNotPresent { .. } => 401,
+            Error::YamlParseBufferForUnsupportedVersion { .. } => 401,
+            Error::UpgradeEventNotPresent { .. } => 402,
             Error::NoDeploymentPresent { .. } => 403,
             Error::MessageInEventNotPresent { .. } => 404,
             Error::NodesInCordonedState { .. } => 405,

--- a/k8s/upgrade/src/user_prompt.rs
+++ b/k8s/upgrade/src/user_prompt.rs
@@ -45,4 +45,4 @@ pub const UPGRADE_PATH_NOT_VALID: &str =
 
 /// Upgrade to unsuppoted version not valid.
 pub const UPGRADE_TO_UNSUPPORTED_VERSION: &str =
-    "\nUpgrade failed as destination version is unsupported. Please try with `--skip-upgrade-path-validation-for-unsupported-version";
+    "\nUpgrade failed as destination version is unsupported. Please try with `--skip-upgrade-path-validation-for-unsupported-version`";

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -6,7 +6,6 @@
 let
   whitelistSource = extensions.project-builder.whitelistSource;
   helm_chart = whitelistSource ../../.. [ "chart" "scripts/helm" ];
-  upgrade_path = whitelistSource ../../.. [ "k8s/upgrade/config" ];
   image_suffix = { "release" = ""; "debug" = "-debug"; "coverage" = "-coverage"; };
   tag = if img_tag != "" then img_tag else extensions.version;
   build-extensions-image = { pname, buildType, package, extraCommands ? '''', contents ? [ ], config ? { } }:
@@ -50,7 +49,7 @@ let
     chmod -w build/chart
     chmod -w build/chart/*.yaml
 
-    mkdir -p $out && cp -drf --preserve=mode build/chart $out/chart && cp -drf --preserve=mode ${upgrade_path}/* $out/k8s
+    mkdir -p $out && cp -drf --preserve=mode build/chart $out/chart
   '';
   build-upgrade-image = { buildType, name }:
     build-extensions-image rec{
@@ -59,7 +58,7 @@ let
       contents = [ kubernetes-helm-wrapped busybox tagged_helm_chart ];
       pname = package.pname;
       config = {
-        Env = [ "CORE_CHART_DIR=/chart" "UPGRADE_EXCEPTION_FILE_PATH=/k8s/upgrade/config/unsupported_versions.yaml" ];
+        Env = [ "CORE_CHART_DIR=/chart" ];
     };
   };
   build-obs-callhome-image = { buildType }:


### PR DESCRIPTION
The `unsupported_versions.yaml` file was read using the std::current_dir(). This lead to the problem where in the file was not present in nix-build environment. 
This PR modifies the code to read the file at compile time only . 