### PR TITLE
fix(upgrade-job): remove short args to resolve conflict over '-h' option

### DIFF
--- a/k8s/upgrade/src/bin/upgrade-job/opts.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/opts.rs
@@ -41,12 +41,12 @@ pub(crate) struct CliArgs {
 
     /// The set values specified by the user for upgrade
     /// (can specify multiple or separate values with commas: key1=val1,key2=val2).
-    #[arg(short, long)]
+    #[arg(long)]
     helm_args_set: String,
 
     /// The set file values specified by the user for upgrade
     /// (can specify multiple or separate values with commas: key1=path1,key2=path2).
-    #[arg(short, long)]
+    #[arg(long)]
     helm_args_set_file: String,
 }
 


### PR DESCRIPTION
Two clap args introduced in https://github.com/openebs/mayastor-extensions/pull/330 make use the short form option argument. These two arguments -- 'helm_args_set' and 'helm_args_set_file' begin with 'h'. Both of these two args, as well the '--help' option try to make use of '-h'. This change removes the short form arg for these two args.

<!--- Provide a general summary of your changes in the Title above -->
Remove short args for 'helm_args_set' and 'helm_args_set_file' CliArgs.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`upgrade-job -h` fails.

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
Yes.
<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->
 Fixes a regression introduced in  https://github.com/openebs/mayastor-extensions/pull/330
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Trivial change, tested the successful execution of `upgrade-job -h`.
