### PR TITLE
fix: use relative url for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "dependencies/control-plane"]
 	path = dependencies/control-plane
-	url = https://github.com/openebs/mayastor-control-plane.git
+	url = ../mayastor-control-plane.git
 	branch = develop


### PR DESCRIPTION
Used for importing the control-plane to this repo.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the URL for importing the control-plane submodule to a relative URL.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The top-level part of the URL is the same between repos, so need not be duplicated,
and can be inferred from the URL of the parent repo.

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
No

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked that it builds locally and in CI.
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.