### PR TITLE
feat(chart): allow to customize the storageclass

### DIFF
--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -1,9 +1,15 @@
+{{ if .Values.storageClass.enabled }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-single-replica
+  name: {{ .Release.Name }}-{{ .Values.storageClass.nameSuffix }}
+  {{- if .Values.storageClass.default }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  {{- end }}
 parameters:
-  repl: '1'
+  repl: {{ .Values.storageClass.parameters.repl | toString | quote }}
   protocol: 'nvmf'
   ioTimeout: '60'
 provisioner: io.openebs.csi-mayastor
+{{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -705,6 +705,13 @@ obs:
         # NodePort associated with https port
         https: 90010
 
+storageClass:
+  enabled: true
+  nameSuffix: single-replica
+  default: false
+  parameters:
+    repl: 1
+
 localpv-provisioner:
   # -- Enables the openebs dynamic-localpv provisioner. If disabled, modify etcd and loki-stack storage class accordingly.
   enabled: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request aims to allow the customization of the `storageClass` created by the mayastor helm chart.


## Description
<!--- Describe your changes in detail -->
The following capabilities are added for the `storageClass`:
- Allow to disable the creation
- Allow to set the `storageClass` as the default one
- Allow to set the replication factor
- Allow to set the name

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The main motivation for those changes is to make the `storageClass` configurable and usable as default in a k8s cluster without the need to create a second one from a separate set of manifests.

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
No

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by deploying Mayastor into a kubernetes cluster and validating that the template is rendered as valid k8s yaml.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.