### PR TITLE
feat(upgrade-job): add support for loki-stack helm chart upgrade

### DIFF
--- a/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
@@ -44,3 +44,6 @@ pub(crate) const TWO_DOT_FOUR: &str = "2.4.0";
 
 /// Version value for the earliest possible 2.5 release.
 pub(crate) const TWO_DOT_FIVE: &str = "2.5.0";
+
+/// Version value for the earliest possible 2.6 release.
+pub(crate) const TWO_DOT_SIX: &str = "2.6.0";

--- a/k8s/upgrade/src/bin/upgrade-job/common/error.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/error.rs
@@ -645,6 +645,19 @@ pub(crate) enum Error {
         std_err: String,
     },
 
+    /// Error for when the yq command to set an object from another YAML file, returns an error.
+    #[snafu(display(
+        "`yq` set-object-command returned an error,\ncommand: {},\nargs: {:?},\nstd_err: {}",
+        command,
+        args,
+        std_err,
+    ))]
+    YqSetObjectFromFileCommand {
+        command: String,
+        args: Vec<String>,
+        std_err: String,
+    },
+
     /// Error for when the yq command to delete an object path returns an error.
     #[snafu(display(
         "`yq` delete-object-command returned an error,\ncommand: {},\nargs: {:?},\nstd_err: {}",

--- a/k8s/upgrade/src/bin/upgrade-job/common/error.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/error.rs
@@ -6,6 +6,7 @@ use crate::{
     events::event_recorder::EventNote,
     helm::chart::PromtailConfigClient,
 };
+use k8s_openapi::api::core::v1::Container;
 use snafu::Snafu;
 use std::path::PathBuf;
 use url::Url;
@@ -438,6 +439,17 @@ pub(crate) enum Error {
         object: PromtailConfigClient,
     },
 
+    /// Error in serializing a k8s_openapi::api::core::v1::Container to a JSON string.
+    #[snafu(display(
+        "Failed to serialize .loki-stack.promtail.initContainer {:?}: {}",
+        object,
+        source
+    ))]
+    SerializePromtailInitContainerToJson {
+        source: serde_json::Error,
+        object: Container,
+    },
+
     /// Error in deserializing a promtail helm chart's deprecated extraClientConfig to a
     /// serde_json::Value.
     #[snafu(display(
@@ -640,19 +652,6 @@ pub(crate) enum Error {
         std_err,
     ))]
     YqSetCommand {
-        command: String,
-        args: Vec<String>,
-        std_err: String,
-    },
-
-    /// Error for when the yq command to set an object from another YAML file, returns an error.
-    #[snafu(display(
-        "`yq` set-object-command returned an error,\ncommand: {},\nargs: {:?},\nstd_err: {}",
-        command,
-        args,
-        std_err,
-    ))]
-    YqSetObjectFromFileCommand {
         command: String,
         args: Vec<String>,
         std_err: String,

--- a/k8s/upgrade/src/bin/upgrade-job/common/error.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/error.rs
@@ -4,6 +4,7 @@ use crate::{
         UMBRELLA_CHART_UPGRADE_DOCS_URL,
     },
     events::event_recorder::EventNote,
+    helm::chart::PromtailConfigClient,
 };
 use snafu::Snafu;
 use std::path::PathBuf;
@@ -426,6 +427,49 @@ pub(crate) enum Error {
         note: EventNote,
     },
 
+    /// Error in serializing a helm::chart::PromtailConfigClient to a JSON string.
+    #[snafu(display(
+        "Failed to serialize .loki-stack.promtail.config.client {:?}: {}",
+        object,
+        source
+    ))]
+    SerializePromtailConfigClientToJson {
+        source: serde_json::Error,
+        object: PromtailConfigClient,
+    },
+
+    /// Error in deserializing a promtail helm chart's deprecated extraClientConfig to a
+    /// serde_json::Value.
+    #[snafu(display(
+        "Failed to deserialize .loki-stack.promtail.config.snippets.extraClientConfig to a serde_json::Value {}: {}",
+        config,
+        source
+    ))]
+    DeserializePromtailExtraConfig {
+        source: serde_yaml::Error,
+        config: String,
+    },
+
+    /// Error in serializing a promtail helm chart's deprecated extraClientConfig, in a
+    /// serde_json::Value, to JSON.
+    #[snafu(display("Failed to serialize to JSON {:?}: {}", config, source))]
+    SerializePromtailExtraConfigToJson {
+        source: serde_json::Error,
+        config: serde_json::Value,
+    },
+
+    /// Error in serializing the deprecated config.snippets.extraClientConfig from the promtail
+    /// helm chart v3.11.0.
+    #[snafu(display(
+        "Failed to serialize object to a serde_json::Value {}: {}",
+        object,
+        source
+    ))]
+    SerializePromtailExtraClientConfigToJson {
+        source: serde_json::Error,
+        object: String,
+    },
+
     /// Error for when there are too many io-engine Pods in one single node;
     #[snafu(display("Too many io-engine Pods in Node '{}'", node_name))]
     TooManyIoEnginePods { node_name: String },
@@ -601,14 +645,40 @@ pub(crate) enum Error {
         std_err: String,
     },
 
-    /// Error for when the yq command to update a yaml object returns an error.
+    /// Error for when the yq command to delete an object path returns an error.
     #[snafu(display(
-        "`yq` set-object-command returned an error,\ncommand: {},\nargs: {:?},\nstd_err: {}",
+        "`yq` delete-object-command returned an error,\ncommand: {},\nargs: {:?},\nstd_err: {}",
         command,
         args,
         std_err,
     ))]
