### PR TITLE
feat(upgrade-job): disable drain when frontend node is ANA-incapable

### DIFF
--- a/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
@@ -20,6 +20,9 @@ pub(crate) const CHART_VERSION_LABEL_KEY: &str = "openebs.io/version";
 /// This is the label set on a storage API Node resource when a 'Node Drain' is issued.
 pub(crate) const DRAIN_FOR_UPGRADE: &str = "mayastor-upgrade";
 
+/// This is the label set on a storage API Node resource when a 'Node Drain' is issued.
+pub(crate) const CORDON_FOR_ANA_CHECK: &str = "mayastor-upgrade-nvme-ana-check";
+
 /// This is the allowed upgrade to-version/to-version-range for the Umbrella chart.
 pub(crate) const TO_UMBRELLA_SEMVER: &str = "3.10.0";
 

--- a/k8s/upgrade/src/bin/upgrade-job/common/error.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/error.rs
@@ -300,7 +300,7 @@ pub(crate) enum Error {
         node_id: String,
     },
 
-    /// Error for when a storage node drain request fails.
+    /// Error for when a storage node cordon request fails.
     #[snafu(display("Failed to cordon {} Node {}: {}", PRODUCT, node_id, source))]
     CordonStorageNode {
         source: openapi::tower::client::Error<openapi::models::RestJsonError>,

--- a/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
@@ -149,8 +149,8 @@ impl HelmUpgraderBuilder {
         let source_values_buf =
             client.get_values_as_yaml::<&str, String>(release_name.as_str(), None)?;
 
-        // The version of the Core chart which we are (maybe) going to.
         let chart_dot_yaml_path = chart_dir.join("Chart.yaml");
+        // The version of the Core chart which we are (maybe) upgrading to.
         let target_version = version_from_chart_yaml_file(chart_dot_yaml_path)?;
 
         // Check if already upgraded.


### PR DESCRIPTION
Requires #377.

Changes:
- Disables node drain during data-plane upgrade if, for a node a frontend_node of a volume target lies on a node which is ANA-incapable.