### PR TITLE
fix(upgrade-job): avoid infinite loop when no unhealthy vols have a target

### DIFF
--- a/k8s/upgrade/src/bin/upgrade-job/upgrade/utils.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/upgrade/utils.rs
@@ -33,14 +33,13 @@ pub(crate) async fn rebuild_result(
             break;
         }
 
+        let mut volume_over_nodes = HashSet::new();
         for volume in unhealthy_volumes.iter() {
-            let target = if let Some(target) = volume.state.target.as_ref() {
-                target
-            } else {
-                continue;
+            let target = match volume.state.target.as_ref() {
+                Some(t) => t,
+                None => continue,
             };
 
-            let mut volume_over_nodes = HashSet::new();
             volume_over_nodes.insert(target.node.as_str());
 
             for (_, topology) in volume.state.replica_topology.iter() {
@@ -73,6 +72,9 @@ pub(crate) async fn rebuild_result(
                     }
                 }
             }
+        }
+        if volume_over_nodes.is_empty() {
+            break;
         }
     }
     Ok(RebuildResult {


### PR DESCRIPTION
Fixes a bug where if, during data-plane upgrade, `rebuild_result` function finds unhealthy volumes, but none of the volumes have a target, then, the function continues to try to list unhealthy volumes constantly.

<!--- Provide a general summary of your changes in the Title above -->
Adds a break from the infinite loop for an empty target accumulator.

## Description
<!--- Describe your changes in detail -->
Adds a break from the infinite loop for an empty target hashset.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.