### PR TITLE
fix: upgrade-job fixes

### DIFF
--- a/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
@@ -76,6 +76,9 @@ pub(crate) struct CoreValues {
     /// This contains loki-stack details.
     #[serde(rename(deserialize = "loki-stack"))]
     loki_stack: LokiStack,
+    /// This contains the sub-chart values for the hostpath provisioner's helm chart.
+    #[serde(rename(deserialize = "localpv-provisioner"))]
+    localpv_provisioner: LocalpvProvisioner,
 }
 
 impl TryFrom<&Path> for CoreValues {
@@ -234,6 +237,21 @@ impl CoreValues {
     /// This returns the image tag for the kiwigrid/k8s-sidecar container.
     pub(crate) fn grafana_sidecar_image_tag(&self) -> &str {
         self.loki_stack.grafana_sidecar_image_tag()
+    }
+
+    /// This is a getter for the localpv-provisioner sub-chart's release version.
+    pub(crate) fn localpv_release_version(&self) -> &str {
+        self.localpv_provisioner.release_version()
+    }
+
+    /// This is a getter for the container image tag of the hostpath localpv provisioner.
+    pub(crate) fn localpv_provisioner_image_tag(&self) -> &str {
+        self.localpv_provisioner.provisioner_image_tag()
+    }
+
+    /// This is a getter for the image tag of the localpv helper container.
+    pub(crate) fn localpv_helper_image_tag(&self) -> &str {
+        self.localpv_provisioner.helper_image_tag()
     }
 }
 
@@ -803,5 +821,100 @@ impl PromtailConfigClient {
         Self {
             url: url.to_string(),
         }
+    }
+}
+
+/// This is used to deserialize the helm values of the localpv-provisioner helm chart.
+#[derive(Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+struct LocalpvProvisioner {
+    release: LocalpvProvisionerRelease,
+    localpv: LocalpvProvisionerLocalpv,
+    helper_pod: LocalpvProvisionerHelperPod,
+}
+
+impl LocalpvProvisioner {
+    /// This is a getter for the localpv-provisioner helm chart's release version.
+    fn release_version(&self) -> &str {
+        self.release.version()
+    }
+
+    /// This is a getter for the container image tag of the provisioner-localpv container.
+    fn provisioner_image_tag(&self) -> &str {
+        self.localpv.image_tag()
+    }
+
+    /// This is a getter for the linux-utils helper container.
+    fn helper_image_tag(&self) -> &str {
+        self.helper_pod.image_tag()
+    }
+}
+
+/// This is used to deserialize the 'release.version' yaml object in the localpv-provisioner helm
+/// chart.
+#[derive(Deserialize)]
+struct LocalpvProvisionerRelease {
+    version: String,
+}
+
+impl LocalpvProvisionerRelease {
+    /// This is a getter for the release version for the localpv-provisioner helm chart.
+    /// This value is set as the value of the 'openebs.io/version' label.
+    fn version(&self) -> &str {
+        self.version.as_str()
+    }
+}
+
+/// This is used to deserialize the 'localpv' yaml object in the localpv-provisioner helm chart.
+#[derive(Deserialize)]
+struct LocalpvProvisionerLocalpv {
+    image: LocalpvProvisionerLocalpvImage,
+}
+
+impl LocalpvProvisionerLocalpv {
+    /// This is getter for the openebs/provisioner-localpv container's image tag.
+    fn image_tag(&self) -> &str {
+        self.image.tag()
+    }
+}
+
+/// This is used to deserialize the 'localpv.image' yaml object in the localpv-provisioner helm
+/// chart.
+#[derive(Deserialize)]
+struct LocalpvProvisionerLocalpvImage {
+    tag: String,
+}
+
+impl LocalpvProvisionerLocalpvImage {
+    /// This is getter for the openebs/provisioner-localpv container's image tag.
+    fn tag(&self) -> &str {
+        self.tag.as_str()
+    }
+}
+
+/// This is used to deserialize the 'helperPod' yaml object in the localpv-provisioner helm chart.
+#[derive(Deserialize)]
+struct LocalpvProvisionerHelperPod {
+    image: LocalpvProvisionerHelperPodImage,
+}
+
+impl LocalpvProvisionerHelperPod {
+    /// This is getter for the openebs/linux-utils helper pod container's image tag.
+    fn image_tag(&self) -> &str {
+        self.image.tag()
+    }
+}
+
+/// This is used to deserialize the 'helperPod.image' yaml object in the localpv-provisioner helm
+/// chart.
+#[derive(Deserialize)]
+struct LocalpvProvisionerHelperPodImage {
+    tag: String,
+}
+
+impl LocalpvProvisionerHelperPodImage {
+    /// This is getter for the openebs/linux-utils helper pod container's image tag.
+    fn tag(&self) -> &str {
+        self.tag.as_str()
     }
 }

