### PR TITLE
fix(upgrade-job): refactor version check

### DIFF
--- a/k8s/upgrade-job/src/common/error.rs
+++ b/k8s/upgrade-job/src/common/error.rs
@@ -499,6 +499,17 @@ pub(crate) enum Error {
     /// Error for when the helm upgrade run is that of an invalid chart configuration.
     #[snafu(display("Invalid helm upgrade request"))]
     InvalidHelmUpgrade,
+
+    /// Error for when the helm upgrade run is that of an invalid chart configuration.
+    #[snafu(display(
+        "Failed to upgrade from {} to {}: upgrade to an earlier-released version is forbidden",
+        from_version,
+        to_version
+    ))]
+    RollbackForbidden {
+        from_version: String,
+        to_version: String,
+    },
 }
 
 /// A wrapper type to remove repeated Result<T, Error> returns.

--- a/k8s/upgrade-job/src/upgrade/path.rs
+++ b/k8s/upgrade-job/src/upgrade/path.rs
@@ -19,7 +19,7 @@ use utils::API_REST_LABEL;
 /// Validates the upgrade path from 'from' Version to 'to' Version for the Core helm chart.
 pub(crate) fn is_valid_for_core_chart(from: &Version) -> Result<bool> {
     let unsupported_version_buf =
-        &std::include_bytes!("../../../upgrade/config/unsupported_versions.yaml")[..];
+        &include_bytes!("../../../upgrade/config/unsupported_versions.yaml")[..];
     let unsupported_versions = UnsupportedVersions::try_from(unsupported_version_buf)
         .context(YamlParseBufferForUnsupportedVersion)?;
     Ok(!unsupported_versions.contains(from))


### PR DESCRIPTION
- add failure case for when the source version is newer than the target version
- remove redundant check for 'already_upgraded' case: currently the invalid versions are explicitly listed in an input YAML file, thus there need not be an additional exclusion case here, as we do not list the current version in the invalid-versions-file