### PR TITLE
fix(callhome) : apply nats when callhome is enabled

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -39,5 +39,5 @@ dependencies:
   - name: nats
     version: 0.19.14
     repository: https://nats-io.github.io/k8s/helm/charts/
-    condition: nats.enabled
+    condition: eventing.enabled
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -155,7 +155,6 @@ $ helm install my-release openebs/mayastor
 | loki-stack.&ZeroWidthSpace;promtail.&ZeroWidthSpace;config.&ZeroWidthSpace;lokiAddress | The Loki address to post logs to | `"http://{{ .Release.Name }}-loki:3100/loki/api/v1/push"` |
 | loki-stack.&ZeroWidthSpace;promtail.&ZeroWidthSpace;enabled | Enables promtail for scraping logs from nodes | `true` |
 | loki-stack.&ZeroWidthSpace;promtail.&ZeroWidthSpace;tolerations | Disallow promtail from running on the master node | `[]` |
-| nats.&ZeroWidthSpace;enabled | Enable nats for transmitting events to subscribers | `true` |
 | nodeSelector | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ Note that if multi-arch images support 'kubernetes.io/arch: amd64' should be removed and set 'nodeSelector' to empty '{}' as default value. | <pre>{<br>"kubernetes.io/arch":"amd64"<br>}</pre> |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;enabled | Enable callhome | `true` |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;logLevel | Log level for callhome | `"info"` |

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -588,10 +588,13 @@ loki-stack:
               - __meta_kubernetes_pod_container_name
               target_label: __path__
 
-# Cloud Native Messaging System
-nats:
-  # -- Enable nats for transmitting events to subscribers
+# Eventing component which enables or disables eventing-related components.
+eventing:
   enabled: true
+
+# Configuration for the nats message-bus. This is an eventing component, and is enabled when
+# 'eventing.enabled' is set to 'true'.
+nats:
   nats:
     image:
       pullPolicy: IfNotPresent


### PR DESCRIPTION
A per the suggestion here `IMHO we should disable it if either callhome or "eventing" is disabled.` 
 I tried to tweak the condition like `condition: obs.callhome.enabled and nats.enabled` , but this doesn't work.

Helm does not support the `and ` in conditions . The max is does is an `OR` condition using comma  like `condition: obs.callhome.enabled, nats.enabled`.  Only the first valid path found in the list is evaluated .

Thus enabling nats only when the call home is enabled.

**Refer**
- [Link 1](https://stackoverflow.com/questions/75649506/how-to-add-multiple-conditions-check-in-global-charts-file-in-helm)
- [Link 2](https://helm.sh/docs/topics/charts/#tags-and-condition-fields-in-dependencies)