--- a/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
@@ -253,6 +253,46 @@ impl CoreValues {
     pub(crate) fn localpv_helper_image_tag(&self) -> &str {
         self.localpv_provisioner.helper_image_tag()
     }
+
+    /// This is a getter for the openebs/node-disk-manager container's image tag.
+    pub(crate) fn localpv_ndm_image_tag(&self) -> &str {
+        self.localpv_provisioner.ndm_image_tag()
+    }
+
+    /// This is a getter for the openebs/linux-utils container's image tag.
+    pub(crate) fn localpv_ndm_helper_tag(&self) -> &str {
+        self.localpv_provisioner.ndm_helper_tag()
+    }
+
+    /// This is a getter for the openebs/node-disk-exporter container's image tag.
+    pub(crate) fn localpv_ndm_exporter_image_tag(&self) -> &str {
+        self.localpv_provisioner.ndm_exporter_image_tag()
+    }
+
+    /// This is a getter for the openebs/node-disk-operator container's image tag.
+    pub(crate) fn localpv_ndm_operator_image_tag(&self) -> &str {
+        self.localpv_provisioner.ndm_operator_image_tag()
+    }
+
+    /// This is a getter for the prometheus/alertmanager container's image tag.
+    pub(crate) fn prometheus_alertmanager_image_tag(&self) -> &str {
+        self.loki_stack.prometheus_alertmanager_image_tag()
+    }
+
+    /// This is a getter for the prometheus/node-exporter container's image tag.
+    pub(crate) fn prometheus_node_exporter_image_tag(&self) -> &str {
+        self.loki_stack.prometheus_node_exporter_image_tag()
+    }
+
+    /// This is a getter for the prom/pushgateway container's image tag.
+    pub(crate) fn prometheus_pushgateway_image_tag(&self) -> &str {
+        self.loki_stack.prometheus_pushgateway_image_tag()
+    }
+
+    /// This is a getter for the prometheus/prometheus container's image tag.
+    pub(crate) fn prometheus_server_image_tag(&self) -> &str {
+        self.loki_stack.prometheus_server_image_tag()
+    }
 }
 
 /// This is used to deserialize the yaml object agents.
@@ -505,6 +545,7 @@ struct LokiStack {
     grafana: Grafana,
     logstash: Logstash,
     loki: Loki,
+    prometheus: Prometheus,
     promtail: Promtail,
 }
 
@@ -568,6 +609,26 @@ impl LokiStack {
     fn grafana_sidecar_image_tag(&self) -> &str {
         self.grafana.sidecar_image_tag()
     }
+
+    /// This is a getter for the prometheus/alertmanager container's image tag.
+    fn prometheus_alertmanager_image_tag(&self) -> &str {
+        self.prometheus.alertmanager_image_tag()
+    }
+
+    /// This is a getter for the prometheus/node-exporter container's image tag.
+    fn prometheus_node_exporter_image_tag(&self) -> &str {
+        self.prometheus.node_exporter_image_tag()
+    }
+
+    /// This is a getter for the prom/pushgateway container's image tag.
+    fn prometheus_pushgateway_image_tag(&self) -> &str {
+        self.prometheus.pushgateway_image_tag()
+    }
+
+    /// This is a getter for the prometheus/prometheus container's image tag.
+    fn prometheus_server_image_tag(&self) -> &str {
+        self.prometheus.server_image_tag()
+    }
 }
 
 /// This is used to deserialize the YAML object 'loki-stack.filebeat'.
