### PR TITLE
fix(nix): use builtins.path instead of builtins.filterSource

### DIFF
--- a/nix/lib/version.nix
+++ b/nix/lib/version.nix
@@ -1,16 +1,18 @@
 { lib, stdenv, git, tag ? "" }:
 let
-  whitelistSource = src: allowedPrefixes:
-    builtins.filterSource
-      (path: type:
+  whitelistSource = src: allowedPrefixes: dirName:
+    builtins.path {
+      filter = (path: type:
         lib.any
           (allowedPrefix: lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
-          allowedPrefixes)
-      src;
+          allowedPrefixes);
+      path = src;
+      name = dirName;
+    };
 in
 stdenv.mkDerivation {
   name = "git-version";
-  src = whitelistSource ../../. [ ".git" ];
+  src = whitelistSource ../../. [ ".git" ] "mayastor-extensions";
   outputs = [ "out" "long" "tag_or_long" ];
 
   buildCommand = ''

--- a/nix/pkgs/extensions/cargo-project.nix
+++ b/nix/pkgs/extensions/cargo-project.nix
@@ -39,16 +39,18 @@ let
     rustc = stable_channel.rustc;
     cargo = stable_channel.cargo;
   };
-  whitelistSource = src: allowedPrefixes:
-    builtins.filterSource
-      (path: type:
+  whitelistSource = src: allowedPrefixes: dirName:
+    builtins.path {
+      filter = (path: type:
         lib.any
           (allowedPrefix:
             (lib.hasPrefix (toString (src + "/${allowedPrefix}")) path) ||
             (type == "directory" && lib.hasPrefix path (toString (src + "/${allowedPrefix}")))
           )
-          allowedPrefixes)
-      src;
+          allowedPrefixes);
+      path = src;
+      name = dirName;
+    };
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";
   version = gitVersions.version;
@@ -73,7 +75,7 @@ let
     "dependencies/control-plane/k8s/operators"
     "k8s"
   ];
-  src = whitelistSource ../../../. src_list;
+  src = whitelistSource ../../../. src_list "mayastor-extensions";
   buildProps = rec {
     name = "extensions-${version}";
     inherit version src;

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -5,7 +5,7 @@
 { dockerTools, lib, extensions, busybox, gnupg, kubernetes-helm-wrapped, semver-tool, yq-go, runCommand, img_tag ? "" }:
 let
   whitelistSource = extensions.project-builder.whitelistSource;
-  helm_chart = whitelistSource ../../.. [ "chart" "scripts/helm" ];
+  helm_chart = whitelistSource ../../.. [ "chart" "scripts/helm" ] "mayastor-extensions";
   image_suffix = { "release" = ""; "debug" = "-debug"; "coverage" = "-coverage"; };
   tag = if img_tag != "" then img_tag else extensions.version;
   build-extensions-image = { pname, buildType, package, extraCommands ? '''', contents ? [ ], config ? { } }:
@@ -59,8 +59,8 @@ let
       pname = package.pname;
       config = {
         Env = [ "CORE_CHART_DIR=/chart" ];
+      };
     };
-  };
   build-obs-callhome-image = { buildType }:
     build-extensions-image rec{
       inherit buildType;


### PR DESCRIPTION
Jenkins CI uses '@' in its workspace directory name. Nix seems to not like that. builtins.path { name = ... } lets you choose the directory name when copying the source files to the nix store directory.