### PR TITLE
Changes for testing 'upgrade' from develop branch

### DIFF
--- a/.github/workflows/main-chart.yml
+++ b/.github/workflows/main-chart.yml
@@ -11,21 +11,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: cachix/install-nix-action@v22
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
           echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
           nix-shell --pure --run "echo" ./scripts/helm/shell.nix
-      - name: Update loglevel to debug
+      - name: Update chart
         run: |
+          # Update logLevel to 'debug'
           sed -Ei "s~(logLevel: .*)~logLevel: debug~" chart/values.yaml
-      - name: Prepare chart for publishing
+          # Update repo url/name across all chart files
+          sed -i "s/mayastor-extensions/mayastor-chart-donotuse/g" chart/*.*
+      - name: Check if the chart is publishable
         run: |
           branch="${{ github.ref_name }}"
-          nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --app-tag  "0.0.0-$branch"" ./scripts/helm/shell.nix
+          nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --check-chart "$branch"" ./scripts/helm/shell.nix
       - name: Publish Mayastor Helm chart
         uses: stefanprodan/helm-gh-pages@v1.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           charts_dir: .
+          charts_url: https://openebs.github.io/mayastor-chart-donotuse
+          owner: openebs
+          repository: mayastor-chart-donotuse
+          branch: gh-pages

--- a/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
@@ -30,5 +30,8 @@ pub(crate) const UMBRELLA_CHART_UPGRADE_DOCS_URL: &str =
 /// This defines the range of helm chart versions for the 2.0 release of the Core helm chart.
 pub(crate) const TWO_DOT_O: &str = ">=2.0.0-rc.0, <2.1.0";
 
+/// This defines the range of helm chart versions 2.1 and higher, of the Core helm chart.
+pub(crate) const TWO_DOT_ONE_AND_UP: &str = ">=2.1.0";
+
 /// This defines the range of helm chart versions for the 2.3 release of the Core helm chart.
 pub(crate) const TWO_DOT_THREE: &str = ">=2.3.0-rc.0, <2.4.0";

--- a/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
@@ -43,6 +43,21 @@ impl CoreValues {
         self.image.tag()
     }
 
+    /// This is a getter for the control-plane repoTag image tag set on a helm chart.
+    pub(crate) fn control_plane_repotag(&self) -> &str {
+        self.image.control_plane_repotag()
+    }
+
+    /// This is a getter for the data-plane repoTag image tag set on a helm chart.
+    pub(crate) fn data_plane_repotag(&self) -> &str {
+        self.image.data_plane_repotag()
+    }
+
+    /// This is a getter for the extensions repoTag image tag set on a helm chart.
+    pub(crate) fn extensions_repotag(&self) -> &str {
+        self.image.extensions_repotag()
+    }
+
     /// This is a getter for the io-engine DaemonSet Pods' logLevel.
     pub(crate) fn io_engine_log_level(&self) -> &str {
         self.io_engine.log_level()
@@ -82,15 +97,66 @@ impl CoreValues {
 /// This is used to deserialize the yaml object "image", which contains details required for pulling
 /// container images.
 #[derive(Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
 pub(crate) struct Image {
     /// The container image tag.
     tag: String,
+    /// This contains image tags set based on which PRODUCT repository the microservice originates
+    /// from.
+    #[serde(default)]
+    repo_tags: RepoTags,
 }
 
 impl Image {
     /// This is a getter for the container image tag used across the helm chart release.
     pub(crate) fn tag(&self) -> &str {
         self.tag.as_str()
+    }
+
+    /// This is a getter for the control-plane repoTag set on a helm chart.
+    pub(crate) fn control_plane_repotag(&self) -> &str {
+        self.repo_tags.control_plane()
+    }
+
+    /// This is a getter for the data-plane repoTag set on a helm chart.
+    pub(crate) fn data_plane_repotag(&self) -> &str {
+        self.repo_tags.data_plane()
+    }
+
+    /// This is a getter for the extensions repoTag set on a helm chart.
+    pub(crate) fn extensions_repotag(&self) -> &str {
+        self.repo_tags.extensions()
+    }
+}
+
+/// This contains image tags for PRODUCT components based on the repository for the specific
+/// component.
+#[derive(Deserialize, Default)]
+#[serde(rename_all(deserialize = "camelCase"))]
+pub(crate) struct RepoTags {
+    /// This member of repoTags is used to set image tags for components from the control-plane
+    /// repo.
+    control_plane: String,
+    /// This member of repoTags is used to set image tags for components from the data-plane repo.
+    data_plane: String,
+    /// This member of repoTags is used to set image tags for components from the extensions repo.
+    extensions: String,
+}
+
+impl RepoTags {
+    /// This is a getter for the control-plane image tag set on a helm chart.
+    pub(crate) fn control_plane(&self) -> &str {
+        self.control_plane.as_str()
+    }
+
+    /// This is a getter for the data-plane image tag set on a helm chart.
+    pub(crate) fn data_plane(&self) -> &str {
+        self.data_plane.as_str()
+    }
+
+    /// This is a getter for the extensions image tag set on a helm chart.
+    pub(crate) fn extensions(&self) -> &str {
+        self.extensions.as_str()
     }
 }
 
@@ -121,6 +187,7 @@ pub(crate) struct Eventing {
     // to compare against new values (those bundled with the chart in the upgrade-job's
     // local filesystem) and decide if a yq 'set' is required. This default is not a
     // fallback value that is set in case the user's value's yaml is missing the value.
+    /// This enables eventing and components when enabled.
     enabled: bool,
 }
 
@@ -134,6 +201,7 @@ impl Eventing {
 /// This is used to deserialize the yaml object 'csi'.
 #[derive(Deserialize)]
 pub(crate) struct Csi {
+    /// This contains the image tags for the kubernetes-csi sidecar containers.
     image: CsiImage,
 }
 
@@ -164,15 +232,21 @@ impl Csi {
     }
 }
 
+/// This contains the image tags for the CSI sidecar containers.
 #[derive(Deserialize)]
 #[serde(rename_all(deserialize = "camelCase"))]
 pub(crate) struct CsiImage {
+    /// This is the image tag for the csi-provisioner container.
     provisioner_tag: String,
+    /// This is the image tag for the csi-attacher container.
     attacher_tag: String,
+    /// This is the image tag for the csi-snapshotter container.
     #[serde(default)]
     snapshotter_tag: String,
+    /// This is the image tag for the snapshot-controller container.
     #[serde(default)]
     snapshot_controller_tag: String,
+    /// This is the image tag for the csi-node-driver-registrar container.
     registrar_tag: String,
 }
 

--- a/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
@@ -183,6 +183,7 @@ impl HelmUpgradeBuilder {
             // Generate values yaml file for upgrade
             let _upgrade_values_file = generate_values_yaml_file(
                 &from_version,
+                &to_version,
                 chart_dir.as_path(),
                 &client,
                 release_name.clone(),

--- a/scripts/helm/test-publish-chart-yaml.sh
+++ b/scripts/helm/test-publish-chart-yaml.sh
@@ -25,6 +25,8 @@ CHECK_BRANCH=
 DATE_TIME=
 # Upgrade from develop to release/x.y*
 DEVELOP_TO_REL=
+# Upgrade from develop to main
+DEVELOP_TO_MAIN=
 # Tag that has been pushed
 APP_TAG=
 # Version from the Chart.yaml
@@ -36,13 +38,23 @@ NEW_CHART_VERSION=
 # Updated AppVersion from the Chart.yaml
 NEW_CHART_APP_VERSION=
 INDEX_CHART_VERSIONS=
+LATEST_RELEASE_BRANCH=
+BUMP_MAJOR_FOR_MAIN=
 EXPECT_FAIL=
 FAILED=
 
 build_output()
 {
   if [ -n "$CHECK_BRANCH" ]; then
-    if [ -n "$DEVELOP_TO_REL" ]; then
+    if [ -n "$DEVELOP_TO_MAIN" ]; then
+      cat <<EOF
+APP_TAG: $APP_TAG
+CHART_VERSION: $CHART_VERSION
+CHART_APP_VERSION: $CHART_APP_VERSION
+NEW_CHART_VERSION: $NEW_CHART_VERSION
+NEW_CHART_APP_VERSION: $NEW_CHART_APP_VERSION
+EOF
+    elif [ -n "$DEVELOP_TO_REL" ]; then
       cat <<EOF
 APP_TAG: $APP_TAG
 CHART_VERSION: $CHART_VERSION
@@ -89,6 +101,15 @@ call_script()
     ARGS="--check-chart $CHECK_BRANCH $ARGS"
     if [ -n "$DEVELOP_TO_REL" ]; then
       ARGS="--develop-to-release $ARGS"
+    fi
+    if [ -n "$DEVELOP_TO_MAIN" ]; then
+      ARGS="--develop-to-main $ARGS"
+    fi
+    if [ -n "$LATEST_RELEASE_BRANCH" ]; then
+      ARGS="--latest-release-branch $LATEST_RELEASE_BRANCH $ARGS"
+      if [ "$BUMP_MAJOR_FOR_MAIN" = "true" ]; then
+        ARGS="--bump-major-for-main $ARGS"
+      fi
     fi
   else
     ARGS="--app-tag $APP_TAG $ARGS"
@@ -140,12 +161,15 @@ test_one()
   CHECK_BRANCH=
   DATE_TIME=
   DEVELOP_TO_REL=
+  DEVELOP_TO_MAIN=
   APP_TAG=
   CHART_VERSION=
   CHART_APP_VERSION=
   INDEX_CHART_VERSIONS=
   NEW_CHART_VERSION=
   NEW_CHART_APP_VERSION=
+  LATEST_RELEASE_BRANCH=
+  BUMP_MAJOR_FOR_MAIN=
   EXPECT_FAIL=
 }
 
@@ -157,15 +181,84 @@ test_one "Develop is special"
 
 CHECK_BRANCH=main
 DATE_TIME=$(date +"$DATE_TIME_FMT")
-APP_TAG=0.0.0-$DATE_TIME
+LATEST_RELEASE_BRANCH="release/123.456"
+BUMP_MAJOR_FOR_MAIN="false"
+APP_TAG=123.457.0-0-main-unstable-$DATE_TIME-0
 CHART_VERSION=0.0.0
 CHART_APP_VERSION=0.0.0
 test_one "Main is special"
 
 CHECK_BRANCH=main
-APP_TAG=0.0.0-main
+DATE_TIME=$(date +"$DATE_TIME_FMT")
+LATEST_RELEASE_BRANCH="release/123.456"
+BUMP_MAJOR_FOR_MAIN="true"
+APP_TAG=124.0.0-0-main-unstable-$DATE_TIME-0
 CHART_VERSION=0.0.0
 CHART_APP_VERSION=0.0.0
+test_one "Main is special"
+
+CHECK_BRANCH=main
+DEVELOP_TO_MAIN=1
+DATE_TIME=$(date +"$DATE_TIME_FMT")
+LATEST_RELEASE_BRANCH="release/123.456"
+BUMP_MAJOR_FOR_MAIN="false"
+APP_TAG=123.457.0-0-main-unstable-$DATE_TIME-0
+CHART_VERSION=0.0.0
+CHART_APP_VERSION=0.0.0
+NEW_CHART_VERSION=123.457.0-0-main-unstable-$DATE_TIME-0
+NEW_CHART_APP_VERSION=123.457.0-0-main-unstable-$DATE_TIME-0
+test_one "Main is special"
+
+CHECK_BRANCH=main
+DEVELOP_TO_MAIN=1
+DATE_TIME=$(date +"$DATE_TIME_FMT")
+LATEST_RELEASE_BRANCH="release/123.456"
+BUMP_MAJOR_FOR_MAIN="true"
+APP_TAG=124.0.0-0-main-unstable-$DATE_TIME-0
+CHART_VERSION=0.0.0
+CHART_APP_VERSION=0.0.0
+NEW_CHART_VERSION=124.0.0-0-main-unstable-$DATE_TIME-0
+NEW_CHART_APP_VERSION=124.0.0-0-main-unstable-$DATE_TIME-0
+test_one "Main is special"
+
+CHECK_BRANCH=main
+LATEST_RELEASE_BRANCH="release/123.456"
+BUMP_MAJOR_FOR_MAIN="false"
+APP_TAG=123.457.0-0-main-unstable-main-0
+CHART_VERSION=0.0.0
+CHART_APP_VERSION=0.0.0
+test_one "Main is special"
+
+CHECK_BRANCH=main
+LATEST_RELEASE_BRANCH="release/123.456"
+BUMP_MAJOR_FOR_MAIN="true"
+APP_TAG=124.0.0-0-main-unstable-main-0
+CHART_VERSION=0.0.0
+CHART_APP_VERSION=0.0.0
+test_one "Main is special"
+
+CHECK_BRANCH=main
+DEVELOP_TO_MAIN=1
+LATEST_RELEASE_BRANCH="release/123.456"
+BUMP_MAJOR_FOR_MAIN="false"
+APP_TAG=123.457.0-0-main-unstable-main-0
+CHART_VERSION=0.0.0
+CHART_APP_VERSION=0.0.0
+NEW_CHART_VERSION=123.457.0-0-main-unstable-main-0
+NEW_CHART_APP_VERSION=123.457.0-0-main-unstable-main-0
+EXPECT_FAIL=1
+test_one "Main is special"
+
+CHECK_BRANCH=main
+DEVELOP_TO_MAIN=1
+LATEST_RELEASE_BRANCH="release/123.456"
+BUMP_MAJOR_FOR_MAIN="true"
+APP_TAG=124.0.0-0-main-unstable-main-0
+CHART_VERSION=0.0.0
+CHART_APP_VERSION=0.0.0
+NEW_CHART_VERSION=124.0.0-0-main-unstable-main-0
+NEW_CHART_APP_VERSION=124.0.0-0-main-unstable-main-0
+EXPECT_FAIL=1
 test_one "Main is special"
 
 CHECK_BRANCH=release/2.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Upgrade e2e tests are run as a part of release/x.y branches, but not develop or main. This change modifies the chart that is posted to the 'main' branch, and this chart should qualify as a valid target helm chart for upgrade, thus allowing testing code from develop (main branch uses code from develop at a set frequency).

The intention is to be able to upgrade from a released version to develop or main.

## Description
<!--- Describe your changes in detail -->
Changes to upgrade code:
- Adds support for parsing repotags in the upgrade-job::helm::chart module
- Adds default set options for setting repotags along with image tags. This is required because the main branch chart uses `image.repoTags` instead of `image.tag`.

Changes to publish_chart_yaml.sh script:
- Changes appVersion and version set when generating main branch chart (using the `--develop-to-main` flag) from `0.0.0-main` to the likes of `2.5.0-0-develop-unstable-2023-09-24-19-55-15-0`, where 2.5.0 is semver minor bump from the latest possible release (based on existing release/x.y branches on openebs/mayastor-extensions), and 2023-09-24-19-55-15 is a timestamp generated from  the command`date +%Y-%m-%d-%H-%M-%S`.
- Latest release branch name can be input to the script using the `--latest-release-branch <branch_name>` option. The default value is generated from git remote refs from the git repo. To use the default branch-name generation, all refs from the remote repo openebs/mayastor-extensions must be pulled in (e.g. `git fetch origin` where origin is the remote entry for the openebs/mayastor-extensions repo)
- Bump to the latest is set to minor version by-default. The `--bump-major-for-main` bumps the major version instead, if and when the version bump needs to be a major one.

GitHub Actions changes:
- Remove the publish step for the main branch helm chart workflow. This is no longer required as helm charts on the main branch will be versioned (the `-main` suffix will no longer have any use) and the charts will be hosted on the https://github.com/openebs/mayastor-chart-donotuse repo.
- Use `--check-chart` to run a basic sanity test, like the one for the develop-chart actions workflow.

### This change adds two major use cases for the publish_chart_yaml.sh script:
1. Generate the main branch helm chart from the develop branch helm chart (used in CI) using  
```console
./scripts/helm/publish_chart_yaml.sh \
        --check-chart main \
        --develop-to-main \
        --date-time $(date +%Y-%m-%d-%H-%M-%S)
```
2. Use it to sanitize changes to the chart using `./scripts/helm/publish_chart_yaml.sh --check-chart main`. This is minor use-case, This does not do a good job of validating the chart version/appVersion, etc.

Tested manually.