-    YqSetObjCommand {
+    YqDeleteObjectCommand {
+        command: String,
+        args: Vec<String>,
+        std_err: String,
+    },
+
+    /// Error for when the yq command to append to an array returns an error.
+    #[snafu(display(
+        "`yq` append-to-array-command returned an error,\ncommand: {},\nargs: {:?},\nstd_err: {}",
+        command,
+        args,
+        std_err,
+    ))]
+    YqAppendToArrayCommand {
+        command: String,
+        args: Vec<String>,
+        std_err: String,
+    },
+
+    /// Error for when the yq command to append to an object returns an error.
+    #[snafu(display(
+        "`yq` append-to-object-command returned an error,\ncommand: {},\nargs: {:?},\nstd_err: {}",
+        command,
+        args,
+        std_err,
+    ))]
+    YqAppendToObjectCommand {
         command: String,
         args: Vec<String>,
         std_err: String,

--- a/k8s/upgrade/src/bin/upgrade-job/common/error.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/error.rs
@@ -601,6 +601,19 @@ pub(crate) enum Error {
         std_err: String,
     },
 
+    /// Error for when the yq command to update a yaml object returns an error.
+    #[snafu(display(
+        "`yq` set-object-command returned an error,\ncommand: {},\nargs: {:?},\nstd_err: {}",
+        command,
+        args,
+        std_err,
+    ))]
+    YqSetObjCommand {
+        command: String,
+        args: Vec<String>,
+        std_err: String,
+    },
+
     /// Error for when we fail to read the entries of a directory.
     #[snafu(display("Failed to read the contents of directory {}: {}", path.display(), source))]
     ReadingDirectoryContents {

--- a/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
@@ -173,11 +173,6 @@ impl CoreValues {
         self.csi.node_nvme_io_timeout()
     }
 
-    /// This is a getter for the grafana/loki container's image tag from the loki helm chart.
-    pub(crate) fn loki_stack_loki_image_tag(&self) -> &str {
-        self.loki_stack.loki_image_tag()
-    }
-
     /// This is a getter for the promtail scrapeConfigs.
     pub(crate) fn loki_stack_promtail_scrape_configs(&self) -> &str {
         self.loki_stack.promtail_scrape_configs()
@@ -185,14 +180,6 @@ impl CoreValues {
 
     pub(crate) fn loki_stack_promtail_loki_address(&self) -> &str {
         self.loki_stack.deprecated_promtail_loki_address()
-    }
-
-    pub(crate) fn loki_stack_promtail_config_file(&self) -> &str {
-        self.loki_stack.promtail_config_file()
-    }
-
-    pub(crate) fn loki_stack_promtail_readiness_probe_path(&self) -> &str {
-        self.loki_stack.promtail_readiness_probe_path()
     }
 
     /// This returns the config.snippets.extraClientConfigs from the promtail helm chart v3.11.0.
@@ -447,7 +434,6 @@ impl CsiNodeNvme {
 /// This is used to deserialize the yaml object 'loki-stack'.
 #[derive(Deserialize)]
 struct LokiStack {
-    loki: Loki,
     promtail: Promtail,
 }
 
@@ -462,47 +448,8 @@ impl LokiStack {
         self.promtail.deprecated_extra_client_configs()
     }
 
-    /// This is a getter for the grafana/loki container's image tag.
-    fn loki_image_tag(&self) -> &str {
-        self.loki.image_tag()
-    }
-
     fn deprecated_promtail_loki_address(&self) -> &str {
         self.promtail.deprecated_loki_address()
-    }
-
-    fn promtail_config_file(&self) -> &str {
-        self.promtail.config_file()
-    }
-
-    fn promtail_readiness_probe_path(&self) -> &str {
-        self.promtail.readiness_probe_http_get_path()
-    }
-}
-
-/// This is used to deserialize the loki dependent helm chart's values set.
-#[derive(Deserialize)]
-struct Loki {
-    image: LokiImage,
-}
-
-impl Loki {
-    /// This is a getter for the container image tag.
-    fn image_tag(&self) -> &str {
-        self.image.tag()
-    }
-}
-
-/// This is used to deserialize the yaml object 'image' in the loki helm chart.
-#[derive(Deserialize)]
-struct LokiImage {
-    tag: String,
-}
-
-impl LokiImage {
-    /// This is a getter for the image's tag.
-    fn tag(&self) -> &str {
-        self.tag.as_str()
     }
 }
 
@@ -511,7 +458,6 @@ impl LokiImage {
 #[serde(rename_all(deserialize = "camelCase"))]
 struct Promtail {
     config: PromtailConfig,
-    readiness_probe: PromtailReadinessProbe,
 }
 
 impl Promtail {
@@ -528,14 +474,6 @@ impl Promtail {
     fn deprecated_loki_address(&self) -> &str {
         self.config.deprecated_loki_address()
     }
-
-    fn config_file(&self) -> &str {
-        self.config.file()
-    }
-
-    fn readiness_probe_http_get_path(&self) -> &str {
-        self.readiness_probe.http_get_path()
-    }
 }
 
 /// This is used to deserialize the promtail.config yaml object.
@@ -543,7 +481,6 @@ impl Promtail {
 struct PromtailConfig {
     #[serde(default, rename(deserialize = "lokiAddress"))]
     deprecated_loki_address: String,
-    file: String,
     snippets: PromtailConfigSnippets,
 }
 
@@ -561,10 +498,6 @@ impl PromtailConfig {
     /// This is a getter for the lokiAddress in the loki helm chart v2.6.4.
     fn deprecated_loki_address(&self) -> &str {
         self.deprecated_loki_address.as_str()
-    }
-
-    fn file(&self) -> &str {
-        self.file.as_str()
     }
 }
 
@@ -586,29 +519,6 @@ impl PromtailConfigSnippets {
     /// This returns the snippets.extraClientConfigs from the promtail helm chart v3.11.0.
     fn deprecated_extra_client_configs(&self) -> &str {
         self.deprecated_extra_client_configs.as_str()
-    }
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all(deserialize = "camelCase"))]
-struct PromtailReadinessProbe {
-    http_get: PromtailReadinessProbeHttpGet,
-}
-
-impl PromtailReadinessProbe {
-    fn http_get_path(&self) -> &str {
-        self.http_get.path()
-    }
-}
-
-#[derive(Deserialize)]
-struct PromtailReadinessProbeHttpGet {
-    path: String,
-}
-
-impl PromtailReadinessProbeHttpGet {
-    fn path(&self) -> &str {
-        self.path.as_str()
     }
 }
 

--- a/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
@@ -1,6 +1,6 @@
 use crate::common::error::{ReadingFile, U8VectorToString, YamlParseFromFile, YamlParseFromSlice};
 use semver::Version;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use std::{fs::read, path::Path, str};
 
@@ -173,35 +173,57 @@ impl CoreValues {
         self.csi.node_nvme_io_timeout()
     }
 
+    /// This is a getter for the grafana/loki container's image tag from the loki helm chart.
+    pub(crate) fn loki_stack_loki_image_tag(&self) -> &str {
+        self.loki_stack.loki_image_tag()
+    }
+
     /// This is a getter for the promtail scrapeConfigs.
-    pub(crate) fn loki_promtail_scrape_configs(&self) -> &str {
+    pub(crate) fn loki_stack_promtail_scrape_configs(&self) -> &str {
         self.loki_stack.promtail_scrape_configs()
+    }
+
+    pub(crate) fn loki_stack_promtail_loki_address(&self) -> &str {
+        self.loki_stack.deprecated_promtail_loki_address()
+    }
+
+    pub(crate) fn loki_stack_promtail_config_file(&self) -> &str {
+        self.loki_stack.promtail_config_file()
+    }
+
+    pub(crate) fn loki_stack_promtail_readiness_probe_path(&self) -> &str {
+        self.loki_stack.promtail_readiness_probe_path()
+    }
+
+    /// This returns the config.snippets.extraClientConfigs from the promtail helm chart v3.11.0.
+    pub(crate) fn promtail_extra_client_configs(&self) -> &str {
+        self.loki_stack.deprecated_promtail_extra_client_configs()
     }
 }
 
 /// This is used to deserialize the yaml object agents.
 #[derive(Deserialize)]
-pub(crate) struct Agents {
+struct Agents {
     ha: Ha,
 }
 
 impl Agents {
     /// This is a getter for state of the 'ha' feature (enabled/disabled).
-    pub(crate) fn ha_is_enabled(&self) -> bool {
+    fn ha_is_enabled(&self) -> bool {
         self.ha.enabled()
     }
 }
 
 /// This is used to deserialize the yaml object 'agents.ha'.
 #[derive(Deserialize)]
-pub(crate) struct Ha {
+struct Ha {
     enabled: bool,
 }
 
 impl Ha {
     /// This returns the value of 'ha.enabled' from the values set. Defaults to 'true' is absent
     /// from the yaml.
-    pub(crate) fn enabled(&self) -> bool {
+    fn enabled(&self) -> bool {
         self.enabled
     }
 }
@@ -210,7 +232,7 @@ impl Ha {
 /// container images.
 #[derive(Deserialize)]
 #[serde(rename_all(deserialize = "camelCase"))]
-pub(crate) struct Image {
+struct Image {
     /// The container image tag.
     tag: String,
     /// This contains image tags set based on which PRODUCT repository the microservice originates
@@ -221,22 +243,22 @@ pub(crate) struct Image {
 
 impl Image {
     /// This is a getter for the container image tag used across the helm chart release.
-    pub(crate) fn tag(&self) -> &str {
+    fn tag(&self) -> &str {
         self.tag.as_str()
     }
 
     /// This is a getter for the control-plane repoTag set on a helm chart.
-    pub(crate) fn control_plane_repotag(&self) -> &str {
+    fn control_plane_repotag(&self) -> &str {
         self.repo_tags.control_plane()
     }
 
     /// This is a getter for the data-plane repoTag set on a helm chart.
-    pub(crate) fn data_plane_repotag(&self) -> &str {
+    fn data_plane_repotag(&self) -> &str {
         self.repo_tags.data_plane()
     }
 
     /// This is a getter for the extensions repoTag set on a helm chart.
-    pub(crate) fn extensions_repotag(&self) -> &str {
+    fn extensions_repotag(&self) -> &str {
         self.repo_tags.extensions()
     }
 }
@@ -245,7 +267,7 @@ impl Image {
 /// component.
 #[derive(Deserialize, Default)]
 #[serde(rename_all(deserialize = "camelCase"))]
-pub(crate) struct RepoTags {
+struct RepoTags {
     /// This member of repoTags is used to set image tags for components from the control-plane
     /// repo.
     control_plane: String,
@@ -257,17 +279,17 @@ pub(crate) struct RepoTags {
 
 impl RepoTags {
     /// This is a getter for the control-plane image tag set on a helm chart.
-    pub(crate) fn control_plane(&self) -> &str {
+    fn control_plane(&self) -> &str {
         self.control_plane.as_str()
     }
 
     /// This is a getter for the data-plane image tag set on a helm chart.
-    pub(crate) fn data_plane(&self) -> &str {
+    fn data_plane(&self) -> &str {
         self.data_plane.as_str()
     }
 
     /// This is a getter for the extensions image tag set on a helm chart.
-    pub(crate) fn extensions(&self) -> &str {
+    fn extensions(&self) -> &str {
         self.extensions.as_str()
     }
 }
@@ -276,14 +298,14 @@ impl RepoTags {
 /// io-engine DaemonSet.
 #[derive(Deserialize)]
 #[serde(rename_all(deserialize = "camelCase"))]
-pub(crate) struct IoEngine {
+struct IoEngine {
     /// Tracing Loglevel details for the io-engine DaemonSet Pods.
     log_level: String,
 }
 
 impl IoEngine {
     /// This is a getter for the io-engine DaemonSet Pod's tracing logLevel.
-    pub(crate) fn log_level(&self) -> &str {
+    fn log_level(&self) -> &str {
         self.log_level.as_str()
     }
 }
@@ -291,7 +313,7 @@ impl IoEngine {
 /// This is used to deserialize the yaml object 'eventing', v2.3.0 has it disabled by default,
 /// the default thereafter has it enabled.
 #[derive(Deserialize, Default)]
-pub(crate) struct Eventing {
+struct Eventing {
     // This value is defaulted to 'false' when 'Eventing' is absent in the yaml.
     // This works fine because we don't use the serde deserialized values during
     // the values.yaml merge. The merge is done with 'yq'. These are assumed values,
@@ -305,14 +327,14 @@ pub(crate) struct Eventing {
 
 impl Eventing {
     /// This is a predicate for the installation setting for eventing.
-    pub(crate) fn enabled(&self) -> bool {
+    fn enabled(&self) -> bool {
         self.enabled
     }
 }
 
 /// This is used to deserialize the yaml object 'csi'.
 #[derive(Deserialize)]
-pub(crate) struct Csi {
+struct Csi {
     /// This contains the image tags for the kubernetes-csi sidecar containers.
     image: CsiImage,
     /// This contains configuration for the CSI node.
@@ -321,32 +343,32 @@ pub(crate) struct Csi {
 
 impl Csi {
     /// This is a getter for the sig-storage/csi-provisioner image tag.
-    pub(crate) fn provisioner_image_tag(&self) -> &str {
+    fn provisioner_image_tag(&self) -> &str {
         self.image.provisioner_tag()
     }
 
     /// This is a getter for the sig-storage/csi-attacher image tag.
-    pub(crate) fn attacher_image_tag(&self) -> &str {
+    fn attacher_image_tag(&self) -> &str {
         self.image.attacher_tag()
     }
 
     /// This is a getter for the sig-storage/csi-snapshotter image tag.
-    pub(crate) fn snapshotter_image_tag(&self) -> &str {
+    fn snapshotter_image_tag(&self) -> &str {
         self.image.snapshotter_tag()
     }
 
     /// This is a getter for the sig-storage/snapshot-controller image tag.
-    pub(crate) fn snapshot_controller_image_tag(&self) -> &str {
+    fn snapshot_controller_image_tag(&self) -> &str {
         self.image.snapshot_controller_tag()
     }
 
     /// This is a getter for the sig-storage/csi-node-driver-registrar image tag.
-    pub(crate) fn node_driver_registrar_image_tag(&self) -> &str {
+    fn node_driver_registrar_image_tag(&self) -> &str {
         self.image.node_driver_registrar_tag()
     }
 
     /// This is a getter for the CSI node NVMe io_timeout.
-    pub(crate) fn node_nvme_io_timeout(&self) -> &str {
+    fn node_nvme_io_timeout(&self) -> &str {
         self.node.nvme_io_timeout()
     }
 }
@@ -354,7 +376,7 @@ impl Csi {
 /// This contains the image tags for the CSI sidecar containers.
 #[derive(Deserialize)]
 #[serde(rename_all(deserialize = "camelCase"))]
-pub(crate) struct CsiImage {
+struct CsiImage {
     /// This is the image tag for the csi-provisioner container.
     provisioner_tag: String,
     /// This is the image tag for the csi-attacher container.
@@ -371,105 +393,240 @@ pub(crate) struct CsiImage {
 
 impl CsiImage {
     /// This is a getter for provisionerTag.
-    pub(crate) fn provisioner_tag(&self) -> &str {
+    fn provisioner_tag(&self) -> &str {
         self.provisioner_tag.as_str()
     }
 
     /// This is a getter for attacherTag.
-    pub(crate) fn attacher_tag(&self) -> &str {
+    fn attacher_tag(&self) -> &str {
         self.attacher_tag.as_str()
     }
 
     /// This is a getter for snapshotterTag.
-    pub(crate) fn snapshotter_tag(&self) -> &str {
+    fn snapshotter_tag(&self) -> &str {
         self.snapshotter_tag.as_str()
     }
 
     /// This is a getter for snapshotControllerTag.
-    pub(crate) fn snapshot_controller_tag(&self) -> &str {
+    fn snapshot_controller_tag(&self) -> &str {
         self.snapshot_controller_tag.as_str()
     }
 
     /// This is a getter for registrarTag.
-    pub(crate) fn node_driver_registrar_tag(&self) -> &str {
+    fn node_driver_registrar_tag(&self) -> &str {
         self.registrar_tag.as_str()
     }
 }
 
 /// This is used to deserialize the yaml object 'csi.node'.
 #[derive(Deserialize)]
-pub(crate) struct CsiNode {
+struct CsiNode {
     nvme: CsiNodeNvme,
 }
 
 impl CsiNode {
     /// This is a getter for the NVMe IO timeout.
-    pub(crate) fn nvme_io_timeout(&self) -> &str {
+    fn nvme_io_timeout(&self) -> &str {
         self.nvme.io_timeout()
     }
 }
 
 /// This is used to deserialize the yaml object 'csi.node.nvme'.
 #[derive(Deserialize)]
-pub(crate) struct CsiNodeNvme {
+struct CsiNodeNvme {
     io_timeout: String,
 }
 
 impl CsiNodeNvme {
     /// This is a getter for the IO timeout configuration.
-    pub(crate) fn io_timeout(&self) -> &str {
+    fn io_timeout(&self) -> &str {
         self.io_timeout.as_str()
     }
 }
 
 /// This is used to deserialize the yaml object 'loki-stack'.
 #[derive(Deserialize)]
-pub(crate) struct LokiStack {
+struct LokiStack {
+    loki: Loki,
     promtail: Promtail,
 }
 
 impl LokiStack {
-    pub(crate) fn promtail_scrape_configs(&self) -> &str {
+    /// This is a getter for the promtail scrapeConfigs value.
+    fn promtail_scrape_configs(&self) -> &str {
         self.promtail.scrape_configs()
+    }
+
+    /// This returns the config.snippets.extraClientConfigs from the promtail helm chart v3.11.0.
+    fn deprecated_promtail_extra_client_configs(&self) -> &str {
+        self.promtail.deprecated_extra_client_configs()
+    }
+
+    /// This is a getter for the grafana/loki container's image tag.
+    fn loki_image_tag(&self) -> &str {
+        self.loki.image_tag()
+    }
+
+    fn deprecated_promtail_loki_address(&self) -> &str {
+        self.promtail.deprecated_loki_address()
+    }
+
+    fn promtail_config_file(&self) -> &str {
+        self.promtail.config_file()
+    }
+
+    fn promtail_readiness_probe_path(&self) -> &str {
+        self.promtail.readiness_probe_http_get_path()
+    }
+}
+
+/// This is used to deserialize the loki dependent helm chart's values set.
+#[derive(Deserialize)]
+struct Loki {
+    image: LokiImage,
+}
+
+impl Loki {
+    /// This is a getter for the container image tag.
+    fn image_tag(&self) -> &str {
+        self.image.tag()
+    }
+}
+
+/// This is used to deserialize the yaml object 'image' in the loki helm chart.
+#[derive(Deserialize)]
+struct LokiImage {
+    tag: String,
+}
+
+impl LokiImage {
+    /// This is a getter for the image's tag.
+    fn tag(&self) -> &str {
+        self.tag.as_str()
     }
 }
 
 /// This is used to deserialize the yaml object 'promtail'.
 #[derive(Deserialize)]
-pub(crate) struct Promtail {
+#[serde(rename_all(deserialize = "camelCase"))]
+struct Promtail {
     config: PromtailConfig,
+    readiness_probe: PromtailReadinessProbe,
 }
 
 impl Promtail {
     /// This returns the promtail.config.snippets.scrapeConfigs as an &str.
-    pub(crate) fn scrape_configs(&self) -> &str {
+    fn scrape_configs(&self) -> &str {
         self.config.scrape_configs()
+    }
+
+    /// This returns the config.snippets.extraClientConfigs from the promtail helm chart v3.11.0.
+    fn deprecated_extra_client_configs(&self) -> &str {
+        self.config.deprecated_extra_client_configs()
+    }
+
+    fn deprecated_loki_address(&self) -> &str {
+        self.config.deprecated_loki_address()
+    }
+
+    fn config_file(&self) -> &str {
+        self.config.file()
+    }
+
+    fn readiness_probe_http_get_path(&self) -> &str {
+        self.readiness_probe.http_get_path()
     }
 }
 
 /// This is used to deserialize the promtail.config yaml object.
 #[derive(Deserialize)]
-pub(crate) struct PromtailConfig {
+struct PromtailConfig {
+    #[serde(default, rename(deserialize = "lokiAddress"))]
+    deprecated_loki_address: String,
+    file: String,
     snippets: PromtailConfigSnippets,
 }
 
 impl PromtailConfig {
     /// This returns the config.snippets.scrapeConfigs as an &str.
-    pub(crate) fn scrape_configs(&self) -> &str {
+    fn scrape_configs(&self) -> &str {
         self.snippets.scrape_configs()
+    }
+
+    /// This returns the snippets.extraClientConfigs from the promtail helm chart v3.11.0.
+    fn deprecated_extra_client_configs(&self) -> &str {
+        self.snippets.deprecated_extra_client_configs()
+    }
+
+    /// This is a getter for the lokiAddress in the loki helm chart v2.6.4.
+    fn deprecated_loki_address(&self) -> &str {
+        self.deprecated_loki_address.as_str()
+    }
+
+    fn file(&self) -> &str {
+        self.file.as_str()
     }
 }
 
 /// This is used to deserialize the config.snippets yaml object.
 #[derive(Deserialize)]
 #[serde(rename_all(deserialize = "camelCase"))]
-pub(crate) struct PromtailConfigSnippets {
+struct PromtailConfigSnippets {
+    #[serde(default, rename(deserialize = "extraClientConfigs"))]
+    deprecated_extra_client_configs: String,
     scrape_configs: String,
 }
 
 impl PromtailConfigSnippets {
     /// This returns the snippets.scrapeConfigs as an &str.
-    pub(crate) fn scrape_configs(&self) -> &str {
+    fn scrape_configs(&self) -> &str {
         self.scrape_configs.as_str()
+    }
+
+    /// This returns the snippets.extraClientConfigs from the promtail helm chart v3.11.0.
+    fn deprecated_extra_client_configs(&self) -> &str {
+        self.deprecated_extra_client_configs.as_str()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+struct PromtailReadinessProbe {
+    http_get: PromtailReadinessProbeHttpGet,
+}
+
+impl PromtailReadinessProbe {
+    fn http_get_path(&self) -> &str {
+        self.http_get.path()
+    }
+}
+
+#[derive(Deserialize)]
+struct PromtailReadinessProbeHttpGet {
+    path: String,
+}
+
+impl PromtailReadinessProbeHttpGet {
+    fn path(&self) -> &str {
+        self.path.as_str()
+    }
+}
+
+/// This is used to serialize the config.clients yaml object in promtail chart v6.13.1
+/// when migrating from promtail v3.11.0 to v6.13.1.
+#[derive(Debug, Serialize)]
+pub(crate) struct PromtailConfigClient {
+    url: String,
+}
+
+impl PromtailConfigClient {
+    /// Create a new PromtailConfigClient with a url.
+    pub(crate) fn with_url<U>(url: U) -> Self
+    where
+        U: ToString,
+    {
+        Self {
+            url: url.to_string(),
+        }
     }
 }

--- a/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
@@ -199,12 +199,41 @@ impl CoreValues {
         self.loki_stack.deprecated_promtail_extra_client_configs()
     }
 
+    /// This returns the initContainers array from the promtail chart v6.13.1.
     pub(crate) fn promtail_init_container(&self) -> Vec<Container> {
         self.loki_stack.promtail_init_container()
     }
 
+    /// This returns the readinessProbe HTTP Get path from the promtail chart v6.13.1.
     pub(crate) fn promtail_readiness_probe_http_get_path(&self) -> String {
         self.loki_stack.promtail_readiness_probe_http_get_path()
+    }
+
+    /// This returns the image tag from the filebeat helm chart. Filebeat is a part of the
+    /// loki-stack chart.
+    pub(crate) fn filebeat_image_tag(&self) -> &str {
+        self.loki_stack.filebeat_image_tag()
+    }
+
+    /// This returns the image tag from the logstash helm chart. Logstash is a part of the
+    /// loki-stack chart.
+    pub(crate) fn logstash_image_tag(&self) -> &str {
+        self.loki_stack.logstash_image_tag()
+    }
+
+    /// This returns the image tag for the curlimages/curl container.
+    pub(crate) fn grafana_download_dashboards_image_tag(&self) -> &str {
+        self.loki_stack.grafana_download_dashboards_image_tag()
+    }
+
+    /// This returns the image tag for the grafana/grafana container.
+    pub(crate) fn grafana_image_tag(&self) -> &str {
+        self.loki_stack.grafana_image_tag()
+    }
+
+    /// This returns the image tag for the kiwigrid/k8s-sidecar container.
+    pub(crate) fn grafana_sidecar_image_tag(&self) -> &str {
+        self.loki_stack.grafana_sidecar_image_tag()
     }
 }
 
@@ -454,6 +483,9 @@ impl CsiNodeNvme {
 /// This is used to deserialize the yaml object 'loki-stack'.
 #[derive(Deserialize)]
 struct LokiStack {
+    filebeat: Filebeat,
+    grafana: Grafana,
+    logstash: Logstash,
     loki: Loki,
     promtail: Promtail,
 }
@@ -464,6 +496,7 @@ impl LokiStack {
         self.promtail.scrape_configs()
     }
 
+    /// This is a getter for the value of 'promtail.config.file'.
     fn promtail_config_file(&self) -> &str {
         self.promtail.config_file()
     }
@@ -473,20 +506,155 @@ impl LokiStack {
         self.promtail.deprecated_extra_client_configs()
     }
 
+    /// This is a getter for the deprecated 'lokiAddress' field in the promtail helm chart v3.11.0.
     fn deprecated_promtail_loki_address(&self) -> &str {
         self.promtail.deprecated_loki_address()
     }
 
+    /// This is a getter for the loki/loki container's image tag.
     fn loki_image_tag(&self) -> &str {
         self.loki.image_tag()
     }
 
+    /// This is a getter for the initContainer array from promtail chart v6.13.1.
     fn promtail_init_container(&self) -> Vec<Container> {
         self.promtail.init_container()
     }
 
+    /// This is a getter for the readinessProbe HTTP GET path from promtail chart v6.13.1.
     fn promtail_readiness_probe_http_get_path(&self) -> String {
         self.promtail.readiness_probe_http_get_path()
+    }
+
+    /// This is a getter for the filebeat image tag from the loki-stack helm chart.
+    fn filebeat_image_tag(&self) -> &str {
+        self.filebeat.image_tag()
+    }
+
+    /// This is a getter for the logstash image tag from the loki-stack helm chart.
+    fn logstash_image_tag(&self) -> &str {
+        self.logstash.image_tag()
+    }
+
+    /// This is a getter for the curlimages/curl container's image tag from the grafana chart.
+    fn grafana_download_dashboards_image_tag(&self) -> &str {
+        self.grafana.download_dashboards_image_tag()
+    }
+
+    /// This is a getter for the grafana/grafana container's image tag from the grafana chart.
+    fn grafana_image_tag(&self) -> &str {
+        self.grafana.image_tag()
+    }
+
+    /// This is a getter for the kiwigrid/k8s-sidecar container's image tag from the grafana chart.
+    fn grafana_sidecar_image_tag(&self) -> &str {
+        self.grafana.sidecar_image_tag()
+    }
+}
+
+/// This is used to deserialize the YAML object 'loki-stack.filebeat'.
+#[derive(Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+struct Filebeat {
+    image_tag: String,
+}
+
+impl Filebeat {
+    /// This is a getter for the Filebeat image tag.
+    fn image_tag(&self) -> &str {
+        self.image_tag.as_str()
+    }
+}
+
+/// This is used to deserialize the YAML object 'loki-stack.grafana'.
+#[derive(Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+struct Grafana {
+    download_dashboards_image: GrafanaDownloadDashboardsImage,
+    image: GrafanaImage,
+    sidecar: GrafanaSidecar,
+}
+
+impl Grafana {
+    /// This is getter for the curlimages/curl container image tag.
+    fn download_dashboards_image_tag(&self) -> &str {
+        self.download_dashboards_image.tag()
+    }
+
+    /// This is getter for the grafana/grafana container image tag.
+    fn image_tag(&self) -> &str {
+        self.image.tag()
+    }
+
+    /// This is a getter for the kiwigrid/k8s-sidecar sidecar container image tag.
+    fn sidecar_image_tag(&self) -> &str {
+        self.sidecar.image_tag()
+    }
+}
+
+/// This is used to deserialize the YAML object 'loki-stack.grafana.downloadDashboardsImage'.
+#[derive(Deserialize)]
+struct GrafanaDownloadDashboardsImage {
+    tag: String,
+}
+
+impl GrafanaDownloadDashboardsImage {
+    /// This is a getter for the curlimages/curl container image on the grafana chart.
+    fn tag(&self) -> &str {
+        self.tag.as_str()
+    }
+}
+
+/// This is used to deserialize the YAML object 'loki-stack.grafana.image'.
+#[derive(Deserialize)]
+struct GrafanaImage {
+    tag: String,
+}
+
+impl GrafanaImage {
+    /// This is a getter for the grafana/grafana container image on the grafana chart.
+    fn tag(&self) -> &str {
+        self.tag.as_str()
+    }
+}
+
+/// This is used to deserialize the YAML object 'loki-stack.grafana.sidecar'.
+#[derive(Deserialize)]
+struct GrafanaSidecar {
+    image: GrafanaSidecarImage,
+}
+
+impl GrafanaSidecar {
+    /// This is a getter for the kiwigrid/k8s-sidecar sidecar container image tag.
+    fn image_tag(&self) -> &str {
+        self.image.tag()
+    }
+}
+
+/// This is used to deserialize the YAML object 'loki-stack.grafana.sidecar.image'.
+#[derive(Deserialize)]
+struct GrafanaSidecarImage {
+    tag: String,
+}
+
+impl GrafanaSidecarImage {
+    /// This is a getter for the kiwigrid/k8s-sidecar container image on the grafana chart.
+    fn tag(&self) -> &str {
+        self.tag.as_str()
+    }
+}
+
+/// This is used to deserialize the YAML object 'loki-stack.logstash'.
+#[derive(Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+struct Logstash {
+    image_tag: String,
+}
+
+impl Logstash {
+    /// This is a getter for the Logstash image tag.
+    fn image_tag(&self) -> &str {
+        self.image_tag.as_str()
     }
 }
 

--- a/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
@@ -129,6 +129,7 @@ impl HelmUpgraderBuilder {
             }
             .build(),
         )?;
+
         let helm_args_set = self.helm_args_set.unwrap_or_default();
         let helm_args_set_file = self.helm_args_set_file.unwrap_or_default();
 

--- a/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
@@ -129,7 +129,6 @@ impl HelmUpgraderBuilder {
             }
             .build(),
         )?;
-
         let helm_args_set = self.helm_args_set.unwrap_or_default();
         let helm_args_set_file = self.helm_args_set_file.unwrap_or_default();
 

--- a/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
@@ -181,6 +181,31 @@ where
             target_values.loki_stack_loki_image_tag(),
             upgrade_values_file.path(),
         )?;
+        yq.set_literal_value(
+            YamlKey::try_from(".loki-stack.filebeat.imageTag")?,
+            target_values.filebeat_image_tag(),
+            upgrade_values_file.path(),
+        )?;
+        yq.set_literal_value(
+            YamlKey::try_from(".loki-stack.logstash.imageTag")?,
+            target_values.logstash_image_tag(),
+            upgrade_values_file.path(),
+        )?;
+        yq.set_literal_value(
+            YamlKey::try_from(".loki-stack.grafana.downloadDashboardsImage.tag")?,
+            target_values.grafana_download_dashboards_image_tag(),
+            upgrade_values_file.path(),
+        )?;
+        yq.set_literal_value(
+            YamlKey::try_from(".loki-stack.grafana.image.tag")?,
+            target_values.grafana_image_tag(),
+            upgrade_values_file.path(),
+        )?;
+        yq.set_literal_value(
+            YamlKey::try_from(".loki-stack.grafana.sidecar.image.tag")?,
+            target_values.grafana_sidecar_image_tag(),
+            upgrade_values_file.path(),
+        )?;
         // Delete deprecated objects.
         yq.delete_object(
             YamlKey::try_from(".loki-stack.loki.config.ingester.lifecycler.ring.kvstore")?,

--- a/k8s/upgrade/src/bin/upgrade-job/helm/yaml/yq.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/yaml/yq.rs
@@ -177,9 +177,10 @@ impl YqV4 {
     }
 
     /// This sets in-place yaml values in yaml files.
-    pub(crate) fn set_value<V>(&self, key: YamlKey, value: V, filepath: &Path) -> Result<()>
+    pub(crate) fn set_value<V, P>(&self, key: YamlKey, value: V, filepath: P) -> Result<()>
     where
         V: Display + Sized,
+        P: AsRef<Path>,
     {
         // Command for use during yq file update
         let mut command = self.command();
@@ -209,7 +210,7 @@ impl YqV4 {
         let yq_set_args = vec_to_strings![
             "-i",
             format!(r#"{} = {value}"#, key.as_str()),
-            filepath.to_string_lossy()
+            filepath.as_ref().to_string_lossy()
         ];
         let yq_set_output = command
             .args(yq_set_args.clone())
@@ -234,16 +235,20 @@ impl YqV4 {
     }
 
     /// This sets yaml objects to a file from the same yaml object in another file.
-    pub(crate) fn set_obj(&self, key: YamlKey, obj_source: &Path, filepath: &Path) -> Result<()> {
+    pub(crate) fn set_obj<P, Q>(&self, key: YamlKey, obj_source: P, filepath: Q) -> Result<()>
+    where
+        P: AsRef<Path>,
+        Q: AsRef<Path>,
+    {
         let yq_set_obj_args = vec_to_strings![
             "-i",
             format!(
                 r#"{} = load("{}"){}"#,
                 key.as_str(),
-                obj_source.to_string_lossy(),
+                obj_source.as_ref().to_string_lossy(),
                 key.as_str()
             ),
-            filepath.to_string_lossy()
+            filepath.as_ref().to_string_lossy()
         ];
         let yq_set_obj_output = self
             .command()

--- a/k8s/upgrade/src/bin/upgrade-job/helm/yaml/yq.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/yaml/yq.rs
@@ -2,7 +2,7 @@ use crate::{
     common::error::{
         NotAValidYamlKeyForStringValue, NotYqV4, RegexCompile, Result, U8VectorToString,
         YqAppendToArrayCommand, YqAppendToObjectCommand, YqCommandExec, YqDeleteObjectCommand,
-        YqMergeCommand, YqSetCommand, YqSetObjectFromFileCommand, YqVersionCommand,
+        YqMergeCommand, YqSetCommand, YqVersionCommand,
     },
     vec_to_strings,
 };
@@ -300,47 +300,6 @@ impl YqV4 {
                 command: self.command_as_str().to_string(),
                 args: yq_set_args,
                 std_err: str::from_utf8(yq_set_output.stderr.as_slice())
-                    .context(U8VectorToString)?
-                    .to_string()
-            }
-        );
-
-        Ok(())
-    }
-
-    /// This sets in-place yaml objects into a YAML file, from a field in another YAML file.
-    /// The 'source' args are the source of the object (where to take it from).
-    /// The 'target' args are the destination of the object (where to make the actual change).
-    pub(crate) fn set_object_from_file<P, Q>(
-        &self,
-        source_key: YamlKey,
-        source_filepath: P,
-        target_key: YamlKey,
-        target_filepath: Q,
-    ) -> Result<()>
-    where
-        P: AsRef<Path>,
-        Q: AsRef<Path>,
-    {
-        let yq_object_from_file_args = vec_to_strings![
-            "-i",
-            format!(
-                r#"{} = load("{}"){}"#,
-                target_key.as_str(),
-                source_filepath.as_ref().to_string_lossy(),
-                source_key.as_str()
-            ),
-            target_filepath.as_ref().to_string_lossy()
-        ];
-
-        let yq_object_from_file_output = self.command_output(yq_object_from_file_args.clone())?;
-
-        ensure!(
-            yq_object_from_file_output.status.success(),
-            YqSetObjectFromFileCommand {
-                command: self.command_as_str().to_string(),
-                args: yq_object_from_file_args,
-                std_err: str::from_utf8(yq_object_from_file_output.stderr.as_slice())
                     .context(U8VectorToString)?
                     .to_string()
             }

--- a/k8s/upgrade/src/bin/upgrade-job/helm/yaml/yq.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/yaml/yq.rs
@@ -1,15 +1,23 @@
 use crate::{
     common::error::{
         NotAValidYamlKeyForStringValue, NotYqV4, RegexCompile, Result, U8VectorToString,
-        YqCommandExec, YqMergeCommand, YqSetCommand, YqSetObjCommand, YqVersionCommand,
+        YqAppendToArrayCommand, YqAppendToObjectCommand, YqCommandExec, YqDeleteObjectCommand,
+        YqMergeCommand, YqSetCommand, YqVersionCommand,
     },
     vec_to_strings,
 };
 use regex::Regex;
 use snafu::{ensure, ResultExt};
-use std::{fmt::Display, ops::Deref, path::Path, process::Command, str};
+use std::{
+    fmt::Display,
+    ops::Deref,
+    path::Path,
+    process::{Command, Output},
+    str,
+};
 
 /// This is a container for the String of an input yaml key.
+#[derive(Clone)]
 pub(crate) struct YamlKey(String);
 
 impl TryFrom<&str> for YamlKey {
@@ -60,14 +68,7 @@ impl YqV4 {
 
         let yq_version_arg = "-V".to_string();
 
-        let yq_version_output = yq_v4
-            .command()
-            .arg(yq_version_arg.clone())
-            .output()
-            .context(YqCommandExec {
-                command: yq_v4.command_as_str().to_string(),
-                args: vec![yq_version_arg.clone()],
-            })?;
+        let yq_version_output = yq_v4.command_output(vec![yq_version_arg.clone()])?;
 
         ensure!(
             yq_version_output.status.success(),
@@ -96,6 +97,86 @@ impl YqV4 {
         );
 
         Ok(yq_v4)
+    }
+
+    /// Append objects to yaml arrays.
+    pub(crate) fn append_to_array<V, P>(&self, key: YamlKey, value: V, filepath: P) -> Result<()>
+    where
+        V: Display + Sized,
+        P: AsRef<Path>,
+    {
+        let yq_append_to_array_args = vec_to_strings![
+            "-i",
+            format!(r#"{} += [{value}]"#, key.as_str()),
+            filepath.as_ref().to_string_lossy()
+        ];
+        let yq_append_to_array_output = self.command_output(yq_append_to_array_args.clone())?;
+
+        ensure!(
+            yq_append_to_array_output.status.success(),
+            YqAppendToArrayCommand {
+                command: self.command_as_str().to_string(),
+                args: yq_append_to_array_args,
+                std_err: str::from_utf8(yq_append_to_array_output.stderr.as_slice())
+                    .context(U8VectorToString)?
+                    .to_string()
+            }
+        );
+
+        Ok(())
+    }
+
+    /// Append objects to yaml arrays.
+    pub(crate) fn append_to_object<V, P>(&self, key: YamlKey, value: V, filepath: P) -> Result<()>
+    where
+        V: Display + Sized,
+        P: AsRef<Path>,
+    {
+        let yq_append_to_object_args = vec_to_strings![
+            "-i",
+            format!(r#"{} += {value}"#, key.as_str()),
+            filepath.as_ref().to_string_lossy()
+        ];
+        let yq_append_to_object_output = self.command_output(yq_append_to_object_args.clone())?;
+
+        ensure!(
+            yq_append_to_object_output.status.success(),
+            YqAppendToObjectCommand {
+                command: self.command_as_str().to_string(),
+                args: yq_append_to_object_args,
+                std_err: str::from_utf8(yq_append_to_object_output.stderr.as_slice())
+                    .context(U8VectorToString)?
+                    .to_string()
+            }
+        );
+
+        Ok(())
+    }
+
+    /// Use the yq 'delpaths' operator to delete objects from a yaml file.
+    pub(crate) fn delete_object<P>(&self, key: YamlKey, filepath: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        let yq_delete_object_args = vec_to_strings![
+            "-i",
+            format!(r#"delpaths([["{}"]])"#, key.as_str()),
+            filepath.as_ref().to_string_lossy()
+        ];
+        let yq_delete_object_output = self.command_output(yq_delete_object_args.clone())?;
+
+        ensure!(
+            yq_delete_object_output.status.success(),
+            YqDeleteObjectCommand {
+                command: self.command_as_str().to_string(),
+                args: yq_delete_object_args,
+                std_err: str::from_utf8(yq_delete_object_output.stderr.as_slice())
+                    .context(U8VectorToString)?
+                    .to_string()
+            }
+        );
+
+        Ok(())
     }
 
     // TODO:
@@ -153,14 +234,7 @@ impl YqV4 {
             low_priority.as_ref().to_string_lossy(),
             high_priority.as_ref().to_string_lossy()
         ];
-        let yq_merge_output = self
-            .command()
-            .args(yq_merge_args.clone())
-            .output()
-            .context(YqCommandExec {
-                command: self.command_as_str().to_string(),
-                args: yq_merge_args.clone(),
-            })?;
+        let yq_merge_output = self.command_output(yq_merge_args.clone())?;
 
         ensure!(
             yq_merge_output.status.success(),
@@ -177,7 +251,7 @@ impl YqV4 {
     }
 
     /// This sets in-place yaml values in yaml files.
-    pub(crate) fn set_value<V, P>(&self, key: YamlKey, value: V, filepath: P) -> Result<()>
+    pub(crate) fn set_literal_value<V, P>(&self, key: YamlKey, value: V, filepath: P) -> Result<()>
     where
         V: Display + Sized,
         P: AsRef<Path>,
@@ -234,48 +308,20 @@ impl YqV4 {
         Ok(())
     }
 
-    /// This sets yaml objects to a file from the same yaml object in another file.
-    pub(crate) fn set_obj<P, Q>(&self, key: YamlKey, obj_source: P, filepath: Q) -> Result<()>
-    where
-        P: AsRef<Path>,
-        Q: AsRef<Path>,
-    {
-        let yq_set_obj_args = vec_to_strings![
-            "-i",
-            format!(
-                r#"{} = load("{}"){}"#,
-                key.as_str(),
-                obj_source.as_ref().to_string_lossy(),
-                key.as_str()
-            ),
-            filepath.as_ref().to_string_lossy()
-        ];
-        let yq_set_obj_output = self
-            .command()
-            .args(yq_set_obj_args.clone())
-            .output()
-            .context(YqCommandExec {
-                command: self.command_as_str().to_string(),
-                args: yq_set_obj_args.clone(),
-            })?;
-
-        ensure!(
-            yq_set_obj_output.status.success(),
-            YqSetObjCommand {
-                command: self.command_as_str().to_string(),
-                args: yq_set_obj_args,
-                std_err: str::from_utf8(yq_set_obj_output.stderr.as_slice())
-                    .context(U8VectorToString)?
-                    .to_string()
-            }
-        );
-
-        Ok(())
-    }
-
     /// Returns an std::process::Command using the command_as_str member's value.
     fn command(&self) -> Command {
         Command::new(self.command_name.clone())
+    }
+
+    /// This executes a command and returns the output.
+    fn command_output(&self, args: Vec<String>) -> Result<Output> {
+        self.command()
+            .args(args.clone())
+            .output()
+            .context(YqCommandExec {
+                command: self.command_as_str().to_string(),
+                args,
+            })
     }
 
     /// The binary name of the `yq` command.

--- a/scripts/helm/generate-consolidated-values.sh
+++ b/scripts/helm/generate-consolidated-values.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]:-"$0"}")")"
+DEFAULT_CHART_DIR="$SCRIPT_DIR/../../chart"
+CHART_DIR="$DEFAULT_CHART_DIR"
+
+# Imports
+source "$SCRIPT_DIR/../utils/log.sh"
+
+# Print usage options for this script.
+print_help() {
+  cat <<EOF
+Usage: $(basename "${0}") [OPTIONS]
+
+Options:
+  -h, --help                    Display this text
+  -d, --chart-dir <DIRECTORY>   Specify the helm chart directory (default "$DEFAULT_CHART_DIR")
+
+Examples:
+  $(basename "${0}") --chart-dir "./chart"
+EOF
+}
+
+# Parse arguments.
+parse_args() {
+  while test $# -gt 0; do
+    arg="$1"
+    case "$arg" in
+    -d | --chart-dir)
+      test $# -lt 2 && log_fatal "missing value for the optional argument '$arg'"
+      CHART_DIR="${2%/}"
+      shift
+      ;;
+    -d=* | --chart-dir=*)
+      CHART_DIR="${arg#*=}"
+      ;;
+    -h* | --help*)
+      print_help
+      exit 0
+      ;;
+    *)
+      print_help
+      log_fatal "unexpected argument '$arg'"
+      ;;
+    esac
+    shift
+  done
+}
+
+# Generate in-place consolidated values YAMLs throughout the
+# helm chart hierarchy (root chart and sub-charts).
+consolidate() {
+  local -r chart_dir="$1"
+  local -r chart_name="${chart_dir##*/}"
+
+  if stat "$chart_dir"/charts &> /dev/null; then
+    for dir in "$chart_dir"/charts/*; do
+      consolidate "$dir"
+    done
+  fi
+
+  if [[ $(yq ".$chart_name" "$chart_dir"/../../values.yaml) == null ]]; then
+    yq -i ".$chart_name = {}" "$chart_dir"/../../values.yaml
+  fi
+
+  yq -i ".$chart_name |= (load(\"$chart_dir/values.yaml\") * .)" "$chart_dir"/../../values.yaml
+}
+
+# Parse CLI args.
+parse_args "$@"
+
+if ! stat "$CHART_DIR"/charts &> /dev/null; then
+  exit 0
+fi
+
+for dir in "$CHART_DIR"/charts/*; do
+  consolidate "$dir"
+done

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -242,8 +242,13 @@ for name in $IMAGES; do
         echo "Updating helm chart dependencies..."
         # Helm chart directory path -- /scripts --> /chart
         CHART_DIR="${SCRIPT_DIR}/../chart"
+        dep_chart_dir="${CHART_DIR}/charts"
 
         $NIX_SHELL --run "helm dependency update ${CHART_DIR}"
+        for dep_chart_tar in "${dep_chart_dir}"/*.tgz; do
+          tar -xf "${dep_chart_tar}" -C "${dep_chart_dir}"
+          rm -f "${dep_chart_tar}"
+        done
 
         # Set flag to true
         _helm_dependencies_updated=true

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -253,8 +253,17 @@ for name in $IMAGES; do
         echo "Updating helm chart dependencies..."
         # Helm chart directory path -- /scripts --> /chart
         CHART_DIR="${SCRIPT_DIR}/../chart"
+        dep_chart_dir="${CHART_DIR}/charts"
 
+        # This performs a dependency update and then extracts the tarballs pulled.
+        # If and when the `--untar` functionality is added to the `helm dependency
+        # update` command, the for block can be removed in favour of the `--untar` option.
+        # Ref: https://github.com/helm/helm/issues/8479
         $NIX_SHELL --run "helm dependency update ${CHART_DIR}"
+        for dep_chart_tar in "${dep_chart_dir}"/*.tgz; do
+          tar -xf "${dep_chart_tar}" -C "${dep_chart_dir}"
+          rm -f "${dep_chart_tar}"
+        done
 
         # Set flag to true
         _helm_dependencies_updated="true"


### PR DESCRIPTION
Requires #386.

Overview:
- adds new yq commands to delete objects, append to objects, and append to arrays.
- adds special upgrade values.yaml update for loki-stack changes from #386. Introduces migrations and set_literal_value updates to alter the existing yaml till it resembles the new one.
- replaces all `&Path` is the `helm::yaml::yq` module with `AsRef<Path>`.

Changes:
- removes .loki-stack.loki.config.ingester.lifecycler.ring.kvstore as it
does not exist in loki-stack v2.9.11
- adds set value for the grafana/loki container image tag
- removes .loki-stack.promtail.config.snippets.extraClientConfigs as it
does not exist in loki-stack v2.9.11
- removes .loki-stack.promtail.initContainer as it does not exist in loki-stack
v2.9.11
- migrates .loki-stack.promtail.config.lokiAddress to .loki-stack.promtail.config.clients
- adds yq command_output helper function
- add set value for .loki-stack.promtail.readinessProbe.httpGet.path
- migrate .loki-stack.promtail.config.snippets.extraClientConfigs to
.loki-stack.promtail.config.clients