### PR TITLE
chore(scripts/utils): remove set options

### DIFF
--- a/scripts/utils/advisory_lock.sh
+++ b/scripts/utils/advisory_lock.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 
-# -o errexit: abort script if one command fails
-# -o errtrace: the ERR trap is inherited by shell functions
-# -o pipefail: entire command fails if pipe fails
-# -o history: record shell history
-# -o allexport: export all functions and variables to be available to subscripts
-set -o errexit -o errtrace -o pipefail -o history -o allexport
-
-# Takes a lock by way of a local file with the name <cleanup-config-file-name>.lock.
+# Takes a lock by way of a local file with the name <file-name>.lock.
 advisory_lock_acquire() {
   local -r filepath=$1
   local -r lock_filepath=$2

--- a/scripts/utils/log.sh
+++ b/scripts/utils/log.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-# -o errexit: abort script if one command fails
-# -o errtrace: the ERR trap is inherited by shell functions
-# -o pipefail: entire command fails if pipe fails
-# -o history: record shell history
-# -o allexport: export all functions and variables to be available to subscripts
-set -o errexit -o errtrace -o pipefail -o history -o allexport
-
 # Write output to error output stream.
 log_to_stderr() {
   echo -e "${1}" >&2


### PR DESCRIPTION
The utils scripts are meant to be imported by other scripts. Setting/unsetting
set options on these scripts may interfere with the set options on the calling
script. The set options aren't an essential part of the scripts, removing them.