### PR TITLE
ci(gha): fix missing tag in kubectl binary

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -28,6 +28,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
+      - run: |
+          # BUG: HEAD tag is fetched as lightweight instead of annotated
+          # https://github.com/actions/checkout/issues/290
+          if [ "${{ github.ref_type }}" == "tag" ]; then
+            git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          fi
       - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos


### PR DESCRIPTION
Add `fetch-depth` to fetch all history for tags.