### PR TITLE
chore(chart): bump snapshot and registrar csi sidecar versions

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -104,11 +104,11 @@ $ helm install my-release openebs/mayastor
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;attacherTag | csi-attacher image release tag | `"v4.3.0"` |
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;provisionerTag | csi-provisioner image release tag | `"v3.5.0"` |
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;pullPolicy | imagePullPolicy for all CSI Sidecar images | `"IfNotPresent"` |
-| csi.&ZeroWidthSpace;image.&ZeroWidthSpace;registrarTag | csi-node-driver-registrar image release tag | `"v2.8.0"` |
+| csi.&ZeroWidthSpace;image.&ZeroWidthSpace;registrarTag | csi-node-driver-registrar image release tag | `"v2.9.0"` |
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;registry | Image registry to pull all CSI Sidecar images | `"registry.k8s.io"` |
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;repo | Image registry's namespace | `"sig-storage"` |
-| csi.&ZeroWidthSpace;image.&ZeroWidthSpace;snapshotControllerTag | csi-snapshot-controller image release tag | `"v6.2.1"` |
-| csi.&ZeroWidthSpace;image.&ZeroWidthSpace;snapshotterTag | csi-snapshotter image release tag | `"v6.2.1"` |
+| csi.&ZeroWidthSpace;image.&ZeroWidthSpace;snapshotControllerTag | csi-snapshot-controller image release tag | `"v6.3.1"` |
+| csi.&ZeroWidthSpace;image.&ZeroWidthSpace;snapshotterTag | csi-snapshotter image release tag | `"v6.3.1"` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;kubeletDir | The kubeletDir directory for the csi-node plugin | `"/var/lib/kubelet"` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;nvme.&ZeroWidthSpace;ctrl_loss_tmo | The ctrl_loss_tmo (controller loss timeout) in seconds | `"1980"` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;nvme.&ZeroWidthSpace;io_timeout | The nvme_core module io timeout in seconds | `"30"` |

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -269,11 +269,11 @@ csi:
     # -- csi-attacher image release tag
     attacherTag: v4.3.0
     # -- csi-snapshotter image release tag
-    snapshotterTag: v6.2.1
+    snapshotterTag: v6.3.1
     # -- csi-snapshot-controller image release tag
-    snapshotControllerTag: v6.2.1
+    snapshotControllerTag: v6.3.1
     # -- csi-node-driver-registrar image release tag
-    registrarTag: v2.8.0
+    registrarTag: v2.9.0
 
   controller:
     # -- Log level for the csi controller


### PR DESCRIPTION
This bumps the csi sidecars for external-snapshotter and node-driver-registrar to minimum versions which support csi spec v1.8.0. The other sidecars are at par.