### PR TITLE
fix(chart): promtail subchart changes for chart v6.13.1

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -163,7 +163,7 @@ $ helm install my-release openebs/mayastor
 | loki-stack.&ZeroWidthSpace;loki.&ZeroWidthSpace;persistence.&ZeroWidthSpace;size | Size of Loki's persistence storage | `"10Gi"` |
 | loki-stack.&ZeroWidthSpace;loki.&ZeroWidthSpace;persistence.&ZeroWidthSpace;storageClassName | StorageClass for Loki's centralised log storage. Options: <p> - `"manual"` - Will provision a hostpath PV on the same node. <br> - `""` (empty) - Will use the default StorageClass on the cluster. </p> | `"mayastor-loki-localpv"` |
 | loki-stack.&ZeroWidthSpace;loki.&ZeroWidthSpace;rbac.&ZeroWidthSpace;create | Create rbac roles for loki | `true` |
-| loki-stack.&ZeroWidthSpace;promtail.&ZeroWidthSpace;config.&ZeroWidthSpace;lokiAddress | The Loki address to post logs to | `"http://{{ .Release.Name }}-loki:3100/loki/api/v1/push"` |
+| loki-stack.&ZeroWidthSpace;promtail.&ZeroWidthSpace;config.&ZeroWidthSpace;clients[0] | The Loki address to post logs to | <pre>{<br>"url":"http://{<br>{<br> .Release.Name <br>}<br>}-loki:3100/loki/api/v1/push"<br>}</pre> |
 | loki-stack.&ZeroWidthSpace;promtail.&ZeroWidthSpace;enabled | Enables promtail for scraping logs from nodes | `true` |
 | loki-stack.&ZeroWidthSpace;promtail.&ZeroWidthSpace;tolerations | Disallow promtail from running on the master node | `[]` |
 | nodeSelector | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ Note that if multi-arch images support 'kubernetes.io/arch: amd64' should be removed and set 'nodeSelector' to empty '{}' as default value. | <pre>{<br>"kubernetes.io/arch":"amd64"<br>}</pre> |

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -594,8 +594,9 @@ loki-stack:
     tolerations: []
     priorityClassName: ""
     config:
-      # -- The Loki address to post logs to
-      lokiAddress: http://{{ .Release.Name }}-loki:3100/loki/api/v1/push
+      clients:
+        # -- The Loki address to post logs to
+        - url: http://{{ .Release.Name }}-loki:3100/loki/api/v1/push
       snippets:
         # Promtail will export logs to loki only based on based on below
         # configuration, below scrape config will export only our services


### PR DESCRIPTION
The `lokiAddress` key is no longer useful with the new loki-stack helm chart. Clients are now input into the `clients[]` array.
Ref: https://github.com/grafana/helm-charts/pull/1425