### PR TITLE
Build aarch64-linux binaries for the kubectl-plugin

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -17,6 +17,9 @@ jobs:
           - os: ubuntu-latest
             target: linux-musl
             arch: x86_64
+          - os: ubuntu-latest
+            target: linux-musl
+            arch: aarch64
           - os: macos-latest
             target: apple-darwin
             arch: x86_64
@@ -38,13 +41,12 @@ jobs:
       - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos
-          extra_nix_config: extra-platforms = aarch64-darwin
       - uses: cachix/cachix-action@v12
         with:
           name: mayastor-extensions
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: |
-          nix-build -A utils.release.${{ matrix.target }}.kubectl-plugin --arg incremental false ${{ matrix.system }}
+          nix-build -A utils.release.${{ matrix.arch }}.${{ matrix.target }}.kubectl-plugin --arg incremental false ${{ matrix.system }}
       - name: Archive executable
         run: |
           tar -czvf kubectl-mayastor-${{ matrix.arch }}-${{ matrix.target }}.tar.gz LICENSE -C result/bin kubectl-mayastor${{ matrix.suffix }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "local-channel"
@@ -2886,9 +2886,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags 2.4.0",
  "errno",

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@ let
   sources = import ./nix/sources.nix;
   hostSystem = (import sources.nixpkgs { }).hostPlatform.system;
   pkgs = import sources.nixpkgs {
-    overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix { inherit allInOne incremental img_tag tag; }) ];
+    overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix { inherit allInOne incremental img_tag tag; }) (import sources.rust-overlay) ];
     system = if system != null then system else hostSystem;
   };
 in

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -1,12 +1,9 @@
-{ sources ? import ../sources.nix }:
+{ pkgs }:
 let
