### PR TITLE
feat(eventing): update events-cache missing fields from events-store with default values

### DIFF
--- a/call-home/src/bin/stats/cache/events_cache.rs
+++ b/call-home/src/bin/stats/cache/events_cache.rs
@@ -14,6 +14,7 @@ static CACHE: OnceCell<Mutex<Cache>> = OnceCell::new();
 
 /// EventSet captures the type of events.
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[serde(default)]
 pub struct EventSet {
     pub(crate) pool: pools::Pool,
     pub(crate) volume: volume::Volume,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When upgrading Mayastor 2.4 to develop the stats events-cache fails to initialise from events-store config map because the events-store does not have the nexus event-data and the stats container fails.
Added #[serde(default)] to the events-cache to initialise the events-cache with default values if the events-store misses any keys(nexus). 

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually tested.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.