### PR TITLE
feat(upgrade): allow upgrade to develop plugin build

### DIFF
--- a/scripts/helm/publish-chart-yaml.sh
+++ b/scripts/helm/publish-chart-yaml.sh
@@ -239,7 +239,7 @@ echo "CHART_VERSION: $CHART_VERSION"
 echo "CHART_APP_VERSION: $CHART_APP_VERSION"
 
 # Allow only for a semver difference of at most patch
-allowed_diff=("" "patch" "prerelease")
+allowed_diff=("" "patch" "prerelease" "major")
 
 diff="$(semver diff "$CHART_VERSION" "$CHART_APP_VERSION")"
 if ! [[ " ${allowed_diff[*]} " =~ " $diff " ]]; then


### PR DESCRIPTION
At present only the semver difference of at most patch is allowed . Refer [here](https://github.com/openebs/mayastor-extensions/blob/d30af753fcd12321d96ea86d34a4c62283d26f9e/scripts/helm/publish-chart-yaml.sh#L242)

This didn't allow to build the plugin with sever tag. Running the below code failed. 
`./scripts/release.sh --image "" --tag 2.3.0-alpha.0-testing --build-bins`  
Error : 
```
patching script interpreter paths in build/scripts/helm/publish-chart-yaml.sh
build/scripts/helm/publish-chart-yaml.sh: interpreter directive changed from "#!/usr/bin/env bash" to "/nix/store/5n8r5fgscx6f5ifmqqpd8gxjf44a0y2l-bash-5.1-p16/bin/bash"
APP_TAG: 2.3.0-alpha.0-testing-2023-05-31-16-50-25
CHART_VERSION: 0.0.0
CHART_APP_VERSION: 0.0.0
Difference(major) between APP_TAG(2.3.0-alpha.0-testing-2023-05-31-16-50-25) CHART_APP_VERSION(0.0.0) not allowed!
builder for '/nix/store/ignl9j54qimfmzp170hjdjnpbhn9clcv-tagged_helm_chart.drv' failed with exit code 1
cannot build derivation '/nix/store/4r90na1w0mpg7kvz2rk546p5800jj91m-docker-layer-mayastor-upgrade-job.drv': 1 dependencies couldn't be build
```

To overcome this i added `major` is the allowed semver difference, but this need discussion and some thought. 
Please suggest.

