### PR TITLE
chore(deps): address CVE-2023-39325, CVE-2023-47108 and GHSA-m425-mq9…

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -104,11 +104,11 @@ $ helm install my-release openebs/mayastor
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;attacherTag | csi-attacher image release tag | `"v4.3.0"` |
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;provisionerTag | csi-provisioner image release tag | `"v3.5.0"` |
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;pullPolicy | imagePullPolicy for all CSI Sidecar images | `"IfNotPresent"` |
-| csi.&ZeroWidthSpace;image.&ZeroWidthSpace;registrarTag | csi-node-driver-registrar image release tag | `"v2.9.0"` |
+| csi.&ZeroWidthSpace;image.&ZeroWidthSpace;registrarTag | csi-node-driver-registrar image release tag | `"v2.10.0"` |
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;registry | Image registry to pull all CSI Sidecar images | `"registry.k8s.io"` |
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;repo | Image registry's namespace | `"sig-storage"` |
-| csi.&ZeroWidthSpace;image.&ZeroWidthSpace;snapshotControllerTag | csi-snapshot-controller image release tag | `"v6.3.1"` |
-| csi.&ZeroWidthSpace;image.&ZeroWidthSpace;snapshotterTag | csi-snapshotter image release tag | `"v6.3.1"` |
+| csi.&ZeroWidthSpace;image.&ZeroWidthSpace;snapshotControllerTag | csi-snapshot-controller image release tag | `"v6.3.3"` |
+| csi.&ZeroWidthSpace;image.&ZeroWidthSpace;snapshotterTag | csi-snapshotter image release tag | `"v6.3.3"` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;kubeletDir | The kubeletDir directory for the csi-node plugin | `"/var/lib/kubelet"` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;nvme.&ZeroWidthSpace;ctrl_loss_tmo | The ctrl_loss_tmo (controller loss timeout) in seconds | `"1980"` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;priorityClassName | Set PriorityClass, overrides global | `""` |

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -269,11 +269,11 @@ csi:
     # -- csi-attacher image release tag
     attacherTag: v4.3.0
     # -- csi-snapshotter image release tag
-    snapshotterTag: v6.3.1
+    snapshotterTag: v6.3.3
     # -- csi-snapshot-controller image release tag
-    snapshotControllerTag: v6.3.1
+    snapshotControllerTag: v6.3.3
     # -- csi-node-driver-registrar image release tag
-    registrarTag: v2.9.0
+    registrarTag: v2.10.0
 
   controller:
     # -- Log level for the csi controller


### PR DESCRIPTION
Upgrade images to fix the following vulnerabilities:

- https://avd.aquasec.com/nvd/2023/cve-2023-47108/
- https://avd.aquasec.com/nvd/2023/cve-2023-39325/
- https://github.com/advisories/GHSA-m425-mq94-257g


## Description

CVE-2023-47108 and CVE-2023-39325 fixed in v2.10.0 from node-driver-registar

GHSA-m425-mq94-257g fixed in v2.10.0 from node-driver-registar, and v6.3.3 from csi-snapshotter (and controller) images.


## Motivation and Context

Have no HIGH vulnerabilities in mayastor-extensions

## Regression
No
--- see how your change affects other areas of the code, etc. -->

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
  - **It not applicable to this changeset**