### PR TITLE
fix: /var/local paths should be under release name

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -122,7 +122,7 @@ $ helm install my-release openebs/mayastor
 | etcd.&ZeroWidthSpace;autoCompactionMode | AutoCompaction Since etcd keeps an exact history of its keyspace, this history should be periodically compacted to avoid performance degradation and eventual storage space exhaustion. Auto compaction mode. Valid values: "periodic", "revision". - 'periodic' for duration based retention, defaulting to hours if no time unit is provided (e.g. 5m). - 'revision' for revision number based retention. | `"revision"` |
 | etcd.&ZeroWidthSpace;autoCompactionRetention | Auto compaction retention length. 0 means disable auto compaction. | `100` |
 | etcd.&ZeroWidthSpace;extraEnvVars[0] | Raise alarms when backend size exceeds the given quota. | <pre>{<br>"name":"ETCD_QUOTA_BACKEND_BYTES",<br>"value":"8589934592"<br>}</pre> |
-| etcd.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;basePath | Host path where local etcd data is stored in. | `"/var/local/localpv-hostpath/{{ .Release.Name }}/etcd"` |
+| etcd.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;basePath | Host path where local etcd data is stored in. | `"/var/local/{{ .Release.Name }}/localpv-hostpath/etcd"` |
 | etcd.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;reclaimPolicy | ReclaimPolicy of etcd's localpv hostpath storage class. | `"Delete"` |
 | etcd.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;volumeBindingMode | VolumeBindingMode of etcd's localpv hostpath storage class. | `"WaitForFirstConsumer"` |
 | etcd.&ZeroWidthSpace;persistence.&ZeroWidthSpace;enabled | If true, use a Persistent Volume Claim. If false, use emptyDir. | `true` |
@@ -153,7 +153,7 @@ $ helm install my-release openebs/mayastor
 | io_engine.&ZeroWidthSpace;tolerations | Set tolerations, overrides global | `[]` |
 | localpv-provisioner.&ZeroWidthSpace;enabled | Enables the openebs dynamic-localpv provisioner. If disabled, modify etcd and loki-stack storage class accordingly. | `true` |
 | loki-stack.&ZeroWidthSpace;enabled | Enable loki log collection for our components | `true` |
-| loki-stack.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;basePath | Host path where local etcd data is stored in. | `"/var/local/localpv-hostpath/{{ .Release.Name }}/loki"` |
+| loki-stack.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;basePath | Host path where local etcd data is stored in. | `"/var/local/{{ .Release.Name }}/localpv-hostpath/loki"` |
 | loki-stack.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;reclaimPolicy | ReclaimPolicy of loki's localpv hostpath storage class. | `"Delete"` |
 | loki-stack.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;volumeBindingMode | VolumeBindingMode of loki's localpv hostpath storage class. | `"WaitForFirstConsumer"` |
 | loki-stack.&ZeroWidthSpace;loki.&ZeroWidthSpace;enabled | Enable loki installation as part of loki-stack | `true` |

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -90,10 +90,10 @@ spec:
         - "-g$(MY_POD_IP)"
         - "-N$(MY_NODE_NAME)"
         - "-Rhttps://{{ .Release.Name }}-agent-core:50051"
-        - "-y/var/local/io-engine/config.yaml"
+        - "-y/var/local/{{ .Release.Name }}/io-engine/config.yaml"
         - "-l{{ include "cpuFlag" . }}"
         - "-p={{ .Release.Name }}-etcd:{{ .Values.etcd.service.port }}"{{ if .Values.io_engine.target.nvmf.ptpl }}
-        - "--ptpl-dir=/var/local/io-engine/ptpl/"{{ end }}
+        - "--ptpl-dir=/var/local/{{ .Release.Name }}/io-engine/ptpl/"{{ end }}
         - "--api-versions={{ .Values.io_engine.api }}"{{ if .Values.io_engine.target.nvmf.iface }}
         - "-T={{ .Values.io_engine.target.nvmf.iface }}"{{ end }}{{ if .Values.io_engine.envcontext }}
         - "--env-context=--{{ .Values.io_engine.envcontext }}"{{ end }}{{ if .Values.io_engine.reactorFreezeDetection.enabled }}
@@ -111,7 +111,7 @@ spec:
         - name: dshm
           mountPath: /dev/shm
         - name: configlocation
-          mountPath: /var/local/io-engine/
+          mountPath: /var/local/{{ .Release.Name }}/io-engine/
         - name: hugepage
           mountPath: /dev/hugepages
         resources:
@@ -145,5 +145,5 @@ spec:
           medium: HugePages
       - name: configlocation
         hostPath:
-          path: /var/local/io-engine/
+          path: /var/local/{{ .Release.Name }}/io-engine/
           type: DirectoryOrCreate

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -386,7 +386,7 @@ etcd:
     # Name of etcd's localpv hostpath storage class.
     name: "mayastor-etcd-localpv"
     # -- Host path where local etcd data is stored in.
-    basePath: "/var/local/localpv-hostpath/{{ .Release.Name }}/etcd"
+    basePath: "/var/local/{{ .Release.Name }}/localpv-hostpath/etcd"
     # -- ReclaimPolicy of etcd's localpv hostpath storage class.
     reclaimPolicy: Delete
     # -- VolumeBindingMode of etcd's localpv hostpath storage class.
@@ -486,7 +486,7 @@ loki-stack:
     # Name of loki's localpv hostpath storage class.
     name: "mayastor-loki-localpv"
     # -- Host path where local etcd data is stored in.
-    basePath: "/var/local/localpv-hostpath/{{ .Release.Name }}/loki"
+    basePath: "/var/local/{{ .Release.Name }}/localpv-hostpath/loki"
     # -- ReclaimPolicy of loki's localpv hostpath storage class.
     reclaimPolicy: Delete
     # -- VolumeBindingMode of loki's localpv hostpath storage class.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently we use `/var/local/io-engine` and `/var/local/local-pv-hostpath/{{ .Release.Name }}`
This is a bit too spread we should bundle it all within a common `/var/local/{{ .Release.Name }}` example:-
`/var/local/{{ .Release.Name }}/{io-engine, localpv-hostpath}`

This PR changes the helm chart to include this.

## Motivation and Context

## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> No

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.