### PR TITLE
chore: add snasphot and rebuild history to bundle, disable resouce level dump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3323,7 +3323,6 @@ dependencies = [
  "once_cell",
  "openapi",
  "platform",
- "prettytable-rs",
  "pstor",
  "schemars",
  "serde",

--- a/k8s/plugin/README.md
+++ b/k8s/plugin/README.md
@@ -274,15 +274,9 @@ kubectl mayastor dump
 Usage: kubectl-mayastor dump [OPTIONS] <COMMAND>
 
 Commands:
-  system   Collects entire system information
-  volumes  Collects information about all volumes and its descendants (replicas/pools/nodes)
-  volume   Collects information about particular volume and its descendants matching to given volume ID
-  pools    Collects information about all pools and its descendants (nodes)
-  pool     Collects information about particular pool and its descendants matching to given pool ID
-  nodes    Collects information about all nodes
-  node     Collects information about particular node matching to given node ID
-  etcd     Collects information from etcd
-  help     Print this message or the help of the given subcommand(s)
+  system  Collects entire system information
+  etcd    Collects information from etcd
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
   -r, --rest <REST>
@@ -300,7 +294,7 @@ Options:
   -d, --output-directory-path <OUTPUT_DIRECTORY_PATH>
           Output directory path to store archive file [default: ./]
   -n, --namespace <NAMESPACE>
-          Kubernetes namespace of mayastor service[default: mayastor]
+          Kubernetes namespace of mayastor service [default: mayastor]
   -o, --output <OUTPUT>
           The Output, viz yaml, json [default: none]
   -j, --jaeger <JAEGER>
@@ -316,58 +310,12 @@ Supportability - collects state & log information of services and dumps it to a 
 
 **Examples**:
 
-1. To collect entire mayastor system information into an archive file
-   ```sh
-   ## Command
-   kubectl mayastor dump system -d <output_directory> -n <mayastor_namespace>
-   ```
-
-    - Example command while running inside Kubernetes cluster nodes / system which
-      has access to cluster node ports
-      ```sh
-      kubectl mayastor dump system -d /mayastor-dump -n mayastor
-      ```
-    - Example command while running outside of Kubernetes cluster nodes where
-      nodes exist in private network (or) node ports are not exposed for outside cluster
-      ```sh
-      kubectl mayastor dump system -d /mayastor-dump -r http://127.0.0.1:30011 -l http://127.0.0.1:3100 -e http://127.0.0.1:2379 -n mayastor
-      ```
-
-2. To collect information about all mayastor volumes into an archive file
-   ```sh
-   ## Command
-   kubectl mayastor dump volumes -d <output_directory> -n <mayastor_namespace>
-   ```
-
-    - Example command while running inside Kubernetes cluster nodes / system which
-      has access to cluster node ports
-      ```sh
-      kubectl mayastor dump volumes -d /mayastor-dump -n mayastor
-      ```
-    - Example command while running outside of Kubernetes cluster nodes where
-      nodes exist in private network (or) node ports are not exposed for outside cluster
-      ```sh
-      kubectl mayastor dump volumes -d /mayastor-dump -r http://127.0.0.1:30011 -l http://127.0.0.1:3100 -e http://127.0.0.1:2379 -n mayastor
-      ```
-
-   **Note**: similarly to dump pools/nodes information then replace `volumes` with an associated resource type(`pools/nodes`).
-
-3. To collect information about particular volume into an archive file
-   ```sh
-   ## Command
-   kubectl mayastor dump volume <volume_name> -d <output_directory> -n <mayastor_namespace>
-   ```
-
-    - Example command while running inside Kubernetes cluster nodes / system which
-      has access to cluster node ports
-      ```sh
-      kubectl mayastor dump volume volume-1 -d /mayastor-dump -n mayastor
-      ```
-    - Example command while running outside of Kubernetes cluster nodes where
-      nodes exist in private network (or) node ports are not exposed for outside cluster
-      ```sh
-      kubectl mayastor dump volume volume-1 -d /mayastor-dump -r http://127.0.0.1:30011 -l http://127.0.0.1:3100 -e http://127.0.0.1:2379 -n mayastor
-      ```
+To collect entire mayastor system information into an archive file
+```sh
+## Command
+kubectl mayastor dump system -d <output_directory> -n <mayastor_namespace>
+```
+ <b>`--disable-log-collection` can be used to disable collection of logs.</b>
 
 </details>
 <details>

--- a/k8s/supportability/Cargo.toml
+++ b/k8s/supportability/Cargo.toml
@@ -24,7 +24,6 @@ clap = { version = "4.1.4", features = ["color", "derive"] }
 anyhow = "1.0.69"
 humantime = "2.1.0"
 async-trait = "0.1.64"
-prettytable-rs = "^0.10"
 serde = "1.0.152"
 serde_json = "1.0.93"
 serde_yaml = "0.9.17"

--- a/k8s/supportability/src/collect/common.rs
+++ b/k8s/supportability/src/collect/common.rs
@@ -1,5 +1,8 @@
-use crate::collect::{error::Error, resources::traits::Topologer, rest_wrapper::RestClient};
+use crate::collect::{error::Error, rest_wrapper::RestClient};
 use chrono::Local;
+
+#[cfg(debug_assertions)]
+use crate::collect::resources::traits::Topologer;
 
 /// DumpConfig helps to create new instance of Dumper
 #[derive(Debug)]
@@ -20,7 +23,8 @@ pub(crate) struct DumpConfig {
     pub(crate) kube_config_path: Option<std::path::PathBuf>,
     /// Specifies the timeout value to interact with other systems
     pub(crate) timeout: humantime::Duration,
-    /// Topologer implements functionality to build topological infotmation of system
+    #[cfg(debug_assertions)]
+    /// Topologer implements functionality to build topological information of system
     pub(crate) topologer: Option<Box<dyn Topologer>>,
     pub(crate) output_format: OutputFormat,
 }

--- a/k8s/supportability/src/collect/k8s_resources/k8s_resource_dump.rs
+++ b/k8s/supportability/src/collect/k8s_resources/k8s_resource_dump.rs
@@ -12,7 +12,15 @@ use k8s_openapi::{
 use k8s_operators::diskpool::crd::DiskPool;
 use kube::Resource;
 use serde::Serialize;
-use std::{collections::HashSet, fs::File, io::Write, iter::FromIterator, path::PathBuf};
+use std::{
+    collections::HashSet,
+    fs::File,
+    io::Write,
+    iter::FromIterator,
+    path::{Path, PathBuf},
+};
+
+const MAYASTOR_CSI_DRIVER: &str = "io.openebs.csi-mayastor";
 
 /// K8s resource dumper client
 #[derive(Clone)]
@@ -109,124 +117,56 @@ impl K8sResourceDumperClient {
         // Create the root dir path
         let mut root_dir = PathBuf::from(root_path);
         root_dir.push("k8s_resources");
-        create_directory_if_not_exist(root_dir.clone())?;
+        create_directory_if_not_exist(root_dir.to_path_buf())?;
 
         // Create the configurations path
-        let mut configurations_path = root_dir.clone();
+        let mut configurations_path = root_dir.to_path_buf();
         configurations_path.push("configurations");
         // Create the configurations directory
         create_directory_if_not_exist(configurations_path.clone())?;
 
         let mut errors = Vec::new();
+
+        // Fetch all events in provided NAMESPACE
+        if let Err(error) = get_k8s_events(&self.k8s_client, &root_dir).await {
+            errors.push(error)
+        }
+
         // Fetch all Daemonsets in provided NAMESPACE
-        log("\t Collecting daemonsets configuration".to_string());
-        match self.k8s_client.get_daemonsets("", "").await {
-            Ok(daemonsets) => {
-                // Create all Daemonsets configurations
-                let _ = create_app_configurations(
-                    daemonsets.into_iter().map(DaemonSet).collect(),
-                    configurations_path.clone(),
-                )
-                .map_err(|e| errors.push(e));
-            }
-            Err(e) => {
-                errors.push(K8sResourceDumperError::K8sResourceError(e));
-            }
+        if let Err(error) = get_k8s_daemonsets(&self.k8s_client, &configurations_path).await {
+            errors.push(error)
         }
 
         // Fetch all Deployments in provided NAMESPACE
-        log("\t Collecting deployments configuration".to_string());
-        match self.k8s_client.get_deployments("", "").await {
-            Ok(deploys) => {
-                // Create all Daemonsets configurations
-                let _ = create_app_configurations(
-                    deploys.into_iter().map(Deployment).collect(),
-                    configurations_path.clone(),
-                )
-                .map_err(|e| errors.push(e));
-            }
-            Err(e) => {
-                errors.push(K8sResourceDumperError::K8sResourceError(e));
-            }
+        if let Err(error) = get_k8s_deployments(&self.k8s_client, &configurations_path).await {
+            errors.push(error)
         }
 
         // Fetch all StatefulSets in provided NAMESPACE
-        log("\t Collecting statefulsets configuration".to_string());
-        match self.k8s_client.get_statefulsets("", "").await {
-            Ok(statefulsets) => {
-                // Create all Daemonsets configurations
-                let _ = create_app_configurations(
-                    statefulsets.into_iter().map(StatefulSet).collect(),
-                    configurations_path.clone(),
-                )
-                .map_err(|e| errors.push(e));
-            }
-            Err(e) => {
-                errors.push(K8sResourceDumperError::K8sResourceError(e));
-            }
-        }
-
-        // Fetch all events in provided NAMESPACE
-        log("\t Collecting Kubernetes events".to_string());
-        match self.k8s_client.get_events("", "").await {
-            Ok(mut events) => {
-                // Sort the events based on event_time
-                events.sort_unstable_by_key(event_time);
-                // NOTE: Unmarshalling object recevied from K8s API-server will not fail
-                let _ = create_file_and_write(
-                    root_dir.clone(),
-                    "k8s_events.json".to_string(),
-                    serde_json::to_string_pretty(&events)?,
-                )
-                .map_err(|e| errors.push(K8sResourceDumperError::IOError(e)));
-            }
-            Err(e) => {
-                errors.push(K8sResourceDumperError::K8sResourceError(e));
-            }
+        if let Err(error) = get_k8s_statefulsets(&self.k8s_client, &configurations_path).await {
+            errors.push(error)
         }
 
         // Fetch all DiskPools in provided NAMESPACE
-        log("\t Collecting Kubernetes disk pool resources".to_string());
-        match self.k8s_client.list_pools(None, None).await {
-            Ok(disk_pools) => {
-                let filtered_pools = match required_pools {
-                    Some(p_names) => {
-                        let names: HashSet<String> = HashSet::from_iter(p_names);
-                        disk_pools
-                            .into_iter()
-                            .filter(|p| names.contains(p.meta().name.as_ref().unwrap()))
-                            .collect::<Vec<DiskPool>>()
-                    }
-                    None => disk_pools,
-                };
-                // NOTE: Unmarshalling object recevied from K8s API-server will not fail
-                let _ = create_file_and_write(
-                    root_dir.clone(),
-                    "k8s_disk_pools.yaml".to_string(),
-                    serde_yaml::to_string(&filtered_pools)?,
-                )
-                .map_err(|e| errors.push(K8sResourceDumperError::IOError(e)));
-            }
-            Err(e) => {
-                errors.push(K8sResourceDumperError::K8sResourceError(e));
-            }
+        if let Err(error) = get_k8s_diskpools(&self.k8s_client, &root_dir, required_pools).await {
+            errors.push(error)
+        }
+
+        // Fetch all VolumeSnapshotClasses for mayastor csi driver
+        if let Err(error) = get_k8s_vs_classes(&self.k8s_client, &root_dir).await {
+            errors.push(error)
+        }
+
+        // Fetch all VolumeSnapshotContents for mayastor csi driver
+        if let Err(error) = get_k8s_vsnapshot_contents(&self.k8s_client, &root_dir).await {
+            errors.push(error)
         }
 
         // Fetch all Pods in provided NAMESPACE
-        log("\t Collecting Kuberbetes pod resources".to_string());
-        match self.k8s_client.get_pods("", "").await {
-            Ok(pods) => {
-                let _ = create_file_and_write(
-                    root_dir.clone(),
-                    "pods.yaml".to_string(),
-                    serde_yaml::to_string(&pods)?,
-                )
-                .map_err(|e| errors.push(K8sResourceDumperError::IOError(e)));
-            }
-            Err(e) => {
-                errors.push(K8sResourceDumperError::K8sResourceError(e));
-            }
+        if let Err(error) = get_k8s_pod_configurations(&self.k8s_client, &root_dir).await {
+            errors.push(error)
         }
+
         if !errors.is_empty() {
             return Err(K8sResourceDumperError::MultipleErrors(errors));
         }
@@ -296,4 +236,182 @@ fn event_time(event: &Event) -> MicroTime {
         return MicroTime(event.last_timestamp.as_ref().unwrap().0);
     }
     event.event_time.as_ref().unwrap().clone()
+}
+
+async fn get_k8s_daemonsets(
+    k8s_client: &ClientSet,
+    configurations_path: &Path,
+) -> Result<(), K8sResourceDumperError> {
+    // Fetch all Daemonsets in provided NAMESPACE
+    log("\t Collecting daemonsets configuration".to_string());
+    match k8s_client.get_daemonsets("", "").await {
+        Ok(daemonsets) => {
+            // Create all Daemonsets configurations
+            create_app_configurations(
+                daemonsets.into_iter().map(DaemonSet).collect(),
+                configurations_path.to_path_buf(),
+            )?;
+            Ok(())
+        }
+        Err(error) => Err(K8sResourceDumperError::K8sResourceError(error)),
+    }
+}
+
+async fn get_k8s_deployments(
+    k8s_client: &ClientSet,
+    configurations_path: &Path,
+) -> Result<(), K8sResourceDumperError> {
+    // Fetch all Deployments in provided NAMESPACE
+    log("\t Collecting deployments configuration".to_string());
+    match k8s_client.get_deployments("", "").await {
+        Ok(deploys) => {
+            // Create all Daemonsets configurations
+            create_app_configurations(
+                deploys.into_iter().map(Deployment).collect(),
+                configurations_path.to_path_buf(),
+            )?;
+            Ok(())
+        }
+        Err(error) => Err(K8sResourceDumperError::K8sResourceError(error)),
+    }
+}
+
+async fn get_k8s_statefulsets(
+    k8s_client: &ClientSet,
+    configurations_path: &Path,
+) -> Result<(), K8sResourceDumperError> {
+    // Fetch all StatefulSets in provided NAMESPACE
+    log("\t Collecting statefulsets configuration".to_string());
+    match k8s_client.get_statefulsets("", "").await {
+        Ok(statefulsets) => {
+            // Create all Daemonsets configurations
+            create_app_configurations(
+                statefulsets.into_iter().map(StatefulSet).collect(),
+                configurations_path.to_path_buf(),
+            )?;
+            Ok(())
+        }
+        Err(error) => Err(K8sResourceDumperError::K8sResourceError(error)),
+    }
+}
+
+async fn get_k8s_diskpools(
+    k8s_client: &ClientSet,
+    root_dir: &Path,
+    required_pools: Option<Vec<String>>,
+) -> Result<(), K8sResourceDumperError> {
+    // Fetch all DiskPools in provided NAMESPACE
+    log("\t Collecting Kubernetes disk pool resources".to_string());
+    match k8s_client.list_pools(None, None).await {
+        Ok(disk_pools) => {
+            let filtered_pools = match required_pools {
+                Some(p_names) => {
+                    let names: HashSet<String> = HashSet::from_iter(p_names);
+                    disk_pools
+                        .into_iter()
+                        .filter(|p| names.contains(p.meta().name.as_ref().unwrap()))
+                        .collect::<Vec<DiskPool>>()
+                }
+                None => disk_pools,
+            };
+            // NOTE: Unmarshalling object recevied from K8s API-server will not fail
+            create_file_and_write(
+                root_dir.to_path_buf(),
+                "k8s_disk_pools.yaml".to_string(),
+                serde_yaml::to_string(&filtered_pools)?,
+            )
+            .map_err(K8sResourceDumperError::IOError)?;
+            Ok(())
+        }
+        Err(error) => Err(K8sResourceDumperError::K8sResourceError(error)),
+    }
+}
+
+async fn get_k8s_vs_classes(
+    k8s_client: &ClientSet,
+    root_dir: &Path,
+) -> Result<(), K8sResourceDumperError> {
+    log("\t Collecting Kubernetes VolumeSnapshotClass resources".to_string());
+    match k8s_client
+        .list_volumesnapshot_classes(Some(MAYASTOR_CSI_DRIVER), None, None)
+        .await
+    {
+        Ok(vscs) => {
+            // NOTE: Unmarshalling object recevied from K8s API-server will not fail
+            create_file_and_write(
+                root_dir.to_path_buf(),
+                "volume_snapshot_classes.yaml".to_string(),
+                serde_yaml::to_string(&vscs)?,
+            )
+            .map_err(K8sResourceDumperError::IOError)?;
+            Ok(())
+        }
+        Err(error) => Err(K8sResourceDumperError::K8sResourceError(error)),
+    }
+}
+
+async fn get_k8s_vsnapshot_contents(
+    k8s_client: &ClientSet,
+    root_dir: &Path,
+) -> Result<(), K8sResourceDumperError> {
+    log("\t Collecting Kubernetes VolumeSnapshotContents resources".to_string());
+    match k8s_client
+        .list_volumesnapshotcontents(Some(MAYASTOR_CSI_DRIVER), None, None)
+        .await
+    {
+        Ok(vscs) => {
+            // NOTE: Unmarshalling object recevied from K8s API-server will not fail
+            create_file_and_write(
+                root_dir.to_path_buf(),
+                "volume_snapshot_contents.yaml".to_string(),
+                serde_yaml::to_string(&vscs)?,
+            )
+            .map_err(K8sResourceDumperError::IOError)?;
+            Ok(())
+        }
+        Err(error) => Err(K8sResourceDumperError::K8sResourceError(error)),
+    }
+}
+
+async fn get_k8s_pod_configurations(
+    k8s_client: &ClientSet,
+    root_dir: &Path,
+) -> Result<(), K8sResourceDumperError> {
+    // Fetch all Pods in provided NAMESPACE
+    log("\t Collecting Kuberbetes pod resources".to_string());
+    match k8s_client.get_pods("", "").await {
+        Ok(pods) => {
+            create_file_and_write(
+                root_dir.to_path_buf(),
+                "pods.yaml".to_string(),
+                serde_yaml::to_string(&pods)?,
+            )
+            .map_err(K8sResourceDumperError::IOError)?;
+            Ok(())
+        }
+        Err(error) => Err(K8sResourceDumperError::K8sResourceError(error)),
+    }
+}
+
+async fn get_k8s_events(
+    k8s_client: &ClientSet,
+    root_dir: &Path,
+) -> Result<(), K8sResourceDumperError> {
+    // Fetch all events in provided NAMESPACE
+    log("\t Collecting Kubernetes events".to_string());
+    match k8s_client.get_events("", "").await {
+        Ok(mut events) => {
+            // Sort the events based on event_time
+            events.sort_unstable_by_key(event_time);
+            // NOTE: Unmarshalling object recevied from K8s API-server will not fail
+            create_file_and_write(
+                root_dir.to_path_buf(),
+                "k8s_events.json".to_string(),
+                serde_json::to_string_pretty(&events)?,
+            )
+            .map_err(K8sResourceDumperError::IOError)?;
+            Ok(())
+        }
+        Err(error) => Err(K8sResourceDumperError::K8sResourceError(error)),
+    }
 }

--- a/k8s/supportability/src/collect/resource_dump.rs
+++ b/k8s/supportability/src/collect/resource_dump.rs
@@ -1,28 +1,40 @@
 use crate::{
     collect::{
         archive, common,
-        common::{DumpConfig, Stringer},
-        constants::MAYASTOR_SERVICE,
+        common::DumpConfig,
         error::Error,
-        k8s_resources::k8s_resource_dump::K8sResourceDumperClient,
-        logs::{LogCollection, LogResource, Logger},
         persistent_store::{etcd::EtcdStore, EtcdError},
-        resources::traits::Topologer,
-        utils::{flush_tool_log_file, init_tool_log_file, write_to_log_file},
+        utils::init_tool_log_file,
     },
     log, OutputFormat,
 };
-use futures::future;
+
 use std::{path::PathBuf, process};
+
+#[cfg(debug_assertions)]
+use crate::collect::{
+    common::Stringer,
+    constants::MAYASTOR_SERVICE,
+    k8s_resources::k8s_resource_dump::K8sResourceDumperClient,
+    logs::LogCollection,
+    logs::{LogResource, Logger},
+    resources::traits::Topologer,
+    utils::{flush_tool_log_file, write_to_log_file},
+};
+#[cfg(debug_assertions)]
+use futures::future;
 
 /// Dumper interacts with various services to collect information like mayastor resource(s),
 /// mayastor service logs and state of mayastor artifacts and mayastor specific artifacts from
 /// etcd
 pub(crate) struct ResourceDumper {
+    #[cfg(debug_assertions)]
     topologer: Option<Box<dyn Topologer>>,
     archive: archive::Archive,
     dir_path: String,
+    #[cfg(debug_assertions)]
     logger: Box<dyn Logger>,
+    #[cfg(debug_assertions)]
     k8s_resource_dumper: K8sResourceDumperClient,
     etcd_dumper: Option<EtcdStore>,
     output_format: OutputFormat,
@@ -69,6 +81,7 @@ impl ResourceDumper {
             }
         };
 
+        #[cfg(debug_assertions)]
         let logger = match LogCollection::new_logger(
             config.kube_config_path.clone(),
             config.namespace.clone(),
@@ -87,6 +100,7 @@ impl ResourceDumper {
             }
         };
 
+        #[cfg(debug_assertions)]
         let k8s_resource_dumper = match K8sResourceDumperClient::new(
             config.kube_config_path.clone(),
             config.namespace.clone(),
@@ -117,16 +131,20 @@ impl ResourceDumper {
         };
 
         ResourceDumper {
+            #[cfg(debug_assertions)]
             topologer: config.topologer,
             archive,
             dir_path: new_dir,
+            #[cfg(debug_assertions)]
             logger,
+            #[cfg(debug_assertions)]
             k8s_resource_dumper,
             etcd_dumper,
             output_format: config.output_format,
         }
     }
 
+    #[cfg(debug_assertions)]
     /// Dumps information associated to given resource(s)
     pub(crate) async fn dump_info(&mut self, folder_path: String) -> Result<(), Error> {
         let mut errors = Vec::new();
@@ -268,6 +286,7 @@ impl ResourceDumper {
         Ok(())
     }
 
+    #[cfg(debug_assertions)]
     /// Copies the temporary directory content into archive and delete temporary directory
     pub fn fill_archive_and_delete_tmp(&mut self) -> Result<(), Error> {
         // Log which is visible in archive system log file

--- a/k8s/supportability/src/collect/resources/mod.rs
+++ b/k8s/supportability/src/collect/resources/mod.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod node;
 pub mod pool;
 pub mod replica;
+pub mod snapshot;
 pub mod traits;
 pub mod utils;
 pub mod volume;

--- a/k8s/supportability/src/collect/resources/snapshot.rs
+++ b/k8s/supportability/src/collect/resources/snapshot.rs
@@ -1,0 +1,130 @@
+use crate::collect::{
+    logs::create_directory_if_not_exist,
+    resources::{
+        traits::{ResourceInformation, Topologer},
+        utils, ResourceError, Resourcer,
+    },
+    rest_wrapper::RestClient,
+};
+use async_trait::async_trait;
+use openapi::models::VolumeSnapshot;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashSet,
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+/// Holds topological information of volume snapshot resource.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct VolumeSnapshotTopology {
+    snapshot: VolumeSnapshot,
+}
+
+/// Implements functionality to inspect topological information of snapshot resource.
+impl Topologer for VolumeSnapshotTopology {
+    fn get_printable_topology(&self) -> Result<(String, String), ResourceError> {
+        let topology_as_pretty = serde_json::to_string_pretty(self)?;
+        let file_path = format!(
+            "snapshot-{}-topology.json",
+            self.snapshot.definition.spec.uuid
+        );
+        Ok((file_path, topology_as_pretty))
+    }
+
+    fn dump_topology_info(&self, dir_path: String) -> Result<(), ResourceError> {
+        create_directory_if_not_exist(PathBuf::from(dir_path.clone()))?;
+        let file_path = Path::new(&dir_path).join(format!(
+            "snapshot-{}-topology.json",
+            self.snapshot.definition.spec.uuid
+        ));
+        let mut topo_file = File::create(file_path)?;
+        let topology_as_pretty = serde_json::to_string_pretty(self)?;
+        topo_file.write_all(topology_as_pretty.as_bytes())?;
+        topo_file.flush()?;
+        Ok(())
+    }
+
+    fn get_unhealthy_resource_info(&self) -> HashSet<ResourceInformation> {
+        // Not neeeded for snapshot topology.
+        unimplemented!()
+    }
+
+    fn get_all_resource_info(&self) -> HashSet<ResourceInformation> {
+        // Not neeeded for snapshot topology.
+        unimplemented!()
+    }
+
+    fn get_k8s_resource_names(&self) -> Vec<String> {
+        // Not neeeded for snapshot topology.
+        unimplemented!()
+    }
+}
+
+/// Wrapper around mayastor REST client.
+#[derive(Debug)]
+pub(crate) struct VolumeSnapshotClientWrapper {
+    rest_client: RestClient,
+}
+
+impl VolumeSnapshotClientWrapper {
+    /// Builds new instance of VolumeSnapshotClientWrapper
+    pub(crate) fn new(client: RestClient) -> Self {
+        VolumeSnapshotClientWrapper {
+            rest_client: client,
+        }
+    }
+
+    async fn list_snapshots(&self) -> Result<Vec<VolumeSnapshot>, ResourceError> {
+        let mut volume_snapshots: Vec<VolumeSnapshot> = Vec::new();
+        let mut next_token: Option<isize> = Some(0);
+        let max_entries: isize = utils::MAX_RESOURCE_ENTRIES;
+        loop {
+            let snapshot_api_resp = self
+                .rest_client
+                .snapshots_api()
+                .get_volumes_snapshots(max_entries, None, None, next_token)
+                .await?
+                .into_body();
+            volume_snapshots.extend(snapshot_api_resp.entries);
+            if snapshot_api_resp.next_token.is_none() {
+                break;
+            }
+            next_token = snapshot_api_resp.next_token;
+        }
+        Ok(volume_snapshots)
+    }
+
+    async fn get_snapshot(&self, id: openapi::apis::Uuid) -> Result<VolumeSnapshot, ResourceError> {
+        let snapshot = self
+            .rest_client
+            .snapshots_api()
+            .get_volumes_snapshot(&id)
+            .await?
+            .into_body();
+        Ok(snapshot)
+    }
+}
+
+#[async_trait(?Send)]
+impl Resourcer for VolumeSnapshotClientWrapper {
+    type ID = openapi::apis::Uuid;
+
+    async fn get_topologer(
+        &self,
+        id: Option<Self::ID>,
+    ) -> Result<Box<dyn Topologer>, ResourceError> {
+        if let Some(snapshot_id) = id {
+            let snapshot = self.get_snapshot(snapshot_id).await?;
+            return Ok(Box::new(VolumeSnapshotTopology { snapshot }));
+        }
+        let snapshots_topology: Vec<VolumeSnapshotTopology> = self
+            .list_snapshots()
+            .await?
+            .into_iter()
+            .map(|snapshot| VolumeSnapshotTopology { snapshot })
+            .collect();
+        Ok(Box::new(snapshots_topology))
+    }
+}

--- a/k8s/supportability/src/collect/resources/traits.rs
+++ b/k8s/supportability/src/collect/resources/traits.rs
@@ -2,7 +2,6 @@ use crate::collect::{constants::DATA_PLANE_CONTAINER_NAME, resources::error::Res
 use async_trait::async_trait;
 use downcast_rs::{impl_downcast, Downcast};
 use lazy_static::lazy_static;
-use prettytable::Row;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
@@ -72,13 +71,6 @@ impl ResourceInformation {
     }
 }
 
-/// Implements functionality for displaying information in tabular manner and reading inputs
-pub(crate) trait TablePrinter {
-    fn get_header_row(&self) -> Row;
-    fn create_rows(&self) -> Vec<Row>;
-    fn get_resource_id(&self, row_data: &Row) -> Result<String, ResourceError>;
-}
-
 /// Implements functionality to inspect topology information
 pub(crate) trait Topologer: Downcast + Debug {
     fn get_printable_topology(&self) -> Result<(String, String), ResourceError>;
@@ -93,9 +85,6 @@ impl_downcast!(Topologer);
 #[async_trait(?Send)]
 pub(crate) trait Resourcer {
     type ID;
-    async fn read_resource_id(&self) -> Result<Self::ID, ResourceError> {
-        panic!("read_resource_id is not yet implemented");
-    }
     async fn get_topologer(
         &self,
         _id: Option<Self::ID>,

--- a/k8s/supportability/src/collect/resources/utils.rs
+++ b/k8s/supportability/src/collect/resources/utils.rs
@@ -1,89 +1,12 @@
 use crate::collect::resources::{
-    traits::{ResourceInformation, TablePrinter, Topologer},
+    traits::{ResourceInformation, Topologer},
     ResourceError,
 };
-use lazy_static::lazy_static;
-use prettytable::{format, Row, Table};
-use serde::{ser, Serialize};
-use std::{collections::HashSet, io};
+use serde::Serialize;
+use std::collections::HashSet;
 
 /// Defines maximum entries REST service can fetch at one network call
 pub(crate) const MAX_RESOURCE_ENTRIES: isize = 200;
-
-// Constants to store the table headers of the Tabular output formats.
-lazy_static! {
-    /// Represents list of Volume table headers
-    pub(crate) static ref VOLUME_HEADERS: Row = row!["INDEX", "ID", "STATUS", "SIZE",];
-    /// Represents list of pool table headers
-    pub(crate) static ref POOL_HEADERS: Row = row!["INDEX", "ID", "DISKS", "NODE", "STATUS",];
-    /// Represents list of node table headers
-    pub(crate) static ref NODE_HEADERS: Row = row!["INDEX", "ID", "STATUS"];
-}
-
-/// Prints list of resources in tabular format and read input based on index
-pub(crate) fn print_table_and_get_id<T>(obj: T) -> Result<String, ResourceError>
-where
-    T: TablePrinter,
-    T: ser::Serialize,
-{
-    let rows: Vec<Row> = obj.create_rows();
-    let header: Row = obj.get_header_row();
-    let mut table = Table::new();
-
-    table.set_format(*format::consts::FORMAT_CLEAN);
-    table.set_titles(header);
-    for row in rows {
-        table.add_row(row);
-    }
-    table.printstd();
-
-    println!("Please enter index of resource: ");
-    let mut index: usize;
-    let mut input_line = String::new();
-    loop {
-        input_line.clear();
-        let _no_of_chars = io::stdin().read_line(&mut input_line)?;
-        let trimmed_input = input_line.trim().trim_end_matches('\n');
-        if trimmed_input.is_empty() {
-            continue;
-        }
-        index = trimmed_input.parse::<usize>().unwrap();
-        if index > table.len() {
-            println!("Please enter number in range of (1, {})", table.len());
-            continue;
-        }
-        break;
-    }
-    index -= 1;
-    let row_data = table.get_row(index).ok_or_else(|| {
-        ResourceError::CustomError("Unable to get resource information".to_string())
-    })?;
-    obj.get_resource_id(row_data)
-}
-
-impl<T> TablePrinter for Vec<T>
-where
-    T: TablePrinter,
-{
-    fn create_rows(&self) -> Vec<Row> {
-        self.iter()
-            .enumerate()
-            .flat_map(|(index, r)| -> Vec<Row> {
-                let mut row_data: Row = r.create_rows()[0].clone();
-                row_data.insert_cell(0, cell![index + 1]);
-                vec![row_data]
-            })
-            .collect()
-    }
-
-    fn get_header_row(&self) -> Row {
-        self.get(0).map(|obj| obj.get_header_row()).unwrap()
-    }
-
-    fn get_resource_id(&self, row_data: &Row) -> Result<String, ResourceError> {
-        self.get(0).unwrap().get_resource_id(row_data)
-    }
-}
 
 impl<T> Topologer for Vec<T>
 where

--- a/k8s/supportability/src/operations.rs
+++ b/k8s/supportability/src/operations.rs
@@ -1,9 +1,12 @@
+#[cfg(debug_assertions)]
 /// Represents type of VolumeID
 pub(crate) type VolumeID = openapi::apis::Uuid;
 
+#[cfg(debug_assertions)]
 /// Represents type of PoolID
 pub(crate) type PoolID = String;
 
+#[cfg(debug_assertions)]
 /// Represents type of NodeID
 pub(crate) type NodeID = String;
 
@@ -15,34 +18,47 @@ pub(crate) enum Operations {
     Dump(Resource),
 }
 
+#[derive(Debug, Clone, clap::Args)]
+pub(crate) struct SystemDumpArgs {
+    /// Set this to disable log collection
+    #[clap(global = true, long)]
+    pub(crate) disable_log_collection: bool,
+}
+
 /// Resources on which operation can be performed
 #[derive(clap::Subcommand, Clone, Debug)]
 pub(crate) enum Resource {
     /// Collects entire system information
-    System,
+    System(SystemDumpArgs),
 
+    #[cfg(debug_assertions)]
     /// Collects information about all volumes and its descendants (replicas/pools/nodes)
     #[clap(name = "volumes")]
     Volumes,
 
+    #[cfg(debug_assertions)]
     /// Collects information about particular volume and its descendants matching
     /// to given volume ID
     #[clap(name = "volume")]
     Volume { id: VolumeID },
 
+    #[cfg(debug_assertions)]
     /// Collects information about all pools and its descendants (nodes)
     #[clap(name = "pools")]
     Pools,
 
+    #[cfg(debug_assertions)]
     /// Collects information about particular pool and its descendants matching
     /// to given pool ID
     #[clap(name = "pool")]
     Pool { id: PoolID },
 
+    #[cfg(debug_assertions)]
     /// Collects information about all nodes
     #[clap(name = "nodes")]
     Nodes,
 
+    #[cfg(debug_assertions)]
     /// Collects information about particular node matching to given node ID
     #[clap(name = "node")]
     Node { id: NodeID },


### PR DESCRIPTION
- Add VolumeSnapshot and VolumeSnapshotContent CRs for mayastor driver.
- Add Rest api snapshot resources to topology.
- Add Rebuild history to the volume.
- Remove dead code and crate.
- Hide resource level dump commands, until further refactor.