### PR TITLE
Adjust jenkins workspace path in case "@" in present in path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,8 +90,9 @@ pipeline {
         printenv
         if [[ ${env.WORKSPACE} =~ "@" ]];
         then
-        newpath=$(echo ${env.WORKSPACE} | sed s/"@"/"__"/)
-        mv ${env.WORKSPACE} newpath
+          newpath=$(echo ${env.WORKSPACE} | sed s/"@"/"__"/)
+          mv ${env.WORKSPACE} newpath
+        fi
         printenv
         """
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
         if [[ "${env.WORKSPACE}" =~ "@" ]];
         then
             newpath=\$(echo ${env.WORKSPACE} | sed s/"@"/"__"/)
-            mv "${env.WORKSPACE}" $newpath
+            mv "${env.WORKSPACE}" "${newpath}"
             echo "Inside if"
         else
             echo "Not needed"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ def notifySlackUponStateChange(build) {
       slackSend(
         channel: '#mayastor',
         color: 'normal',
-        message: "In Mayastor-Extensions repo, branch e has been fixed :beers: (<${env.BUILD_URL}|Open>)"
+        message: "In Mayastor-Extensions repo, branch ${env.BRANCH_NAME} has been fixed :beers: (<${env.BUILD_URL}|Open>)"
       )
     } else if (prev == 'SUCCESS') {
       slackSend(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
       steps{
         sh """
         printenv
-        if [[ ${env.WORKSPACE} =~ "@" ]];
+        if [ ${env.WORKSPACE} =~ "@" ];
         then
           newpath=$(echo ${env.WORKSPACE} | sed s/"@"/"__"/)
           mv ${env.WORKSPACE} newpath

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
         if [[ "${env.WORKSPACE}" =~ "@" ]];
         then
             newpath=\$(echo ${env.WORKSPACE} | sed s/"@"/"__"/)
-            mv "${env.WORKSPACE}" newpath
+            mv "${env.WORKSPACE}" $newpath
             echo "Inside if"
         else
             echo "Not needed"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,6 +82,20 @@ pipeline {
         ])
       }
     }
+
+    stage('Rename jenkins workspace path') {
+      agent {label 'nixos-mayastor'}
+      steps{
+        sh """
+        printenv
+        if [[ ${env.WORKSPACE} =~ "@" ]];
+        then
+        newpath=$(echo ${env.WORKSPACE} | sed s/"@"/"__"/)
+        mv ${env.WORKSPACE} newpath
+        printenv
+        """
+      }
+    }
     stage('linter') {
       agent { label 'nixos-mayastor' }
       when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ def notifySlackUponStateChange(build) {
       slackSend(
         channel: '#mayastor',
         color: 'normal',
-        message: "In Mayastor-Extensions repo, branch ${env.BRANCH_NAME} has been fixed :beers: (<${env.BUILD_URL}|Open>)"
+        message: "In Mayastor-Extensions repo, branch e has been fixed :beers: (<${env.BUILD_URL}|Open>)"
       )
     } else if (prev == 'SUCCESS') {
       slackSend(
@@ -88,10 +88,13 @@ pipeline {
       steps{
         sh """
         printenv
-        if [ ${env.WORKSPACE} =~ "@" ];
+        if [[ "${env.WORKSPACE_TMP}" =~ "@" ]];
         then
-          newpath=$(echo ${env.WORKSPACE} | sed s/"@"/"__"/)
-          mv ${env.WORKSPACE} newpath
+            newpath=\$(echo ${env.WORKSPACE} | sed s/"@"/"__"/)
+            mv "${env.WORKSPACE}" newpath
+            echo "Inside if"
+        else
+            echo "Not needed"
         fi
         printenv
         """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
       steps{
         sh """
         printenv
-        if [[ "${env.WORKSPACE_TMP}" =~ "@" ]];
+        if [[ "${env.WORKSPACE}" =~ "@" ]];
         then
             newpath=\$(echo ${env.WORKSPACE} | sed s/"@"/"__"/)
             mv "${env.WORKSPACE}" newpath


### PR DESCRIPTION
This PR , modifies the workspace name in case "@" is present in the jenkins workspace dir.
I am not sure, if this will actually update the WORKSPACE env variable. I am hoping the next time it picks up the workspace it should point to the new one.
I did try to test this a few times, but since I was unable to reproduce the issue, It will have to be tested once this live and then adjusted if needed.
