### PR TITLE
fix(upgrade-job): set defaults for absent helm values

### DIFF
--- a/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
@@ -31,6 +31,7 @@ pub(crate) struct CoreValues {
     /// This is the yaml object which contains the configuration for the io-engine DaemonSet.
     io_engine: IoEngine,
     /// This toggles installation of eventing components.
+    #[serde(default)]
     eventing: Eventing,
     /// This contains Kubernetes CSI sidecar container image details.
     csi: Csi,
@@ -111,8 +112,15 @@ impl IoEngine {
 
 /// This is used to deserialize the yaml object 'eventing', v2.3.0 has it disabled by default,
 /// the default thereafter has it enabled.
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 pub(crate) struct Eventing {
+    // This value is defaulted to 'false' when 'Eventing' is absent in the yaml.
+    // This works fine because we don't use the serde deserialized values during
+    // the values.yaml merge. The merge is done with 'yq'. These are assumed values,
+    // in case the value is absent (usually due to added features). This is used
+    // to compare against new values (those bundled with the chart in the upgrade-job's
+    // local filesystem) and decide if a yq 'set' is required. This default is not a
+    // fallback value that is set in case the user's value's yaml is missing the value.
     enabled: bool,
 }
 
@@ -161,7 +169,9 @@ impl Csi {
 pub(crate) struct CsiImage {
     provisioner_tag: String,
     attacher_tag: String,
+    #[serde(default)]
     snapshotter_tag: String,
+    #[serde(default)]
     snapshot_controller_tag: String,
     registrar_tag: String,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The upgrade-job parses few specific values from the source mayastor helm chart's values.yaml. These are used to make conditional value 'sets'. Usually these values would always be available in the target helm chart, but it may be absent in the source helm chart (as it may have been added during later releases). It has to assume sane defaults for these values, so that the parse operation does not fail for the source helm chart.

## Description
<!--- Describe your changes in detail -->
This PR sets default values for 'csi.image.snapshotterTag', 'csi.image.snapshotControllerTag' and 'eventing.enabled'.

**N.B.:**
These default values are not used in the final values set used with the helm upgrade. They are simply used to conveniently make decisions about 'special' yq set operations (e.g. changed default values, etc.). Values yaml for upgrade is generated using yq.