-  pkgs =
-    import sources.nixpkgs { overlays = [ (import sources.rust-overlay) ]; };
-  makeRustTarget = platform: pkgs.rust.toRustTargetSpec platform;
-  static_target = makeRustTarget pkgs.pkgsStatic.stdenv.hostPlatform;
+  lib = pkgs.lib;
 in
 rec {
-  inherit makeRustTarget;
+  makeRustTarget = platform: pkgs.rust.toRustTargetSpec platform;
   rust_default = { override ? { } }: rec {
     nightly_pkg = pkgs.rust-bin.nightly."2023-08-10";
     stable_pkg = pkgs.rust-bin.stable."1.71.1";
@@ -21,11 +18,77 @@ rec {
   default_src = rust_default {
     override = { extensions = [ "rust-src" ]; };
   };
-  static = { target ? makeRustTarget pkgs.pkgsStatic.stdenv.hostPlatform }: rust_default {
+  static-arch = { target }: rust_default {
     override = { targets = [ "${target}" ]; };
   };
-  hostStatic = rust_default { override = { targets = [ "${makeRustTarget pkgs.pkgsStatic.stdenv.hostPlatform}" ]; }; };
-  windows_cross = rust_default {
-    override = { targets = [ "${pkgs.rust.toRustTargetSpec pkgs.pkgsCross.mingwW64.hostPlatform}" ]; };
+
+  rustPlatformDeps = { target, sources }: rec {
+    naersk_package = channel: pkgs.callPackage sources.naersk {
+      rustc = channel.stable;
+      cargo = channel.stable;
+    };
+    os = platform: builtins.replaceStrings [ "${platform.qemuArch}-" ] [ "" ] platform.system;
+    hostPlatform = "${pkgs.rust.toRustTargetSpec pkgs.pkgsStatic.hostPlatform}";
+    targetPlatform = "${pkgs.rust.toRustTargetSpec pkgs.pkgsCross."${target}".hostPlatform}";
+    pkgsTarget = if hostPlatform == targetPlatform then pkgs.pkgsStatic else pkgs.pkgsCross."${target}";
+    pkgsTargetNative = if hostPlatform == targetPlatform then pkgs else if hostOs == targetOs then
+      import sources.nixpkgs
+        {
+          config = { };
+          overlays = [ ];
+          system = "${pkgsTarget.system}";
+        } else pkgs.pkgsCross."${target}";
+    hostOs = os pkgs.hostPlatform;
+    targetOs = os pkgs.pkgsCross."${target}".hostPlatform;
+    naersk = naersk_package (static-arch {
+      target = targetPlatform;
+    });
+    targetUpper = lib.toUpper (
+      builtins.replaceStrings [ "-" ] [ "_" ] targetPlatform
+    );
+    check_assert =
+      if (targetOs == "darwin") then
+        if hostPlatform != targetPlatform
+        # maybe can be achieved used unstable-pkgs until the fixes drop on the stable channel/release.
+        then lib.asserts.assertMsg (false) "Cross-compiling on darwin not supported yet"
+        else lib.asserts.assertMsg (pkgs.hostPlatform.isDarwin) "This may only be built on Darwin"
+      else lib.asserts.assertMsg (pkgs.hostPlatform.isLinux) "This may only be built on Linux";
+  };
+  rustBuilderOpts = { rustPlatformDeps }: rustPlatformDeps // {
+    preBuild = lib.optionalString (rustPlatformDeps.pkgsTarget.hostPlatform.isWindows) ''
+      export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS="-C link-args=''$(echo $NIX_LDFLAGS | tr ' ' '\n' | grep -- '^-L' | tr '\n' ' ')"
+      export NIX_LDFLAGS=
+      export NIX_LDFLAGS_FOR_BUILD=
+    '';
+    addPreBuild = "";
+    nativeBuildInputs = with pkgs;
+      [ pkgconfig protobuf openapi-generator which git ] ++
+        [ rustPlatformDeps.pkgsTarget.stdenv.cc ] ++
+        lib.optional (rustPlatformDeps.pkgsTarget.hostPlatform.isDarwin)
+          [
+            (rustPlatformDeps.pkgsTarget.libiconv.override {
+              enableStatic = true;
+              enableShared = false;
+            })
+          ];
+    addNativeBuildInputs = [ ];
+    buildInputs = if (rustPlatformDeps.pkgsTarget.hostPlatform.isWindows) then with rustPlatformDeps.pkgsTargetNative.windows; [ mingw_w64_pthreads pthreads ] else [ ];
+  };
+  rustPackageBuilder = { rustBuildOpts, name, src, release, version, singleStep, GIT_VERSION, GIT_VERSION_LONG }: rustBuildOpts.naersk.buildPackage {
+    inherit name release src version singleStep GIT_VERSION_LONG GIT_VERSION;
+
+    preBuild = rustBuildOpts.preBuild + rustBuildOpts.addPreBuild;
+    cargoBuildOptions = attrs: attrs ++ rustBuildOpts.buildOptions;
+    nativeBuildInputs = rustBuildOpts.nativeBuildInputs ++ rustBuildOpts.addNativeBuildInputs;
+    buildInputs = rustBuildOpts.buildInputs;
+
+    doCheck = false;
+    check_assert = rustBuildOpts.check_assert;
+    usePureFromTOML = true;
+    CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+    CARGO_BUILD_TARGET = rustBuildOpts.targetPlatform;
+    "CARGO_TARGET_${rustBuildOpts.targetUpper}_LINKER" = with rustBuildOpts.pkgsTarget.stdenv;
+      if (rustBuildOpts.check_assert) then "${cc}/bin/${cc.targetPrefix}cc" else null;
+    #${if pkgs.hostPlatform.isDarwin then "LIBCLANG_PATH" else null} = "${rustBuildOpts.pkgsTarget.llvmPackages.libclang.lib}/lib";
   };
 }

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -48,11 +48,11 @@ rec {
     );
     check_assert =
       if (targetOs == "darwin") then
-        if hostPlatform != targetPlatform
+        if hostOs == "darwin" && hostPlatform != targetPlatform
         # maybe can be achieved used unstable-pkgs until the fixes drop on the stable channel/release.
         then lib.asserts.assertMsg (false) "Cross-compiling on darwin not supported yet"
-        else lib.asserts.assertMsg (pkgs.hostPlatform.isDarwin) "This may only be built on Darwin"
-      else lib.asserts.assertMsg (pkgs.hostPlatform.isLinux) "This may only be built on Linux";
+        else lib.asserts.assertMsg (pkgs.hostPlatform.isDarwin) "${targetOs} binaries can only be built on darwin (ie not ${hostOs})"
+      else lib.asserts.assertMsg (pkgs.hostPlatform.isLinux) "${targetOs} binaries can only be built on linux (ie not ${hostOs})";
   };
   rustBuilderOpts = { rustPlatformDeps }: rustPlatformDeps // {
     preBuild = lib.optionalString (rustPlatformDeps.pkgsTarget.hostPlatform.isWindows) ''

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -4,4 +4,5 @@ self: super: {
   extensions = super.callPackage ./pkgs/extensions { inherit allInOne incremental tag; };
   openapi-generator = super.callPackage ./../dependencies/control-plane/nix/pkgs/openapi-generator { };
   utils = super.callPackage ./pkgs/utils { inherit incremental; };
+  channel = import ./lib/rust.nix { pkgs = super.pkgs; };
 }

--- a/nix/pkgs/extensions/cargo-project.nix
+++ b/nix/pkgs/extensions/cargo-project.nix
@@ -4,6 +4,7 @@
 , pkg-config
 , protobuf
 , sources
+, channel
 , pkgs
 , clang
 , libxfs
@@ -26,7 +27,6 @@
 , incremental ? false
 }:
 let
-  channel = import ../../lib/rust.nix { inherit sources; };
   stable_channel = {
     rustc = channel.default.stable;
     cargo = channel.default.stable;
@@ -58,7 +58,6 @@ let
     "Cargo.lock"
     "Cargo.toml"
     "metrics-exporter"
-    "rpc"
     "console-logger"
     "call-home"
     "upgrade"
@@ -82,9 +81,8 @@ let
     GIT_VERSION_LONG = "${gitVersions.long}";
     GIT_VERSION = "${gitVersions.tag_or_long}";
 
-    inherit PROTOC PROTOC_INCLUDE;
-    nativeBuildInputs = [ clang pkg-config git openapi-generator which ];
-    buildInputs = [ llvmPackages.libclang protobuf openssl utillinux ];
+    nativeBuildInputs = [ clang pkg-config git openapi-generator which protobuf ];
+    buildInputs = [ llvmPackages.libclang openssl utillinux ];
     doCheck = false;
   };
   release_build = { "release" = true; "debug" = false; };

--- a/nix/pkgs/utils/default.nix
+++ b/nix/pkgs/utils/default.nix
@@ -1,21 +1,10 @@
-{ git, lib, stdenv, openapi-generator, pkgs, which, sources, llvmPackages, protobuf, extensions, incremental }:
+{ git, lib, stdenv, openapi-generator, pkgs, which, sources, llvmPackages, protobuf, extensions, incremental, channel }:
 let
-  channel = import ../../lib/rust.nix { inherit sources; };
   src = extensions.project-builder.src;
   version = extensions.version;
   GIT_VERSION_LONG = extensions.gitVersions.long;
   GIT_VERSION = extensions.gitVersions.tag_or_long;
-
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
-  PROTOC = "${protobuf}/bin/protoc";
-  PROTOC_INCLUDE = "${protobuf}/include";
-
   singleStep = !incremental;
-  naersk_package = channel: pkgs.callPackage sources.naersk {
-    rustc = channel.stable;
-    cargo = channel.stable;
-  };
-  naersk_cross = naersk_package channel.windows_cross;
   preBuildOpenApi = ''
     # don't run during the dependency build phase
     if [ ! -f build.rs ]; then
@@ -23,98 +12,48 @@ let
       ./dependencies/control-plane/scripts/rust/generate-openapi-bindings.sh --skip-git-diff
     fi
   '';
-  static_ssl = (pkgs.openssl.override {
-    static = true;
-  });
-
-  components = { release ? false }: {
-    windows-gnu = {
-      kubectl-plugin = naersk_cross.buildPackage {
-        inherit release src version singleStep GIT_VERSION_LONG GIT_VERSION;
-        name = "kubectl-plugin";
-
-        preBuild = preBuildOpenApi + ''
-          export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS="-C link-args=''$(echo $NIX_LDFLAGS | tr ' ' '\n' | grep -- '^-L' | tr '\n' ' ')"
-          export NIX_LDFLAGS=
-          export NIX_LDFLAGS_FOR_BUILD=
-          export OPENSSL_STATIC=1
-          export OPENSSL_DIR=${pkgs.pkgsCross.mingwW64.openssl.dev};
-        '';
-        cargoBuildOptions = attrs: attrs ++ [ "-p" "kubectl-plugin" "--no-default-features" "--features" "tls" ];
-        buildInputs = with pkgs.pkgsCross.mingwW64.windows; [ mingw_w64_pthreads pthreads ];
-        nativeBuildInputs = [ pkgs.pkgsCross.mingwW64.stdenv.cc openapi-generator which git pkgs.pkgsCross.mingwW64.openssl.dev ];
-        doCheck = false;
-        usePureFromTOML = true;
-
-        PROTOC = "${protobuf}/bin/protoc";
-        CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
-        CARGO_BUILD_TARGET = "x86_64-pc-windows-gnu";
-        CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = with pkgs.pkgsCross.mingwW64.stdenv;
-          "${cc}/bin/${cc.targetPrefix}cc";
-      };
-      recurseForDerivations = true;
-    };
-    linux-musl = rec {
-      target = channel.makeRustTarget pkgs.pkgsStatic.hostPlatform;
-      naersk = naersk_package (channel.static {
-        inherit target;
+  buildKubectlPlugin = { target, release, addBuildOptions ? [ ] }:
+    let
+      platformDeps = channel.rustPlatformDeps { inherit target sources; };
+      # required for darwin because its pkgsStatic is not static!
+      static_ssl = (platformDeps.pkgsTarget.pkgsStatic.openssl.override {
+        static = true;
       });
-      check_assert = lib.asserts.assertMsg (pkgs.hostPlatform.isLinux == true) "This may only be built on Linux";
-
-      kubectl-plugin = naersk.buildPackage {
-        inherit release src version singleStep GIT_VERSION_LONG GIT_VERSION check_assert;
-        name = "kubectl-plugin";
-
-        preBuild = preBuildOpenApi + ''
+      rustBuildOpts = channel.rustBuilderOpts { rustPlatformDeps = platformDeps; } // {
+        buildOptions = [ "-p" "kubectl-plugin" ] ++ addBuildOptions;
+        ${if !pkgs.hostPlatform.isDarwin then "addNativeBuildInputs" else null} = [ platformDeps.pkgsTargetNative.pkgsStatic.openssl.dev ];
+        addPreBuild = preBuildOpenApi + ''
           export OPENSSL_STATIC=1
-        '';
-        inherit LIBCLANG_PATH PROTOC PROTOC_INCLUDE;
-        cargoBuildOptions = attrs: attrs ++ [ "-p" "kubectl-plugin" ];
-        nativeBuildInputs = with pkgs; [ pkgconfig clang openapi-generator which git pkgsStatic.openssl.dev ];
-        doCheck = false;
-        usePureFromTOML = true;
-
-        CARGO_BUILD_TARGET = target;
-        CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
-      };
-      recurseForDerivations = true;
-    };
-    # Can only be built on apple-darwin
-    apple-darwin = rec {
-      target = channel.makeRustTarget pkgs.pkgsStatic.hostPlatform;
-      naersk = naersk_package (channel.static {
-        inherit target;
-      });
-      check_assert = lib.asserts.assertMsg (pkgs.hostPlatform.isDarwin == true) "This may only be built on darwin";
-
-      kubectl-plugin = naersk.buildPackage {
-        inherit release src version singleStep GIT_VERSION_LONG GIT_VERSION check_assert;
-        name = "kubectl-plugin";
-
-        preBuild = preBuildOpenApi + ''
-          export OPENSSL_STATIC=1
+        '' + lib.optionalString (pkgs.hostPlatform.isDarwin) ''
           export OPENSSL_LIB_DIR=${static_ssl.out}/lib
           export OPENSSL_INCLUDE_DIR=${static_ssl.dev}/include
         '';
-        inherit LIBCLANG_PATH PROTOC PROTOC_INCLUDE;
-        cargoBuildOptions = attrs: attrs ++ [ "-p" "kubectl-plugin" ];
-        nativeBuildInputs = with pkgs; [
-          clang
-          openapi-generator
-          which
-          git
-          pkg-config
-          (libiconv.override {
-            enableStatic = true;
-            enableShared = false;
-          })
-        ];
-        doCheck = false;
-        usePureFromTOML = true;
-
-        CARGO_BUILD_TARGET = target;
       };
-      recurseForDerivations = true;
+      name = "kubectl-plugin";
+    in
+    channel.rustPackageBuilder {
+      inherit name release src version singleStep GIT_VERSION_LONG GIT_VERSION rustBuildOpts;
+    };
+
+  components = { release ? false }: {
+    windows-gnu = rec {
+      kubectl-plugin = buildKubectlPlugin {
+        inherit release;
+        target = "mingwW64";
+        addBuildOptions = [ "--no-default-features" "--features" "tls" ];
+      };
+    };
+    linux-musl = rec {
+      kubectl-plugin = buildKubectlPlugin {
+        inherit release;
+        target = "musl64";
+      };
+    };
+    apple-darwin = rec {
+      kubectl-plugin = buildKubectlPlugin {
+        inherit release;
+        target = "x86_64-darwin";
+      };
     };
   };
 in

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
 let
   sources = import ./nix/sources.nix;
   pkgs = import sources.nixpkgs {
-    overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix { }) ];
+    overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix { }) (import sources.rust-overlay) ];
   };
 in
 with pkgs;
@@ -11,7 +11,7 @@ let
     "You have requested an environment without rust, you should provide it!";
   devrustup_moth =
     "You have requested an environment for rustup, you should provide it!";
-  channel = import ./nix/lib/rust.nix { inherit sources; };
+  channel = import ./nix/lib/rust.nix { inherit pkgs; };
   rust_chan = channel.default_src;
   rust = rust_chan.${rust-profile};
 in


### PR DESCRIPTION
Cross compile aarch64-linux static binary from x86_64-linux.

## Description
Refactor the static binary building to allow cross-compilation.
Also simplifies adding a new binary by adding generic builders.

## Motivation and Context
Building aarch64 binaries.

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.