### PR TITLE
fix(upgrade-job): use '--install' flag with helm upgrade

### DIFF
--- a/k8s/upgrade/src/bin/upgrade-job/helm/client.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/client.rs
@@ -189,6 +189,9 @@ impl HelmReleaseClient {
         C: ToString,
     {
         let command: &str = "helm";
+        // The --install flag is required to install CRDs when new ones are present,
+        // This will not create a fresh install as we check for a helm release in
+        // 'deployed' state before embarking on our upgrade journey.
         let mut args: Vec<String> = vec_to_strings![
             "upgrade",
             release_name,
@@ -196,7 +199,8 @@ impl HelmReleaseClient {
             "-n",
             self.namespace.as_str(),
             "--timeout",
-            "15m"
+            "15m",
+            "--install"
         ];
 
         // Extra args


### PR DESCRIPTION
The upgrade-job issues a helm upgrade command which in itself does not install CRDs. The changes for release v2.3.0 introduces the snapshot CRDs to the mayastor helm chart. Using the --install flag will add it into the upgrade template if it is missing from the cluster