### PR TITLE
feat(charts): version main branch chart with 2.5.0-alpha.main 

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.0
+version: 2.5.0-alpha.main
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.0"
+appVersion: "2.5.0-alpha.main"
 
 dependencies:
   - name: etcd

--- a/chart/README.md
+++ b/chart/README.md
@@ -2,7 +2,7 @@
 
 Mayastor Helm chart for Kubernetes
 
-![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 2.5.0-alpha.main](https://img.shields.io/badge/Version-2.5.0--alpha.main-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0-alpha.main](https://img.shields.io/badge/AppVersion-2.5.0--alpha.main-informational?style=flat-square)
 
 ## Installation Guide
 

--- a/chart/doc.yaml
+++ b/chart/doc.yaml
@@ -8,7 +8,7 @@ repository:
   name: mayastor
 chart:
   name: mayastor
-  version: 0.0.0
+  version: 2.5.0-alpha.main
   values: "-- generate from values file --"
   valuesExample: "-- generate from values file --"
 prerequisites:


### PR DESCRIPTION
This PR changes the helm chart version on the `main` branch from 0.0.0 to 2.5.0-alpha.main.