### PR TITLE
feat(upgrade): add special values options for 2.5.0 

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -588,7 +588,7 @@ loki-stack:
               - docker: {}
               - replace:
                   expression: '(\n)'
-                  replace: ""
+                  replace: ''
               - multiline:
                   firstline: '^  \x1b\[2m(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{6})Z'
                   max_wait_time: 3s

--- a/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
@@ -41,3 +41,6 @@ pub(crate) const TWO_DOT_THREE: &str = "2.3.0";
 
 /// Version value for the earliest possible 2.4 release (there were no pre-releases).
 pub(crate) const TWO_DOT_FOUR: &str = "2.4.0";
+
+/// Version value for the earliest possible 2.5 release.
+pub(crate) const TWO_DOT_FIVE: &str = "2.5.0";

--- a/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
@@ -72,6 +72,8 @@ pub(crate) struct CoreValues {
     eventing: Eventing,
     /// This contains Kubernetes CSI sidecar container image details.
     csi: Csi,
+    /// This contains promtail details.
+    promtail: Promtail,
 }
 
 impl TryFrom<&Path> for CoreValues {
@@ -140,29 +142,34 @@ impl CoreValues {
         self.eventing.enabled()
     }
 
-    /// This is a getter or the sig-storage/csi-provisioner image tag.
+    /// This is a getter for the sig-storage/csi-provisioner image tag.
     pub(crate) fn csi_provisioner_image_tag(&self) -> &str {
         self.csi.provisioner_image_tag()
     }
 
-    /// This is a getter or the sig-storage/csi-attacher image tag.
+    /// This is a getter for the sig-storage/csi-attacher image tag.
     pub(crate) fn csi_attacher_image_tag(&self) -> &str {
         self.csi.attacher_image_tag()
     }
 
-    /// This is a getter or the sig-storage/csi-snapshotter image tag.
+    /// This is a getter for the sig-storage/csi-snapshotter image tag.
     pub(crate) fn csi_snapshotter_image_tag(&self) -> &str {
         self.csi.snapshotter_image_tag()
     }
 
-    /// This is a getter or the sig-storage/snapshot-controller image tag.
+    /// This is a getter for the sig-storage/snapshot-controller image tag.
     pub(crate) fn csi_snapshot_controller_image_tag(&self) -> &str {
         self.csi.snapshot_controller_image_tag()
     }
 
-    /// This is a getter or the sig-storage/csi-node-driver-registrar image tag.
+    /// This is a getter for the sig-storage/csi-node-driver-registrar image tag.
     pub(crate) fn csi_node_driver_registrar_image_tag(&self) -> &str {
         self.csi.node_driver_registrar_image_tag()
+    }
+
+    /// This is a getter for the promtail scrapeConfigs.
+    pub(crate) fn promtail_scrape_configs(&self) -> &str {
+        self.promtail.scrape_configs()
     }
 }
 
@@ -373,5 +380,45 @@ impl CsiImage {
     /// This is a getter for registrarTag.
     pub(crate) fn node_driver_registrar_tag(&self) -> &str {
         self.registrar_tag.as_str()
+    }
+}
+
+/// This is used to deserialize the yaml object 'promtail'.
+#[derive(Deserialize)]
+pub(crate) struct Promtail {
+    config: PromtailConfig,
+}
+
+impl Promtail {
+    /// This returns the promtail.config.snippets.scrapeConfigs as an &str.
+    pub(crate) fn scrape_configs(&self) -> &str {
+        self.config.scrape_configs()
+    }
+}
+
+/// This is used to deserialize the promtail.config yaml object.
+#[derive(Deserialize)]
+pub(crate) struct PromtailConfig {
+    snippets: PromtailConfigSnippets,
+}
+
+impl PromtailConfig {
+    /// This returns the config.snippets.scrapeConfigs as an &str.
+    pub(crate) fn scrape_configs(&self) -> &str {
+        self.snippets.scrape_configs()
+    }
+}
+
+/// This is used to deserialize the config.snippets yaml object.
+#[derive(Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+pub(crate) struct PromtailConfigSnippets {
+    scrape_configs: String,
+}
+
+impl PromtailConfigSnippets {
+    /// This returns the snippets.scrapeConfigs as an &str.
+    pub(crate) fn scrape_configs(&self) -> &str {
+        self.scrape_configs.as_str()
     }
 }

--- a/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::{
-        constants::{TWO_DOT_FOUR, TWO_DOT_ONE, TWO_DOT_O_RC_ONE, TWO_DOT_THREE},
+        constants::{TWO_DOT_FIVE, TWO_DOT_FOUR, TWO_DOT_ONE, TWO_DOT_O_RC_ONE, TWO_DOT_THREE},
         error::{Result, SemverParse},
         file::write_to_tempfile,
     },
@@ -124,6 +124,23 @@ where
         yq.set_value(
             YamlKey::try_from(".eventing.enabled")?,
             target_values.eventing_enabled(),
+            upgrade_values_file.path(),
+        )?;
+    }
+
+    // Special-case values for 2.5.x.
+    let two_dot_five = Version::parse(TWO_DOT_FIVE).context(SemverParse {
+        version_string: TWO_DOT_FIVE.to_string(),
+    })?;
+    if source_version.ge(&two_dot_o_rc_zero)
+        && source_version.lt(&two_dot_five)
+        && source_values
+            .promtail_scrape_configs()
+            .ne(target_values.promtail_scrape_configs())
+    {
+        yq.set_value(
+            YamlKey::try_from(".promtail.config.snippets.scrapeConfigs")?,
+            target_values.promtail_scrape_configs(),
             upgrade_values_file.path(),
         )?;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In 2.5.0, the scrapeConfigs options is changed (ref: #344). This adds values changes for upgrade when going from a source version <2.5.0 to a target version >=2.5.0.

## Description
<!--- Describe your changes in detail -->
Changes:
- Sets .promtail.config.snippets.scrapeConfigs for upgrade from anywhere in the range 2.0.0-rc.1 - 2.4.0.
- Changes loki scrapeConfig to use single quotes, because [the code here](https://github.com/openebs/mayastor-extensions/blob/develop/k8s/upgrade/src/bin/upgrade-job/helm/yaml/yq.rs#L178) adds double quotes to strings, avoiding bools, null and ints. When double quotes are added to scrapeConfigs, it'll require the double quotes withing the scrapeConfigs to use escapes (\\").