### PR TITLE
Modify github action and publish-chart-yaml.sh to support helm-testing/<release> branches

### DIFF
--- a/.github/workflows/main-chart.yml
+++ b/.github/workflows/main-chart.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'helm-testing/**'
     paths:
       - 'chart/**'
 

--- a/scripts/helm/test-publish-chart-yaml.sh
+++ b/scripts/helm/test-publish-chart-yaml.sh
@@ -261,6 +261,12 @@ NEW_CHART_APP_VERSION=124.0.0-0-main-unstable-main-0
 EXPECT_FAIL=1
 test_one "Main is special"
 
+CHECK_BRANCH=helm-testing/2.4
+APP_TAG=2.4.0
+CHART_VERSION=2.4.0
+CHART_APP_VERSION=2.4.0
+test_one "helm-testing/<release> is special"
+
 CHECK_BRANCH=release/2.0
 APP_TAG=2.0.0
 CHART_VERSION=2.0.0


### PR DESCRIPTION
Modify github action and publish-chart-yaml.sh to support helm-testing/* branches


## Description
- Modify github action  to support helm-testing/* branches created for release branches
- Modify publish-chart-yaml.sh to support helm-testing/* branches 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change will publish helm chart to system test helm registry for release branches

## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> No

## How Has This Been Tested? 
Tested locally 

