### PR TITLE
feat(helm/nvme): add more knobs to control timeouts and qdepth

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -111,7 +111,6 @@ $ helm install my-release openebs/mayastor
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;snapshotterTag | csi-snapshotter image release tag | `"v6.3.1"` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;kubeletDir | The kubeletDir directory for the csi-node plugin | `"/var/lib/kubelet"` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;nvme.&ZeroWidthSpace;ctrl_loss_tmo | The ctrl_loss_tmo (controller loss timeout) in seconds | `"1980"` |
-| csi.&ZeroWidthSpace;node.&ZeroWidthSpace;nvme.&ZeroWidthSpace;io_timeout | The nvme_core module io timeout in seconds | `"30"` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;priorityClassName | Set PriorityClass, overrides global | `""` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for csi node plugin | `"100m"` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;memory | Memory limits for csi node plugin | `"128Mi"` |
@@ -141,6 +140,8 @@ $ helm install my-release openebs/mayastor
 | io_engine.&ZeroWidthSpace;envcontext | Pass additional arguments to the Environment Abstraction Layer. Example: --set {product}.envcontext=iova-mode=pa | `""` |
 | io_engine.&ZeroWidthSpace;logLevel | Log level for the io-engine service | `"info"` |
 | io_engine.&ZeroWidthSpace;nodeSelector | Node selectors to designate storage nodes for diskpool creation Note that if multi-arch images support 'kubernetes.io/arch: amd64' should be removed. | <pre>{<br>"kubernetes.io/arch":"amd64",<br>"openebs.io/engine":"mayastor"<br>}</pre> |
+| io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;ioTimeout | Timeout for IOs The default here is exaggerated for local disks but we've observed that in shared virtual environments having a higher timeout value is beneficial. In certain cases, you may have to set this to an even higher value. For example, in Hetzner we've had better results setting it to 300s. Please adjust this according to your hardware and needs. | `"110s"` |
+| io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;tcp.&ZeroWidthSpace;maxQueueDepth | You may need to increase this for a higher outstanding IOs per volume | `"32"` |
 | io_engine.&ZeroWidthSpace;priorityClassName | Set PriorityClass, overrides global | `""` |
 | io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for the io-engine | `""` |
 | io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;hugepages2Mi | Hugepage size available on the nodes | `"2Gi"` |

--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -78,7 +78,10 @@ spec:
         - "--csi-socket={{ .Values.csi.node.pluginMounthPath }}/{{ .Values.csi.node.socketPath }}"
         - "--node-name=$(MY_NODE_NAME)"
         - "--grpc-endpoint=$(MY_POD_IP):10199"{{ if .Values.csi.node.nvme.io_timeout }}
-        - "--nvme-core-io-timeout={{ .Values.csi.node.nvme.io_timeout }}"{{ end }}{{ if .Values.csi.node.nvme.ctrl_loss_tmo }}
+        - "--nvme-io-timeout={{ .Values.csi.node.nvme.io_timeout }}"
+        - "--nvme-core-io-timeout={{ .Values.csi.node.nvme.io_timeout }}"{{ else }}
+        - "--nvme-io-timeout={{ .Values.io_engine.nvme.ioTimeout }}10s"
+        - "--nvme-core-io-timeout={{ .Values.io_engine.nvme.ioTimeout }}10s"{{ end }}{{ if .Values.csi.node.nvme.ctrl_loss_tmo }}
         - "--nvme-ctrl-loss-tmo={{ .Values.csi.node.nvme.ctrl_loss_tmo }}"{{ end }}{{ if .Values.csi.node.nvme.keep_alive_tmo }}
         - "--nvme-keep-alive-tmo={{ .Values.csi.node.nvme.keep_alive_tmo }}"{{ end }}
         - "--nvme-nr-io-queues={{ include "coreCount" . }}"

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -64,10 +64,14 @@ spec:
         env:
         - name: RUST_LOG
           value: {{ .Values.io_engine.logLevel }}
-        - name: NVME_QPAIR_CONNECT_ASYNC
-          value: "true"
         - name: NVMF_TCP_MAX_QUEUE_DEPTH
-          value: "32"
+          value: "{{ .Values.io_engine.nvme.tcp.maxQueueDepth }}"
+        - name: NVME_TIMEOUT
+          value: "{{ .Values.io_engine.nvme.ioTimeout }}"
+        - name: NVME_TIMEOUT_ADMIN
+          value: "{{ .Values.io_engine.nvme.adminTimeout }}"
+        - name: NVME_KATO
+          value: "{{ .Values.io_engine.nvme.keepAliveTimeout }}"
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:

--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -10,6 +10,5 @@ metadata:
 parameters:
   repl: {{ .Values.storageClass.parameters.repl | toString | quote }}
   protocol: 'nvmf'
-  ioTimeout: '60'
 provisioner: io.openebs.csi-mayastor
 {{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -314,8 +314,10 @@ csi:
         # -- Memory requests for csi node plugin
         memory: "64Mi"
     nvme:
-      # -- The nvme_core module io timeout in seconds
-      io_timeout: "30"
+      # The nvme_core module and nvme block io timeout in humantime
+      # By default it uses the "io_engine.nvme.ioTimeout" + 10s
+      # Do not modify this unless you're really sure about its effects
+      io_timeout: ""
       # -- The ctrl_loss_tmo (controller loss timeout) in seconds
       ctrl_loss_tmo: "1980"
       # Kato (keep alive timeout) in seconds
@@ -341,8 +343,24 @@ io_engine:
       ptpl: true
       # NVMF target Command Retry Delay for volume target initiators
       hostCmdRetryDelay:
-        # A command retry delay in seconds. A value of 0 means no delay, host may retry immediately
+        # A command retry delay in milliseconds. A value of 0 means no delay, host may retry immediately
         crdt1: 30
+  nvme:
+    # -- Timeout for IOs
+    # The default here is exaggerated for local disks but we've observed that in
+    # shared virtual environments having a higher timeout value is beneficial.
+    # In certain cases, you may have to set this to an even higher value. For example,
+    # in Hetzner we've had better results setting it to 300s.
+    # Please adjust this according to your hardware and needs.
+    ioTimeout: "110s"
+    # Timeout for admin commands
+    adminTimeout: "30s"
+    # Timeout for keep alives
+    keepAliveTimeout: "10s"
+    tcp:
+      # -- Max size setting (both initiator and target) for an NVMe queue
+      # -- You may need to increase this for a higher outstanding IOs per volume
+      maxQueueDepth: "32"
 
   # -- Pass additional arguments to the Environment Abstraction Layer.
   # Example: --set {product}.envcontext=iova-mode=pa


### PR DESCRIPTION
Add more nvme knobs.

## Description
Allow controlling nvme timeouts and q depth.

## Motivation and Context
In some virtual environments (non-nvme), the backend can be slower and lead into timeouts and degraded replicas.
More back-pressure work is required to ensure we don't attempt rebuilds and further IO on a backend which is "stuck", but this will give us some hooks for testing etc.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.