@@ -589,7 +650,7 @@ impl Filebeat {
 #[serde(rename_all(deserialize = "camelCase"))]
 struct Grafana {
     download_dashboards_image: GrafanaDownloadDashboardsImage,
-    image: GrafanaImage,
+    image: GenericImage,
     sidecar: GrafanaSidecar,
 }
 
@@ -623,42 +684,16 @@ impl GrafanaDownloadDashboardsImage {
     }
 }
 
-/// This is used to deserialize the YAML object 'loki-stack.grafana.image'.
-#[derive(Deserialize)]
-struct GrafanaImage {
-    tag: String,
-}
-
-impl GrafanaImage {
-    /// This is a getter for the grafana/grafana container image on the grafana chart.
-    fn tag(&self) -> &str {
-        self.tag.as_str()
-    }
-}
-
 /// This is used to deserialize the YAML object 'loki-stack.grafana.sidecar'.
 #[derive(Deserialize)]
 struct GrafanaSidecar {
-    image: GrafanaSidecarImage,
+    image: GenericImage,
 }
 
 impl GrafanaSidecar {
     /// This is a getter for the kiwigrid/k8s-sidecar sidecar container image tag.
     fn image_tag(&self) -> &str {
         self.image.tag()
-    }
-}
-
-/// This is used to deserialize the YAML object 'loki-stack.grafana.sidecar.image'.
-#[derive(Deserialize)]
-struct GrafanaSidecarImage {
-    tag: String,
-}
-
-impl GrafanaSidecarImage {
-    /// This is a getter for the kiwigrid/k8s-sidecar container image on the grafana chart.
-    fn tag(&self) -> &str {
-        self.tag.as_str()
     }
 }
 
