### PR TITLE
fix(publish_chart): support git remote URLs with '.git' at the end of it

### DIFF
--- a/scripts/helm/publish-chart-yaml.sh
+++ b/scripts/helm/publish-chart-yaml.sh
@@ -34,7 +34,7 @@ latest_release_branch() {
   local openebs_remote=""
   for remote in $(git remote show); do
     remote_url=$(git ls-remote --get-url $remote)
-    if [[ "$remote_url" =~ ([\/:]openebs\/mayastor-extensions)$ ]]; then
+    if [[ "$remote_url" =~ ([\/:]openebs\/mayastor-extensions(.git)?)$ ]]; then
       openebs_remote=$remote
       break
     fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Whenever the `--check-chart main` option is used with the script scripts/helm/publish_chart_yaml.sh, it lists the URLs for all of the remote refs available. The name of the first remote ref URL matching the URL to this repo (openebs/mayastor-extensions) is picked up. This uses a regex which expects 'openebs/mayastor-extensions' at the end of the URL. However, some folks may use a '.git' at the end of their remote ref URLs. The regex doesn't account for this possibility.

## Description
<!--- Describe your changes in detail -->
Covers the case for an optional .git at the end of the remote ref for openebs/mayastor-extensions repo.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helm-core uses a .git. Helm-core is the main consumer for this script's 'main' branch chart features.

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
No
<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->
