### PR TITLE
ci: ensure released binaries are executable 

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -45,8 +45,11 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: |
           nix-build -A utils.release.${{ matrix.target }}.kubectl-plugin --arg incremental false ${{ matrix.system }}
+      - name: Archive executable
+        run: |
+          tar -czvf kubectl-mayastor-${{ matrix.arch }}-${{ matrix.target }}.tar.gz -C result/bin kubectl-mayastor${{ matrix.suffix }}
       - uses: actions/upload-artifact@v3
         with:
           name: kubectl-mayastor-${{ matrix.arch }}-${{ matrix.target }}
-          path: ./result/bin/kubectl-mayastor${{ matrix.suffix }}
+          path: kubectl-mayastor-${{ matrix.arch }}-${{ matrix.target }}.tar.gz
           if-no-files-found: error


### PR DESCRIPTION

## Description

Ensure released binaries are executable.

## Motivation and Context

Removes the need to `chmod +x` after downloading. Also, allows this to be added to the `krew-index` for easy installation.


## Regression

No.

## How Has This Been Tested?

Ran CI on my fork. There doesn't seem to be a step which uploads the artifacts to the GitHub release though.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.