@@ -679,7 +714,7 @@ impl Logstash {
 /// This is used to deserialize the YAML object 'loki-stack.loki'.
 #[derive(Deserialize)]
 struct Loki {
-    image: LokiImage,
+    image: GenericImage,
 }
 
 impl Loki {
@@ -688,15 +723,83 @@ impl Loki {
     }
 }
 
-/// This is used to deserialize the YAML object 'loki-stack.loki.image'.
+/// This is used to deserialize the yaml object 'loki-stack.prometheus'.
 #[derive(Deserialize)]
-struct LokiImage {
-    tag: String,
+#[serde(rename_all(deserialize = "camelCase"))]
+struct Prometheus {
+    alertmanager: PrometheusAlertmanager,
+    node_exporter: PrometheusNodeExporter,
+    pushgateway: PrometheusPushgateway,
+    server: PrometheusServer,
 }
 
-impl LokiImage {
-    fn tag(&self) -> &str {
-        self.tag.as_str()
+impl Prometheus {
+    /// Returns the image tag of the alertmanager container.
+    fn alertmanager_image_tag(&self) -> &str {
+        self.alertmanager.image_tag()
+    }
+
+    /// Returns the image tag of the nodeExporter container.
+    fn node_exporter_image_tag(&self) -> &str {
+        self.node_exporter.image_tag()
+    }
+
+    /// Returns the pushgateway container's image tag.
+    fn pushgateway_image_tag(&self) -> &str {
+        self.pushgateway.image_tag()
+    }
+
+    /// Returns the prometheus server's container image tag.
+    fn server_image_tag(&self) -> &str {
+        self.server.image_tag()
+    }
+}
+
+/// This is used to deserialize the prometheus chart's alertmanager YAML object.
+#[derive(Deserialize)]
+struct PrometheusAlertmanager {
+    image: GenericImage,
+}
+
+impl PrometheusAlertmanager {
+    fn image_tag(&self) -> &str {
+        self.image.tag()
+    }
+}
+
+/// This is used to deserialize the prometheus chart's nodeExporter YAML object.
+#[derive(Deserialize)]
+struct PrometheusNodeExporter {
+    image: GenericImage,
+}
+
+impl PrometheusNodeExporter {
+    fn image_tag(&self) -> &str {
+        self.image.tag()
+    }
+}
+
+/// This is used to deserialize the prometheus chart's pushgateway YAML object.
+#[derive(Deserialize)]
+struct PrometheusPushgateway {
+    image: GenericImage,
+}
+
+impl PrometheusPushgateway {
+    fn image_tag(&self) -> &str {
+        self.image.tag()
+    }
+}
+
+/// This is used to deserialize the prometheus chart's server YAML object.
+#[derive(Deserialize)]
+struct PrometheusServer {
+    image: GenericImage,
+}
+
+impl PrometheusServer {
+    fn image_tag(&self) -> &str {
+        self.image.tag()
     }
 }
 
@@ -831,6 +934,10 @@ struct LocalpvProvisioner {
     release: LocalpvProvisionerRelease,
     localpv: LocalpvProvisionerLocalpv,
     helper_pod: LocalpvProvisionerHelperPod,
+    /// This is the NDM helm subchart values. This is absent ('None' case) if
+    /// openebsNDM.enabled=false.
+    #[serde(rename(deserialize = "openebs-ndm"))]
+    openebs_ndm: LocalpvProvisionerNdm,
 }
 
 impl LocalpvProvisioner {
@@ -844,9 +951,29 @@ impl LocalpvProvisioner {
         self.localpv.image_tag()
     }
 
-    /// This is a getter for the linux-utils helper container.
+    /// This is a getter for the linux-utils helper container's image tag.
     fn helper_image_tag(&self) -> &str {
         self.helper_pod.image_tag()
+    }
+
+    /// This is a getter for the openebs/node-disk-manager container's image tag.
+    fn ndm_image_tag(&self) -> &str {
+        self.openebs_ndm.ndm_image_tag()
+    }
+
+    /// This is a getter for the openebs/linux-utils container's image tag.
+    fn ndm_helper_tag(&self) -> &str {
+        self.openebs_ndm.ndm_helper_image_tag()
+    }
+
+    /// This is a getter for the openebs/node-disk-exporter container's image tag.
+    fn ndm_exporter_image_tag(&self) -> &str {
+        self.openebs_ndm.ndm_exporter_image_tag()
+    }
+
+    /// This is a getter for the openebs/node-disk-operator container's image tag.
+    fn ndm_operator_image_tag(&self) -> &str {
+        self.openebs_ndm.ndm_operator_image_tag()
     }
 }
 
@@ -868,7 +995,7 @@ impl LocalpvProvisionerRelease {
 /// This is used to deserialize the 'localpv' yaml object in the localpv-provisioner helm chart.
 #[derive(Deserialize)]
 struct LocalpvProvisionerLocalpv {
-    image: LocalpvProvisionerLocalpvImage,
+    image: GenericImage,
 }
 
 impl LocalpvProvisionerLocalpv {
@@ -878,15 +1005,15 @@ impl LocalpvProvisionerLocalpv {
     }
 }
 
-/// This is used to deserialize the 'localpv.image' yaml object in the localpv-provisioner helm
+/// This is used to deserialize various 'image' yaml objects in the localpv-provisioner helm
 /// chart.
 #[derive(Deserialize)]
-struct LocalpvProvisionerLocalpvImage {
+struct GenericImage {
     tag: String,
 }
 
-impl LocalpvProvisionerLocalpvImage {
-    /// This is getter for the openebs/provisioner-localpv container's image tag.
+impl GenericImage {
+    /// This is getter for the various container image tags in the localpv-provisioner helm chart.
     fn tag(&self) -> &str {
         self.tag.as_str()
     }
@@ -895,7 +1022,7 @@ impl LocalpvProvisionerLocalpvImage {
 /// This is used to deserialize the 'helperPod' yaml object in the localpv-provisioner helm chart.
 #[derive(Deserialize)]
 struct LocalpvProvisionerHelperPod {
-    image: LocalpvProvisionerHelperPodImage,
+    image: GenericImage,
 }
 
 impl LocalpvProvisionerHelperPod {
@@ -905,16 +1032,72 @@ impl LocalpvProvisionerHelperPod {
     }
 }
 
-/// This is used to deserialize the 'helperPod.image' yaml object in the localpv-provisioner helm
-/// chart.
 #[derive(Deserialize)]
-struct LocalpvProvisionerHelperPodImage {
-    tag: String,
+#[serde(rename_all(deserialize = "camelCase"))]
+struct LocalpvProvisionerNdm {
+    helper_pod: LocalpvProvisionerHelperPod,
+    ndm: Ndm,
+    ndm_exporter: NdmExporter,
+    ndm_operator: NdmOperator,
 }
 
-impl LocalpvProvisionerHelperPodImage {
-    /// This is getter for the openebs/linux-utils helper pod container's image tag.
-    fn tag(&self) -> &str {
-        self.tag.as_str()
+impl LocalpvProvisionerNdm {
+    /// Returns the ndm daemonset image tag.
+    fn ndm_image_tag(&self) -> &str {
+        self.ndm.image_tag()
+    }
+
+    /// Returns the ndm helper image tag.
+    fn ndm_helper_image_tag(&self) -> &str {
+        self.helper_pod.image_tag()
+    }
+
+    /// Returns the ndm exporter image tag.
+    fn ndm_exporter_image_tag(&self) -> &str {
+        self.ndm_exporter.image_tag()
+    }
+
+    /// Returns the ndm operator image tag.
+    fn ndm_operator_image_tag(&self) -> &str {
+        self.ndm_operator.image_tag()
+    }
+}
+
+/// This is used to deserialize the '.localpv-provisioner.openebs-ndm.ndm' YAML object.
+#[derive(Deserialize)]
+struct Ndm {
+    image: GenericImage,
+}
+
+impl Ndm {
+    /// This returns the image tag for ndm.
+    fn image_tag(&self) -> &str {
+        self.image.tag()
+    }
+}
+
+/// This is used to deserialize the '.localpv-provisioner.openebs-ndm.ndmExporter' YAML object.
+#[derive(Deserialize)]
+struct NdmExporter {
+    image: GenericImage,
+}
+
+impl NdmExporter {
+    /// This returns the image tag for ndm-exporter.
+    fn image_tag(&self) -> &str {
+        self.image.tag()
+    }
+}
+
+/// This is used to deserialize the '.localpv-provisioner.openebs-ndm.ndmOperator' YAML object.
+#[derive(Deserialize)]
+struct NdmOperator {
+    image: GenericImage,
+}
+
+impl NdmOperator {
+    /// This returns the image tag for ndm-operator.
+    fn image_tag(&self) -> &str {
+        self.image.tag()
     }
 }

--- a/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
@@ -141,10 +141,50 @@ where
     })?;
     if source_version.ge(&two_dot_o_rc_zero) && source_version.lt(&two_dot_five) {
         // promtail
-        // TODO: check to see if it is the wrong one first.
+        let scrape_configs_to_replace = r"- job_name: {{ .Release.Name }}-pods-name
+  pipeline_stages:
+    - docker: {}
+  kubernetes_sd_configs:
+  - role: pod
+  relabel_configs:
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: hostname
+    action: replace
+  - action: labelmap
+    regex: __meta_kubernetes_pod_label_(.+)
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_pod_label_openebs_io_logging
+    regex: true
+    target_label: {{ .Release.Name }}_component
+  - action: replace
+    replacement: $1
+    separator: /
+    source_labels:
+    - __meta_kubernetes_namespace
+    target_label: job
+  - action: replace
+    source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+  - action: replace
+    source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - replacement: /var/log/pods/*$1/*.log
+    separator: /
+    source_labels:
+    - __meta_kubernetes_pod_uid
+    - __meta_kubernetes_pod_container_name
+    target_label: __path__
+";
         if source_values
             .loki_stack_promtail_scrape_configs()
-            .ne(target_values.loki_stack_promtail_scrape_configs())
+            .eq(scrape_configs_to_replace)
+            && target_values
+                .loki_stack_promtail_scrape_configs()
+                .ne(scrape_configs_to_replace)
         {
             yq.set_literal_value(
                 YamlKey::try_from(".loki-stack.promtail.config.snippets.scrapeConfigs")?,
@@ -165,6 +205,32 @@ where
             yq.set_literal_value(
                 YamlKey::try_from(".csi.node.nvme.io_timeout")?,
                 target_values.csi_node_nvme_io_timeout(),
+                upgrade_values_file.path(),
+            )?;
+        }
+
+        // Update localpv-provisioner helm chart.
+        let localpv_version_to_replace = "3.4.0";
+        if source_values
+            .localpv_release_version()
+            .eq(localpv_version_to_replace)
+            && target_values
+                .localpv_release_version()
+                .ne(localpv_version_to_replace)
+        {
+            yq.set_literal_value(
+                YamlKey::try_from(".localpv-provisioner.release.version")?,
+                target_values.localpv_release_version(),
+                upgrade_values_file.path(),
+            )?;
+            yq.set_literal_value(
+                YamlKey::try_from(".localpv-provisioner.localpv.image.tag")?,
+                target_values.localpv_provisioner_image_tag(),
+                upgrade_values_file.path(),
+            )?;
+            yq.set_literal_value(
+                YamlKey::try_from(".localpv-provisioner.helperPod.image.tag")?,
+                target_values.localpv_helper_image_tag(),
                 upgrade_values_file.path(),
             )?;
         }

--- a/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
@@ -243,6 +243,26 @@ where
                 target_values.localpv_helper_image_tag(),
                 upgrade_values_file.path(),
             )?;
+            yq.set_literal_value(
+                YamlKey::try_from(".localpv-provisioner.openebs-ndm.ndm.image.tag")?,
+                target_values.localpv_ndm_image_tag(),
+                upgrade_values_file.path(),
+            )?;
+            yq.set_literal_value(
+                YamlKey::try_from(".localpv-provisioner.openebs-ndm.helperPod.image.tag")?,
+                target_values.localpv_ndm_helper_tag(),
+                upgrade_values_file.path(),
+            )?;
+            yq.set_literal_value(
+                YamlKey::try_from(".localpv-provisioner.openebs-ndm.ndmExporter.image.tag")?,
+                target_values.localpv_ndm_exporter_image_tag(),
+                upgrade_values_file.path(),
+            )?;
+            yq.set_literal_value(
+                YamlKey::try_from(".localpv-provisioner.openebs-ndm.ndmOperator.image.tag")?,
+                target_values.localpv_ndm_operator_image_tag(),
+                upgrade_values_file.path(),
+            )?;
         }
     }
 
@@ -282,6 +302,27 @@ where
             target_values.grafana_sidecar_image_tag(),
             upgrade_values_file.path(),
         )?;
+        yq.set_literal_value(
+            YamlKey::try_from(".loki-stack.prometheus.alertmanager.image.tag")?,
+            target_values.prometheus_alertmanager_image_tag(),
+            upgrade_values_file.path(),
+        )?;
+        yq.set_literal_value(
+            YamlKey::try_from(".loki-stack.prometheus.nodeExporter.image.tag")?,
+            target_values.prometheus_node_exporter_image_tag(),
+            upgrade_values_file.path(),
+        )?;
+        yq.set_literal_value(
+            YamlKey::try_from(".loki-stack.prometheus.pushgateway.image.tag")?,
+            target_values.prometheus_pushgateway_image_tag(),
+            upgrade_values_file.path(),
+        )?;
+        yq.set_literal_value(
+            YamlKey::try_from(".loki-stack.prometheus.server.image.tag")?,
+            target_values.prometheus_server_image_tag(),
+            upgrade_values_file.path(),
+        )?;
+
         // Delete deprecated objects.
         yq.delete_object(
             YamlKey::try_from(".loki-stack.loki.config.ingester.lifecycler.ring.kvstore")?,

--- a/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
@@ -208,8 +208,18 @@ where
                 upgrade_values_file.path(),
             )?;
         }
+    }
 
+    // Special-case values for 2.6.x.
+    let two_dot_six = Version::parse(TWO_DOT_SIX).context(SemverParse {
+        version_string: TWO_DOT_SIX.to_string(),
+    })?;
+    if source_version.ge(&two_dot_o_rc_zero) && source_version.lt(&two_dot_six) {
         // Update localpv-provisioner helm chart.
+        // This change is meant for versions from 2.0.0 to 2.4.0. However, this code wasn't checked
+        // into 2.5.0, and likely users of upgrade-job 2.5.0 are using the localpv image tag
+        // from 2.4.0 (i.e. 3.4.0) with the 3.5.0 localpv helm chart. So these options should
+        // also be set for source version 2.5.0.
         let localpv_version_to_replace = "3.4.0";
         if source_values
             .localpv_release_version()


### PR DESCRIPTION
Changes:
1. The localpv-provisioner helm chart was updated to v3.5.0 with the release of Mayastor v2.5.0. The yq merge would retain the release-version and image tags on the localpv helm values. They need to be manually overriden.
2. The scrapeConfigs change is only applied if the source configuration is the older default. It should move to newer default, only if the chart had the older default to begin with. This prevents overriding user-defined custom configuration.