### PR TITLE
fix(eventing): enable stats container when eventing is enabled

### DIFF
--- a/call-home/src/common/constants.rs
+++ b/call-home/src/common/constants.rs
@@ -13,9 +13,6 @@ pub const HELM_RELEASE_NAME_LABEL: &str = "openebs.io/release";
 /// Defines the default helm chart release name.
 pub const DEFAULT_RELEASE_NAME: &str = "mayastor";
 
-/// Defines the default url for stats aggregator.
-pub const DEFAULT_STATS_AGGREGATOR_URL: &str = "http://mayastor-obs-callhome-stats:9090/stats";
-
 /// Defines the Label select for mayastor REST API.
 pub const API_REST_LABEL_SELECTOR: &str = "app=api-rest";
 

--- a/chart/templates/mayastor/obs/obs-callhome-deployment.yaml
+++ b/chart/templates/mayastor/obs/obs-callhome-deployment.yaml
@@ -38,8 +38,8 @@ spec:
           image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ .Chart.Name }}-obs-callhome:{{ default .Values.image.tag .Values.image.repoTags.extensions }}"
           args:
             - "-e http://{{ .Release.Name }}-api-rest:8081"
-            - "-n {{ .Release.Namespace }}"
-            - "--aggregator-url=http://{{ .Release.Name }}-obs-callhome-stats:9090/stats"
+            - "-n {{ .Release.Namespace }}"{{ if .Values.eventing.enabled }}
+            - "--aggregator-url=http://{{ .Release.Name }}-obs-callhome-stats:9090/stats"{{ end }}
             {{ if .Values.obs.callhome.sendReport }}
             - "--send-report"
             {{ end }}
@@ -54,7 +54,7 @@ spec:
             requests:
               cpu: {{ .Values.obs.callhome.resources.requests.cpu | quote }}
               memory: {{ .Values.obs.callhome.resources.requests.memory | quote }}
-        {{- if .Values.obs.callhome.enabled }}
+        {{- if .Values.eventing.enabled }}
         - name: obs-callhome-stats
           image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ .Chart.Name }}-obs-callhome-stats:{{ default .Values.image.tag .Values.image.repoTags.extensions }}"
           args:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This code enables the obs-callhome-stats container when eventing is enabled.

## Description
<!--- Describe your changes in detail -->
Before, the ops-stats-callhome container was enabled when the call home feature was activated. However, it's unnecessary for the container to run when eventing is disabled. To address this, I've introduced the appropriate condition to activate the stats container when eventing is enabled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested manually
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.