### PR TITLE
feat(upgrade-job): enforce defaults for eventing and csi sidecars

### DIFF
--- a/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
@@ -21,7 +21,7 @@ pub(crate) const CHART_VERSION_LABEL_KEY: &str = "openebs.io/version";
 pub(crate) const DRAIN_FOR_UPGRADE: &str = "mayastor-upgrade";
 
 /// This is the allowed upgrade to-version/to-version-range for the Umbrella chart.
-pub(crate) const TO_UMBRELLA_SEMVER: &str = "3.8.0";
+pub(crate) const TO_UMBRELLA_SEMVER: &str = "3.9.0";
 
 /// This is the user docs URL for the Umbrella chart.
 pub(crate) const UMBRELLA_CHART_UPGRADE_DOCS_URL: &str =

--- a/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
@@ -29,3 +29,6 @@ pub(crate) const UMBRELLA_CHART_UPGRADE_DOCS_URL: &str =
 
 /// This defines the range of helm chart versions for the 2.0 release of the Core helm chart.
 pub(crate) const TWO_DOT_O: &str = ">=2.0.0-rc.0, <2.1.0";
+
+/// This defines the range of helm chart versions for the 2.3 release of the Core helm chart.
+pub(crate) const TWO_DOT_THREE: &str = ">=2.3.0-rc.0, <2.4.0";

--- a/k8s/upgrade/src/bin/upgrade-job/events/event_recorder.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/events/event_recorder.rs
@@ -268,8 +268,10 @@ impl EventRecorder {
 
     /// Shuts down the event channel which makes the event loop worker exit its loop and return.
     pub(crate) async fn shutdown_worker(mut self) {
+        // Dropping the sender, to signify no more channel messages.
         let _ = self.event_sender.take();
 
+        // Wait for event loop to publish its last events and exit.
         let _ = self.event_loop_handle.await;
     }
 }

