### PR TITLE
fix: exclude staging and staging-merge branches from chart publish

### DIFF
--- a/.github/workflows/main-chart.yml
+++ b/.github/workflows/main-chart.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - 'helm-testing/**'
+      - '!helm-testing/**-staging**'
     paths:
       - 'chart/**'
 


### PR DESCRIPTION
- exclude staging and staging-merge branches from publishing charts to helm registry

