### PR TITLE
feat(snapshot, restore): prevent volume mode conversion for restore as default behaviour

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -94,6 +94,7 @@ $ helm install my-release openebs/mayastor
 | base.&ZeroWidthSpace;logSilenceLevel | Silence specific module components | `nil` |
 | base.&ZeroWidthSpace;metrics.&ZeroWidthSpace;enabled | Enable the metrics exporter | `true` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;logLevel | Log level for the csi controller | `"info"` |
+| csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;preventVolumeModeConversion | Prevent modifying the volume mode when creating a PVC from an existing VolumeSnapshot | `true` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;priorityClassName | Set PriorityClass, overrides global | `""` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for csi controller | `"32m"` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;memory | Memory limits for csi controller | `"128Mi"` |

--- a/chart/templates/mayastor/csi/csi-controller-deployment.yaml
+++ b/chart/templates/mayastor/csi/csi-controller-deployment.yaml
@@ -49,6 +49,9 @@ spec:
             - "--extra-create-metadata" # This is needed for volume group feature to work
             - "--timeout=36s"
             - "--worker-threads=10" # 10 for create and 10 for delete
+            {{- if default .Values.csi.controller.preventVolumeModeConversion }}
+            - "--prevent-volume-mode-conversion"
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -84,6 +87,9 @@ spec:
           args:
             - "--v=2"
             - "--leader-election=false" # since we are running single container
+            {{- if default .Values.csi.controller.preventVolumeModeConversion }}
+            - "--prevent-volume-mode-conversion"
+            {{- end }}
           image: "{{ .Values.csi.image.registry }}/{{ .Values.csi.image.repo }}/snapshot-controller:{{ .Values.csi.image.snapshotControllerTag }}"
           imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
         - name: csi-controller

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -293,6 +293,8 @@ csi:
     tolerations: []
     # -- Set PriorityClass, overrides global
     priorityClassName: ""
+    # -- Prevent modifying the volume mode when creating a PVC from an existing VolumeSnapshot
+    preventVolumeModeConversion: true
   node:
     logLevel: info
     topology:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
`--prevent-volume-mode-conversion`: Boolean that prevents an unauthorised user from modifying the volume mode when creating a PVC from an existing VolumeSnapshot. Only present as an alpha feature in v6.0.0 and above.

We enable the above flag on the csi-provisioner and the csi-snapshot-controller as a default behaviour.

## Motivation and Context
This change is needed so that the users cannot accidently change the volume mode, as changing mode from Block to Filesystem is destructive.

## Regression
No

## How Has This Been Tested?
This was tested manually. We would also add a bdd scenario to cover this in the e2e system tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.