### PR TITLE
feat(app node): update csi node with latests args to enable registration

### DIFF
--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -29,6 +29,7 @@ spec:
     spec:
       serviceAccount: {{ .Release.Name }}-service-account
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:
         {{- include "base_pull_secrets" . }}
       {{- if $pcName := include "priority_class" (dict "template" . "localPriorityClass" .Values.csi.node.priorityClassName) }}
@@ -77,6 +78,8 @@ spec:
         args:
         - "--csi-socket={{ .Values.csi.node.pluginMounthPath }}/{{ .Values.csi.node.socketPath }}"
         - "--node-name=$(MY_NODE_NAME)"
+        - "--rest-endpoint=http://{{ .Release.Name }}-api-rest:8081"
+        - "--enable-registration"
         - "--grpc-endpoint=$(MY_POD_IP):10199"{{ if .Values.csi.node.nvme.io_timeout }}
         - "--nvme-io-timeout={{ .Values.csi.node.nvme.io_timeout }}"
         - "--nvme-core-io-timeout={{ .Values.csi.node.nvme.io_timeout }}"{{ else }}


### PR DESCRIPTION
### Changes in this PR

1. Adds the `dnsPolicy: ClusterFirstWithHostNet` so that endpoints are discoverable by dns name.
2. Adds the args to specify rest-api endpoint and enabled registration.

### Why are the changes needed?

1. These changes are needed because csi node now should register itself as an app node to the control-plane.
2. This app node info would be used in snapshot creation to issue FIFREEZE and FITHAW to the filesystem for consistency if enabled. 

Related Control Plane PR --> https://github.com/openebs/mayastor-control-plane/pull/730