### PR TITLE
feat(loki): adding multiline support

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -586,6 +586,15 @@ loki-stack:
           - job_name: {{ .Release.Name }}-pods-name
             pipeline_stages:
               - docker: {}
+              - replace:
+                  expression: '(\n)'
+                  replace: ""
+              - multiline:
+                  firstline: '^  \x1b\[2m(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{6})Z'
+                  max_wait_time: 3s
+              - multiline:
+                  firstline: '^  (\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{6})Z'
+                  max_wait_time: 3s
             kubernetes_sd_configs:
             - role: pod
             relabel_configs:


### PR DESCRIPTION
With multiline support we define starting point of the log block when it gets filtered through `logcli` parameter. 

Every log that we stdout starts with timestamp(with ansi color char now by default) . In Regex1 , `\x1b\[2m` matches colour unicode pattern. logger adds 2 zero width space also hence Regex has space to match.

 We might have uncolored timestamp in future. So In Regex2, we handle that scenario.

Regex1: '^  \x1b\[2m(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{6})Z'

Regex2 : '^  (\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{6})Z'