### PR TITLE
feat(upgrade-job): recognise flexible testing versions for helm charts

### DIFF
--- a/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
@@ -21,7 +21,7 @@ pub(crate) const CHART_VERSION_LABEL_KEY: &str = "openebs.io/version";
 pub(crate) const DRAIN_FOR_UPGRADE: &str = "mayastor-upgrade";
 
 /// This is the allowed upgrade to-version/to-version-range for the Umbrella chart.
-pub(crate) const TO_UMBRELLA_SEMVER: &str = "3.7.0";
+pub(crate) const TO_UMBRELLA_SEMVER: &str = "3.8.0";
 
 /// This is the user docs URL for the Umbrella chart.
 pub(crate) const UMBRELLA_CHART_UPGRADE_DOCS_URL: &str =

--- a/k8s/upgrade/src/bin/upgrade-job/common/error.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/error.rs
@@ -361,7 +361,8 @@ pub(crate) enum Error {
 
     /// Error for when detected helm chart name is not known helm chart.
     #[snafu(display(
-        "'{}' is not a known {} helm chart, only the '{}' and '{}' charts are supported",
+        "'{}' is not a known {} helm chart, only helm charts '{}-<version-tag>' and '{}-<version-tag>' \
+        are supported",
         chart_name,
         PRODUCT,
         CORE_CHART_NAME,

--- a/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
@@ -113,8 +113,25 @@ impl HelmUpgradeBuilder {
         // <chart-name>-<chart-version> string.
         let umbrella_chart_regex = format!(r"^({UMBRELLA_CHART_NAME}-[0-9]+\.[0-9]+\.[0-9]+)$");
         // Accepts pre-release and release, both.
+        // Q: How do I read this regex?
+        // A: This regular expressions is bounded by the '^' and '$' characters, which means
+        //    that the input string has to match all of the expression exactly. It is not enough
+        //    if a substring within the input string matches the regular expression. The pattern
+        //    requires the following conditions to be met:
+        //    1. The string must start with the literal contained in the literal CORE_CHART_NAME.
+        //       e.g.: mayastor-2.2.0 starts with 'mayastor'
+        //    2. A '-' followed by three sets of numbers (each with one or more) separated by '.',
+        //       must sit after the value of CORE_CHART_NAME.
+        //       e.g. mayastor-4.56.789 is a valid chart-name.
+        //    3. A '-' followed by one or many alphanumeric characters may optionally sit after a
+        //       chart-name like 'mayastor-1.2.3'.
+        //       e.g.: mayastor-1.2.3-testing, mayastor-1.2.3-testing-upgrade-23-35-25-05-2023,
+        //       mayastor-2.3.0-rc-3
+        //    4. The optional group of character(s) mentioned in (3) above, may optionally contain
+        //       a '.' followed by a set of numbers.
+        //       e.g.: mayastor-2.3.4-rc.1, mayastor-2.3.4-alpha.2
         let core_chart_regex =
-            format!(r"^({CORE_CHART_NAME}-[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)$");
+            format!(r"^({CORE_CHART_NAME}-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)*)$");
 
         // Validate if already upgraded for Umbrella chart, and prepare for upgrade for Core chart.
         let chart_variant: HelmChart;


### PR DESCRIPTION
E2e tests may use helm chart versions which do not conform to the release/pre-release patterns. While most tests don't require this, as we do not validate the version string pattern for the helm chart in the container, restarts after the helm upgrade stage (control plane upgrade) position the target chart as the source chart, and that goes through validation.

This regex change allows e2e test tags to be pass the validation.