### PR TITLE
chore(upgrade): update upgrade docs

### DIFF
--- a/k8s/plugin/README.md
+++ b/k8s/plugin/README.md
@@ -344,27 +344,29 @@ kubectl mayastor dump system -d <output_directory> -n <mayastor_namespace>
 
   Options:
   -d, --dry-run
-        Display all the validations output but will not execute upgrade
+          Display all the validations output but will not execute upgrade
   -r, --rest <REST>
-        The rest endpoint to connect to
-  -D, --skip-data-plane-restart
-        If set then upgrade will skip the io-engine pods restart
+          The rest endpoint to connect to
   -k, --kube-config-path <KUBE_CONFIG_PATH>
-        Path to kubeconfig file
-  -S, --skip-single-replica-volume-validation
-        If set then it will continue with upgrade without validating singla replica volume
-  -R, --skip-replica-rebuild
-        If set then upgrade will skip the repilca rebuild in progress validation
-  -C, --skip-cordoned-node-validation
-        If set then upgrade will skip the cordoned node validation
+          Path to kubeconfig file
+      --skip-data-plane-restart
+          If set then upgrade will skip the io-engine pods restart
+      --skip-single-replica-volume-validation
+          If set then it will continue with upgrade without validating singla replica volume
+      --skip-replica-rebuild
+          If set then upgrade will skip the repilca rebuild in progress validation
+      --skip-cordoned-node-validation
+          If set then upgrade will skip the cordoned node validation
+      --set-args <SET_ARGS>
+          The set values on the command line. (can specify multiple or separate values with commas: key1=val1,key2=val2)
   -o, --output <OUTPUT>
-        The Output, viz yaml, json [default: none]
+          The Output, viz yaml, json [default: none]
   -j, --jaeger <JAEGER>
-        Trace rest requests to the Jaeger endpoint agent
+          Trace rest requests to the Jaeger endpoint agent
   -n, --namespace <NAMESPACE>
-        Kubernetes namespace of mayastor service [default: mayastor]
+          Kubernetes namespace of mayastor service [default: mayastor]
   -h, --help
-        Print help
+          Print help
 ```
 
 2. Get the upgrade status

--- a/k8s/upgrade/src/plugin/upgrade.rs
+++ b/k8s/upgrade/src/plugin/upgrade.rs
@@ -86,26 +86,26 @@ pub struct UpgradeArgs {
     pub dry_run: bool,
 
     /// If set then upgrade will skip the io-engine pods restart.
-    #[clap(global = true, long, short = 'D', default_value_t = false)]
+    #[clap(global = true, long, default_value_t = false)]
     pub skip_data_plane_restart: bool,
 
     /// If set then it will continue with upgrade without validating singla replica volume.
-    #[clap(global = true, long, short = 'S')]
+    #[clap(global = true, long)]
     pub skip_single_replica_volume_validation: bool,
 
     /// If set then upgrade will skip the repilca rebuild in progress validation.
-    #[clap(global = true, long, short = 'R')]
+    #[clap(global = true, long)]
     pub skip_replica_rebuild: bool,
 
     /// If set then upgrade will skip the cordoned node validation.
-    #[clap(global = true, long, short = 'C')]
+    #[clap(global = true, long)]
     pub skip_cordoned_node_validation: bool,
 
     /// Upgrade to an unsupported version.
     #[clap(global = true, hide = true, long, default_value_t = false)]
     pub skip_upgrade_path_validation_for_unsupported_version: bool,
 
-    /// The set values specified by the user for upgrade.
+    /// The set values on the command line.
     /// (can specify multiple or separate values with commas: key1=val1,key2=val2).
     #[clap(global = true, long)]
     pub set_args: Vec<String>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update upgrade docs.
## Description
<!--- Describe your changes in detail -->
Add `set-args` to upgrade docs and remove the _capital_ aliases for `skip-data-plane-restart` , `skip-single-replica-volume-validation`, `skip-replica-rebuild`, `skip-cordoned-node-validation` to make it consistent with helm command 
The helm command doesn't have any capital alias.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In case the user sets any value using --set-args flag at the time of install. The upgrade might override those values. 
So in order to keep the user values intact the user have to pass the `--set-args ` while upgrade.
Like `kubectl-mayastor upgrade --set-args obs.callhome.enabled=false`
<!--- If it fixes an open issue, please link to the issue here. -->


## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
No. This is just a docs update , The feature was in PR #307 
<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Install mayastor 
 ```
helm install mayastor mayastor/mayastor -n mayastor --set obs.callhome.enabled=false --create-namespace --version 2.3.0 
```
2. Run upgrade
```
 kubectl-mayastor  upgrade --set-args obs.callhome.enabled=true  --skip-upgrade-path-validation-for-unsupported-version
```
 
 <!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.