--- a/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
@@ -30,6 +30,10 @@ pub(crate) struct CoreValues {
     image: Image,
     /// This is the yaml object which contains the configuration for the io-engine DaemonSet.
     io_engine: IoEngine,
+    /// This toggles installation of eventing components.
+    eventing: Eventing,
+    /// This contains Kubernetes CSI sidecar container image details.
+    csi: Csi,
 }
 
 impl CoreValues {
@@ -41,6 +45,36 @@ impl CoreValues {
     /// This is a getter for the io-engine DaemonSet Pods' logLevel.
     pub(crate) fn io_engine_log_level(&self) -> &str {
         self.io_engine.log_level()
+    }
+
+    /// This is a getter for the eventing installation enable/disable state.
+    pub(crate) fn eventing_enabled(&self) -> bool {
+        self.eventing.enabled()
+    }
+
+    /// This is a getter or the sig-storage/csi-provisioner image tag.
+    pub(crate) fn csi_provisioner_image_tag(&self) -> &str {
+        self.csi.provisioner_image_tag()
+    }
+
+    /// This is a getter or the sig-storage/csi-attacher image tag.
+    pub(crate) fn csi_attacher_image_tag(&self) -> &str {
+        self.csi.attacher_image_tag()
+    }
+
+    /// This is a getter or the sig-storage/csi-snapshotter image tag.
+    pub(crate) fn csi_snapshotter_image_tag(&self) -> &str {
+        self.csi.snapshotter_image_tag()
+    }
+
+    /// This is a getter or the sig-storage/snapshot-controller image tag.
+    pub(crate) fn csi_snapshot_controller_image_tag(&self) -> &str {
+        self.csi.snapshot_controller_image_tag()
+    }
+
+    /// This is a getter or the sig-storage/csi-node-driver-registrar image tag.
+    pub(crate) fn csi_node_driver_registrar_image_tag(&self) -> &str {
+        self.csi.node_driver_registrar_image_tag()
     }
 }
 
@@ -72,5 +106,89 @@ impl IoEngine {
     /// This is a getter for the io-engine DaemonSet Pod's tracing logLevel.
     pub(crate) fn log_level(&self) -> &str {
         self.log_level.as_str()
+    }
+}
+
+/// This is used to deserialize the yaml object 'eventing', v2.3.0 has it disabled by default,
+/// the default thereafter has it enabled.
+#[derive(Deserialize)]
+pub(crate) struct Eventing {
+    enabled: bool,
+}
+
+impl Eventing {
+    /// This is a predicate for the installation setting for eventing.
+    pub(crate) fn enabled(&self) -> bool {
+        self.enabled
+    }
+}
+
+/// This is used to deserialize the yaml object 'csi'.
+#[derive(Deserialize)]
+pub(crate) struct Csi {
+    image: CsiImage,
+}
+
+impl Csi {
+    /// This is a getter for the sig-storage/csi-provisioner image tag.
+    pub(crate) fn provisioner_image_tag(&self) -> &str {
+        self.image.provisioner_tag()
+    }
+
+    /// This is a getter for the sig-storage/csi-attacher image tag.
+    pub(crate) fn attacher_image_tag(&self) -> &str {
+        self.image.attacher_tag()
+    }
+
+    /// This is a getter for the sig-storage/csi-snapshotter image tag.
+    pub(crate) fn snapshotter_image_tag(&self) -> &str {
+        self.image.snapshotter_tag()
+    }
+
+    /// This is a getter for the sig-storage/snapshot-controller image tag.
+    pub(crate) fn snapshot_controller_image_tag(&self) -> &str {
+        self.image.snapshot_controller_tag()
+    }
+
+    /// This is a getter for the sig-storage/csi-node-driver-registrar image tag.
+    pub(crate) fn node_driver_registrar_image_tag(&self) -> &str {
+        self.image.node_driver_registrar_tag()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+pub(crate) struct CsiImage {
+    provisioner_tag: String,
+    attacher_tag: String,
+    snapshotter_tag: String,
+    snapshot_controller_tag: String,
+    registrar_tag: String,
+}
+
+impl CsiImage {
+    /// This is a getter for provisionerTag.
+    pub(crate) fn provisioner_tag(&self) -> &str {
+        self.provisioner_tag.as_str()
+    }
+
+    /// This is a getter for attacherTag.
+    pub(crate) fn attacher_tag(&self) -> &str {
+        self.attacher_tag.as_str()
+    }
+
+    /// This is a getter for snapshotterTag.
+    pub(crate) fn snapshotter_tag(&self) -> &str {
+        self.snapshotter_tag.as_str()
+    }
+
+    /// This is a getter for snapshotControllerTag.
+    pub(crate) fn snapshot_controller_tag(&self) -> &str {
+        self.snapshot_controller_tag.as_str()
+    }
+
+    /// This is a getter for registrarTag.
+    pub(crate) fn node_driver_registrar_tag(&self) -> &str {
+        self.registrar_tag.as_str()
     }
 }

--- a/k8s/upgrade/src/bin/upgrade-job/helm/client.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/client.rs
@@ -120,7 +120,7 @@ impl HelmReleaseClient {
             })?;
 
         ensure!(
-            output.stderr.is_empty(),
+            output.status.success(),
             HelmGetValuesCommand {
                 command: command.to_string(),
                 args,
@@ -170,7 +170,7 @@ impl HelmReleaseClient {
         let stdout_str = str::from_utf8(output.stdout.as_slice()).context(U8VectorToString)?;
         debug!(stdout=%stdout_str, "Helm list command standard output");
         ensure!(
-            output.stderr.is_empty(),
+            output.status.success(),
             HelmListCommand {
                 command: command.to_string(),
                 args,
@@ -235,7 +235,7 @@ impl HelmReleaseClient {
         let stdout_str = str::from_utf8(output.stdout.as_slice()).context(U8VectorToString)?;
         debug!(stdout=%stdout_str, "Helm upgrade command standard output");
         ensure!(
-            output.stderr.is_empty(),
+            output.status.success(),
             HelmUpgradeCommand {
                 command: command.to_string(),
                 args,

--- a/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
@@ -290,7 +290,7 @@ impl HelmUpgrade {
             let stderr_str = str::from_utf8(output.stderr.as_slice()).context(U8VectorToString)?;
             debug!(stdout=%stdout_str, stderr=%stderr_str, "Helm upgrade dry-run command standard output and error");
             ensure!(
-                output.stderr.is_empty(),
+                output.status.success(),
                 HelmUpgradeDryRunCommand {
                     std_err: str::from_utf8(output.stderr.as_slice())
                         .context(U8VectorToString)?

--- a/k8s/upgrade/src/bin/upgrade-job/helm/yaml/yq.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/yaml/yq.rs
@@ -70,7 +70,7 @@ impl YqV4 {
             })?;
 
         ensure!(
-            yq_version_output.stderr.is_empty(),
+            yq_version_output.status.success(),
             YqVersionCommand {
                 command: yq_v4.command_as_str().to_string(),
                 arg: yq_version_arg,
@@ -151,7 +151,7 @@ impl YqV4 {
             })?;
 
         ensure!(
-            yq_merge_output.stderr.is_empty(),
+            yq_merge_output.status.success(),
             YqMergeCommand {
                 command: self.command_as_str().to_string(),
                 args: yq_merge_args,
@@ -186,7 +186,7 @@ impl YqV4 {
                 })?;
 
         ensure!(
-            yq_set_output.stderr.is_empty(),
+            yq_set_output.status.success(),
             YqSetCommand {
                 command: self.command_as_str().to_string(),
                 args: yq_set_args,

--- a/k8s/upgrade/src/bin/upgrade-job/opts/validators.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/opts/validators.rs
@@ -39,7 +39,7 @@ pub(crate) fn validate_helm_release(name: String, namespace: String) -> Result<(
     let stdout_str = str::from_utf8(output.stdout.as_slice()).context(U8VectorToString)?;
     debug!(stdout=%stdout_str, "Helm list command standard output");
     ensure!(
-        output.stderr.is_empty(),
+        output.status.success(),
         HelmListCommand {
             command: command.to_string(),
             args,
@@ -80,7 +80,7 @@ pub(crate) fn validate_helmv3_in_path() -> Result<()> {
     let stdout_str = str::from_utf8(output.stdout.as_slice()).context(U8VectorToString)?;
     debug!(stdout=%stdout_str, "Helm version command standard output");
     ensure!(
-        output.stderr.is_empty(),
+        output.status.success(),
         HelmVersionCommand {
             command: command.to_string(),
             args,


### PR DESCRIPTION
This PR enforces the use of defaults for the following helm chart values, when upgrading to 2.4.0:
- eventing.enabled (only for 2.3.x releases)
- csi.image.provisionerTag
- csi.image.attacherTag
- csi.image.snapshotterTag
- csi.image.snapshotControllerTag
- csi.image.registrarTag