### PR TITLE
fix: fix upgrade

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -205,3 +205,30 @@ Usage:
         {{- end -}}
     {{- end -}}
 {{- end -}}
+
+{{/*
+    Generate the default StorageClass parameters.
+    This is required because StorageClass parameters cannot be patched after creation.
+    If the StorageClass already exists, the default StorageClass carries the parameters and values
+    of that StorageClass. Else, it carries the default parameters and values.
+*/}}
+{{- define "storageClass.parameters" -}}
+    {{- $scName := index . 0 -}}
+    {{- $valuesParams := index . 1 -}}
+
+    {{/* Check to see if a default StorageClass already exists */}}
+    {{- $sc := lookup "storage.k8s.io/v1" "StorageClass" "" $scName -}}
+
+    {{- if $sc -}}
+        {{/* Existing defaults */}}
+        {{ range $param, $val := $sc.parameters }}
+{{ $param | quote }}: {{ $val | quote }}
+        {{- end -}}
+
+    {{- else -}}
+        {{/* Current defaults */}}
+        {{ range $param, $val := $valuesParams }}
+{{ $param | quote }}: {{ $val | quote }}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}

--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -1,14 +1,21 @@
 {{ if .Values.storageClass.enabled }}
+{{- $scName := (printf "%s-%s" .Release.Name .Values.storageClass.nameSuffix | trunc 63) }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.storageClass.nameSuffix }}
+  name: {{ $scName }}
   {{- if .Values.storageClass.default }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
   {{- end }}
 parameters:
-  repl: {{ .Values.storageClass.parameters.repl | toString | quote }}
-  protocol: 'nvmf'
+{{/*
+  Set StorageClass parameters by adding to the values.yaml 'storageClass.parameters' map.
+  Don't add the parameters to this template directly.
+  This is done so that during an upgrade, an existing default StorageClass's config can
+  be given preference over this chart's defaults.
+*/}}
+{{ $valuesParams := .Values.storageClass.parameters }}
+{{ (include "storageClass.parameters" (list $scName $valuesParams)) | indent 2 }}
 provisioner: io.openebs.csi-mayastor
 {{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -728,6 +728,7 @@ storageClass:
   nameSuffix: single-replica
   default: false
   parameters:
+    protocol: nvmf
     repl: 1
 
 localpv-provisioner:


### PR DESCRIPTION
Change:
- Use yq's strenv operator to use special characters with yq when updating the upgrade values.yaml.
- Fix check which forbids upgrade from a stable release to unstable version.
- Prefers the parameters of an existing default StorageClass over the chart defaults.