### PR TITLE
fix(upgrade-job): upgrade path validation and set flags

### DIFF
--- a/k8s/upgrade-job/src/common/constants.rs
+++ b/k8s/upgrade-job/src/common/constants.rs
@@ -27,5 +27,5 @@ pub(crate) const TO_UMBRELLA_SEMVER: &str = "3.7.0";
 pub(crate) const UMBRELLA_CHART_UPGRADE_DOCS_URL: &str =
     "https://openebs.io/docs/user-guides/upgrade#mayastor-upgrade";
 
-/// This defines the range of helm chart versions for the 2.1 release of the Core helm chart.
-pub(crate) const TWO_DOT_ONE: &str = ">=2.1.0-rc.0, <=2.1.0";
+/// This defines the range of helm chart versions for the 2.0 release of the Core helm chart.
+pub(crate) const TWO_DOT_O: &str = ">=2.0.0-rc.0, <=2.0.1";

--- a/k8s/upgrade-job/src/common/constants.rs
+++ b/k8s/upgrade-job/src/common/constants.rs
@@ -28,4 +28,4 @@ pub(crate) const UMBRELLA_CHART_UPGRADE_DOCS_URL: &str =
     "https://openebs.io/docs/user-guides/upgrade#mayastor-upgrade";
 
 /// This defines the range of helm chart versions for the 2.0 release of the Core helm chart.
-pub(crate) const TWO_DOT_O: &str = ">=2.0.0-rc.0, <=2.0.1";
+pub(crate) const TWO_DOT_O: &str = ">=2.0.0-rc.0, <2.1.0";

--- a/k8s/upgrade-job/src/helm/upgrade.rs
+++ b/k8s/upgrade-job/src/helm/upgrade.rs
@@ -105,15 +105,6 @@ impl HelmUpgradeBuilder {
         let chart_yaml_path = chart_dir.join("Chart.yaml");
         let to_version: Version = upgrade::path::version_from_chart_yaml_file(chart_yaml_path)?;
 
-        // Basic validation.
-        // Rollbacks not supported.
-        ensure!(
-            to_version.ge(&from_version),
-            RollbackForbidden {
-                from_version: from_version.to_string(),
-                to_version: to_version.to_string()
-            }
-        );
         // Check if already upgraded.
         let already_upgraded = to_version.eq(&from_version);
 
@@ -148,6 +139,15 @@ impl HelmUpgradeBuilder {
             // Skip upgrade-path validation and allow all upgrades for the Core helm chart, if the
             // flag is set.
             if !self.skip_upgrade_path_validation {
+                // Rollbacks not supported.
+                ensure!(
+                    to_version.ge(&from_version),
+                    RollbackForbidden {
+                        from_version: from_version.to_string(),
+                        to_version: to_version.to_string()
+                    }
+                );
+
                 let upgrade_path_is_valid = upgrade::path::is_valid_for_core_chart(&from_version)?;
                 ensure!(upgrade_path_is_valid, InvalidUpgradePath);
             }

--- a/k8s/upgrade-job/src/helm/values.rs
+++ b/k8s/upgrade-job/src/helm/values.rs
@@ -41,6 +41,20 @@ pub(crate) fn generate_values_args(
     // use from installed-release's values, if present, else use defaults from to-chart.
     let mut upgrade_args: Vec<String> = Vec::with_capacity(18);
 
+    // For the rest of the this function's body, the flags which must be included to achieve
+    // a successful helm upgrade will be added to the 'upgrade_args' vector.
+    // There are two types of flags -- 1. Default flags, 2. Version-specific flags.
+    // Default flags set helm values options which must be included with all of the upgrade
+    // source versions.
+    // The version-specific flags set options which are required only in case the version of
+    // the source helm chart matches some ranges, e.g. the 2.0.x helm charts, including the
+    // pre-release versions.
+
+    // Version-specific set flags for 2.0.x source helm versions.
+    // For instance, These did not have the thin-provisioning options when they
+    // were released, and require explicit helm `--set` flags (when using the
+    // `--reuse-values`) to successfully generate the helm templates (the
+    // 'default' template function cannot work with a nil value).
     let version_two_dot_o = VersionReq::parse(TWO_DOT_O).context(SemverParse {
         version_string: TWO_DOT_O.to_string(),
     })?;

--- a/k8s/upgrade-job/src/helm/values.rs
+++ b/k8s/upgrade-job/src/helm/values.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::{
-        constants::TWO_DOT_ONE,
+        constants::TWO_DOT_O,
         error::{
             OpeningFile, Result, SemverParse, U8VectorToString, YamlParseFromFile,
             YamlParseFromSlice,
@@ -41,10 +41,10 @@ pub(crate) fn generate_values_args(
     // use from installed-release's values, if present, else use defaults from to-chart.
     let mut upgrade_args: Vec<String> = Vec::with_capacity(18);
 
-    let version_two_dot_one = VersionReq::parse(TWO_DOT_ONE).context(SemverParse {
-        version_string: TWO_DOT_ONE.to_string(),
+    let version_two_dot_o = VersionReq::parse(TWO_DOT_O).context(SemverParse {
+        version_string: TWO_DOT_O.to_string(),
     })?;
-    if version_two_dot_one.matches(from_version) {
+    if version_two_dot_o.matches(from_version) {
         let io_engine_key = "io_engine";
         let log_level_key = "logLevel";
         let log_level_to_replace = "info,io_engine=info";


### PR DESCRIPTION
- use `--set` flags to set thin provisioning flags for 2.0.x releases, instead of 2.1.x release.
- allow 'no-rollback' rule to be overridden by the `--skip-upgrade-path-validation` flag. This is not necessary for the openebs/openebs (Umbrella) chart because this upgrade-job does not support upgrade for the openebs chart, so might as well move that check to be a Core chart exclusive check.
- allow the `--set` flags for 2.0.x release to be used with future 2.0.x releases as well, and not just till 2.0.1.