### PR TITLE
feat(publish_chart): relax prerel absent check for existing chart

### DIFF
--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -43,7 +43,10 @@ let
 
     # if tag is not semver just keep whatever is checked-in
     # todo: handle this properly?
-    if [ "$(semver validate ${tag})" = "valid" ]; then
+    # Script doesn't need to be used with main branch `--alias-tag <main-branch-style-tag>`.
+    # The repo chart is already prepared.
+    if [[ "$(semver validate ${tag})" == "valid" ]] &&
+      [[ ! ${tag} =~ ^([0-9]+\.[0-9]+\.[0-9]+-0-main-unstable(-[0-9]+){6}-0)$ ]]; then
       CHART_FILE=build/chart/Chart.yaml build/scripts/helm/publish-chart-yaml.sh --app-tag ${tag} --override-index ""
     fi
     chmod -w build/chart


### PR DESCRIPTION
For all branches, except for the main branch if '--app-tag <tag>' is set the script fails if the existing version and appVersion of the helm chart on the branch contains a tag with a prerelase extensions. This check makes sense, however, the main branch will always have a prerelase tag. This change relaxes the check for specific chart versions which match the unmistakable main branch version tags.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes:
- Ignore prerel check if existing chart version matches the regex for the main branch chart.
- Ignore prerel check if existing chart appVersion matches the regex for the main branch chart.
- Allow for all kinds of diff amongst the APP_TAG, CHART_VERSION, CHART_APP_VERSION for not only `--check-chart main`, but also `--app-tag <main-branch-style-tag>`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helm core

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
No.
<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using the test script.