### PR TITLE
feat(upgrade): add set flag in upgrade

### DIFF
--- a/k8s/plugin/src/main.rs
+++ b/k8s/plugin/src/main.rs
@@ -172,10 +172,7 @@ async fn execute(cli_args: CliArgs) {
                     &cli_args.namespace,
                     cli_args.kube_config_path.clone(),
                     cli_args.timeout,
-                    resources.skip_single_replica_volume_validation,
-                    resources.skip_replica_rebuild,
-                    resources.skip_cordoned_node_validation,
-                    resources.skip_upgrade_path_validation_for_unsupported_version,
+                    &resources,
                 )
                 .await
                 .map_err(|error| {
@@ -186,7 +183,10 @@ async fn execute(cli_args: CliArgs) {
                 if resources.dry_run {
                     _ = resources.dummy_apply(&cli_args.namespace).await;
                 } else {
-                    resources.apply(&cli_args.namespace).await;
+                    _ = resources.apply(&cli_args.namespace).await.map_err(|error| {
+                        eprintln!("{error}");
+                        std::process::exit(error.into());
+                    });
                 }
             }
 

--- a/k8s/upgrade/src/bin/upgrade-job/common/error.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/error.rs
@@ -346,6 +346,10 @@ pub(crate) enum Error {
         std_err: String,
     },
 
+    /// Error for when a Helm upgrade command execution succeeds, but with an error.
+    #[snafu(display("`helm upgrade --dry-run` command return an error, error: {}", std_err,))]
+    HelmUpgradeDryRunCommand { std_err: String },
+
     /// Error for when a Helm get values command execution succeeds, but with an error.
     #[snafu(display(
         "`helm get values` command return an error,\ncommand: {},\nargs: {:?},\nstd_err: {}",

--- a/k8s/upgrade/src/bin/upgrade-job/helm/client.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/client.rs
@@ -68,7 +68,7 @@ impl HelmReleaseClientBuilder {
 /// releases.
 #[derive(Clone)]
 pub(crate) struct HelmReleaseClient {
-    namespace: String,
+    pub(crate) namespace: String,
 }
 
 impl HelmReleaseClient {

--- a/k8s/upgrade/src/bin/upgrade-job/opts.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/opts.rs
@@ -38,6 +38,11 @@ pub(crate) struct CliArgs {
     /// The name of the Kubernetes Job Pod. The Job object will be used to post upgrade event.
     #[arg(env = "POD_NAME")]
     pod_name: String,
+
+    /// The set values specified by the user for upgrade
+    /// (can specify multiple or separate values with commas: key1=val1,key2=val2).
+    #[arg(short, long)]
+    values: String,
 }
 
 impl CliArgs {
@@ -75,5 +80,10 @@ impl CliArgs {
     /// This returns the name of the Kubernetes Pod where this binary will be running.
     pub(crate) fn pod_name(&self) -> String {
         self.pod_name.clone()
+    }
+
+    /// This returns the set values passed during upgrade.
+    pub(crate) fn values(&self) -> String {
+        self.values.clone()
     }
 }

--- a/k8s/upgrade/src/plugin/constants.rs
+++ b/k8s/upgrade/src/plugin/constants.rs
@@ -120,3 +120,6 @@ pub(crate) const HELM_RELEASE_VERSION_LABEL: &str = "openebs.io/version";
 
 /// Upgrade to develop.
 pub(crate) const UPGRADE_TO_DEVELOP_BRANCH: &str = "develop";
+
+/// Number of retries for fetching the events.
+pub(crate) const MAX_RETRY_ATTEMPTS: u8 = 6;

--- a/k8s/upgrade/src/plugin/error.rs
+++ b/k8s/upgrade/src/plugin/error.rs
@@ -144,6 +144,11 @@ pub enum Error {
     #[snafu(display("Failed to list Events with field selector {}: {}", field, source))]
     ListEventsWithFieldSelector { source: kube::Error, field: String },
 
+    /// Error for when a Kubernetes API request for Deleting a list of events filtered by
+    /// filed selector fails.
+    #[snafu(display("Failed to delete Events with field selector {}: {}", field, source))]
+    DeleteEventsWithFieldSelector { source: kube::Error, field: String },
+
     /// Error listing the pvc list.
     #[snafu(display("Failed to list pvc : {}", source))]
     ListPVC { source: kube::Error },
@@ -280,6 +285,7 @@ impl From<Error> for i32 {
             Error::SourceTargetVersionSame { .. } => 443,
             Error::NotAValidSourceForUpgrade { .. } => 444,
             Error::InvalidUpgradePath { .. } => 445,
+            Error::DeleteEventsWithFieldSelector { .. } => 446,
         }
     }
 }

--- a/k8s/upgrade/src/plugin/objects.rs
+++ b/k8s/upgrade/src/plugin/objects.rs
@@ -4,6 +4,7 @@ use crate::{
         UPGRADE_JOB_CLUSTERROLE_NAME_SUFFIX, UPGRADE_JOB_CONTAINER_NAME, UPGRADE_JOB_NAME_SUFFIX,
         UPGRADE_JOB_SERVICEACCOUNT_NAME_SUFFIX,
     },
+    upgrade::UpgradeArgs,
     upgrade_labels,
 };
 
@@ -251,20 +252,21 @@ pub(crate) fn upgrade_job(
     namespace: &str,
     upgrade_image: String,
     release_name: String,
-    skip_data_plane_restart: bool,
-    skip_upgrade_path_validation: bool,
+    args: &UpgradeArgs,
     image_pull_secrets: Option<Vec<k8s_openapi::api::core::v1::LocalObjectReference>>,
     image_pull_policy: Option<String>,
 ) -> Job {
+    let values = args.set_args.join(",");
     let mut job_args: Vec<String> = vec![
         format!("--rest-endpoint=http://{release_name}-api-rest:8081"),
         format!("--namespace={namespace}"),
         format!("--release-name={release_name}"),
+        format!("--values={values}"),
     ];
-    if skip_data_plane_restart {
+    if args.skip_data_plane_restart {
         job_args.push("--skip-data-plane-restart".to_string());
     }
-    if skip_upgrade_path_validation {
+    if args.skip_upgrade_path_validation_for_unsupported_version {
         job_args.push("--skip-upgrade-path-validation".to_string());
     }
 

--- a/k8s/upgrade/src/plugin/user_prompt.rs
+++ b/k8s/upgrade/src/plugin/user_prompt.rs
@@ -50,3 +50,7 @@ pub const UPGRADE_TO_UNSUPPORTED_VERSION: &str =
 /// Delete an incomplete job.
 pub const DELETE_INCOMPLETE_JOB: &str =
     "\n Cant delete an incomplete upgrade job. Please try with `--force` flag to forcefully remove upgrade resources and bypass graceful deletion.";
+
+/// Information about successful start of upgrade process.
+pub const HELM_UPGRADE_VALIDATION_ERROR: &str =
+    "\nThe validation for upgrade Failed, hence deleting the upgrade resources. Please re-run upgrade with valid values.";


### PR DESCRIPTION
Helm doesn't validates the  value passed 
Example 
```
root@ashish-dev:~/code/rust/mayastor-extensions(set-flag)$ helm install mayastor mayastor/mayastor -n mayastor --create-namespace --version 2.3.0 --set='alpha=beta,gamma={30,101}'
NAME: mayastor
LAST DEPLOYED: Wed Aug  9 06:26:30 2023
NAMESPACE: mayastor
STATUS: deployed
REVISION: 1
NOTES:
OpenEBS Mayastor has been installed. Check its status by running:
$ kubectl get pods -n mayastor
```
Upon getting the values 
```
root@ashish-dev:~/code/rust/mayastor-extensions(set-flag)$ helm get values mayastor --all  -n mayastor  -oyaml > ~/test.yaml
```

The values present in `test.yaml` 
```
root@ashish-dev:~$ grep -i alpha  test.yaml
alpha: beta
root@ashish-dev:~$ grep -i -C 4 gamma  test.yaml
      limits: {}
      requests: {}
eventing:
  enabled: false
gamma:
- 30
- 101
image:
  pullPolicy: IfNotPresent
```

So , we don't need to validate the values passed, Its just that we need to validate the format.

This PR validates by running `helm upgrade --dry-run` command .
```
root@ashish-dev:~/code/rust/mayastor-extensions(set-flag)$ ./target/debug/kubectl-mayastor  upgrade --set obs.callhome.enabled=false,a={1,2  --skip-upgrade-path-validation-for-unsupported-version

Volumes which make use of a single volume replica instance will be unavailable for some time during upgrade.
It is recommended that you do not create new volumes which make use of only one volume replica.

ServiceAccount: mayastor-upgrade-service-account-bbb created in namespace: mayastor
Cluster Role: mayastor-upgrade-role-bbb in namespace mayastor created
ClusterRoleBinding: mayastor-upgrade-role-binding-bbb in namespace mayastor created
Job: mayastor-upgrade-bbb created in namespace: mayastor

 The validation failed for upgrade, hence deleting teh upgrade resources. Please re-run upgrade with valid values.
 {"fromVersion":"2.3.0","toVersion":"0.0.0","message":"Failed to upgrade: `helm upgrade` command return an error,\ncommand: helm,\nargs: [\"upgrade\", \"mayastor\", \"/chart\", \"-n\", \"mayastor\", \"--timeout\", \"15m\", \"-f\", \"/chart/.tmpGpv2QI\", \"--set\", \"obs.callhome.enabled=false,a={1,2\", \"--atomic\", \"--dry-run\"],\nstd_err: Error: failed parsing --set data: list must terminate with '}'\n"}
Job mayastor-upgrade-bbb in namespace mayastor deleted
ClusterRoleBinding mayastor-upgrade-role-binding-bbb in namespace mayastor deleted
ClusterRole mayastor-upgrade-role-bbb in namespace mayastor deleted
ServiceAccount mayastor-upgrade-service-account-bbb in namespace mayastor deleted
```