### PR TITLE
chore(deps): update k8s-openapi lib version to v1_25

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "dependencies/control-plane"]
 	path = dependencies/control-plane
 	url = https://github.com/openebs/mayastor-control-plane.git
-	branch = develop
+	branch = kube-v1_25

--- a/call-home/Cargo.toml
+++ b/call-home/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/bin/stats/main.rs"
 [dependencies]
 openapi = {path = "../dependencies/control-plane/openapi"}
 kube = { version = "0.85.0", features = ["runtime", "derive"] }
-k8s-openapi = { version = "0.19.0", features = ["v1_20"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
 futures = "0.3.28"
 tokio = { version = "1.33.0", features = ["full"] }
 clap = { version = "4.4.6", features = ["cargo", "derive", "string"] }

--- a/k8s/supportability/Cargo.toml
+++ b/k8s/supportability/Cargo.toml
@@ -17,7 +17,7 @@ tls = [ "openapi/tower-client-tls" ]
 [dependencies]
 futures = "0.3"
 tokio = { version = "1.33.0", features = ["full"] }
-k8s-openapi = { version = "0.19.0", features = ["v1_20"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
 kube = { version = "0.85.0", features = ["derive"] }
 yaml-rust = { version = "0.4" }
 clap = { version = "4.4.6", features = ["color", "derive"] }

--- a/k8s/upgrade/Cargo.toml
+++ b/k8s/upgrade/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1.0.75"
 clap = { version = "4.4.6", features = ["derive", "env", "string", "color"] }
 humantime = "2.1.0"
 maplit = "1.0.2"
-k8s-openapi = { version = "0.19.0", features = ["v1_20"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
 tower = { version = "0.4.13", features = [ "timeout", "util" ] }
 hyper = { version = "0.14.27", features = [ "client", "http1", "http2", "tcp", "stream" ] }
 http = "0.2.9"


### PR DESCRIPTION
Updates the kubernetes openapi libraries to those compatible with kubernetes v1.25.