### PR TITLE
feat(topology): add plugin code for label node

### DIFF
--- a/k8s/plugin/README.md
+++ b/k8s/plugin/README.md
@@ -24,6 +24,7 @@ Usage: kubectl-mayastor [OPTIONS] <COMMAND>
 
 Commands:
   drain      'Drain' resources
+  label      'Label' resources
   get        'Get' resources
   scale      'Scale' resources
   cordon     'Cordon' resources
@@ -212,7 +213,7 @@ b5de71a6-055d-433a-a1c5-2b39ade05d86  0dafa450-7a19-4e21-a919-89c6f9bd2a97  Comp
 </details>
 
 <details>
-<summary> Node Cordon And Drain Operations </summary>
+<summary> Node Cordon, Drain and Label Operations </summary>
 
 1. Node Cordoning
 ```
@@ -263,6 +264,16 @@ Node io-engine-1 successfully uncordoned
  node-2-14048  95.217.152.7:10124   Online  true      Draining     my_drain_2
  node-1-14048  95.217.158.66:10124  Online  true      Drained      my_drain_1
 
+```
+7. Node Labeling
+```
+❯ kubectl mayastor label node kworker1 zone-us=east-1
+Node node-1-14048  labelled successfully. Current labels: {"zone-us": "east-1"}
+```
+8. Node Unlabelling
+```
+❯ kubectl mayastor label node kworker1 zone-us-
+Node node-1-14048 labelled successfully. Current labels: {}
 ```
 </details>
 

--- a/k8s/plugin/src/resources/mod.rs
+++ b/k8s/plugin/src/resources/mod.rs
@@ -1,7 +1,10 @@
 use crate::Error;
 use clap::Parser;
 use plugin::{
-    resources::{CordonResources, DrainResources, GetResources, ScaleResources, UnCordonResources},
+    resources::{
+        CordonResources, DrainResources, GetResources, LabelResources, ScaleResources,
+        UnCordonResources,
+    },
     ExecuteOperation,
 };
 use std::{ops::Deref, path::PathBuf};
@@ -47,6 +50,9 @@ pub enum Operations {
     /// 'Drain' resources.
     #[clap(subcommand)]
     Drain(DrainResources),
+    /// 'Label' resources.
+    #[clap(subcommand)]
+    Label(LabelResources),
     /// 'Get' resources.
     #[clap(subcommand)]
     Get(GetResourcesK8s),
@@ -82,6 +88,8 @@ impl ExecuteOperation for Operations {
                 }
             },
             Operations::Drain(resource) => resource.execute(cli_args).await?,
+            Operations::Label(resource) => resource.execute(cli_args).await?,
+
             Operations::Scale(resource) => resource.execute(cli_args).await?,
             Operations::Cordon(resource) => resource.execute(cli_args).await?,
             Operations::Uncordon(resource) => resource.execute(cli_args).await?,


### PR DESCRIPTION
**Node Labeling**
```
❯ kubectl mayastor label node node-0-158373 C=D
Node node-0-158373 labelled successfully. Current labels: {"A": "B", "C": "D"}
```
**show-labels**
```
ashish@ashish-dev-vm:~/code/rust/mayastor-extensions$ ./target/debug/kubectl-mayastor get nodes --show-labels
 ID             GRPC ENDPOINT         STATUS  LABELS
 node-1-158373  95.217.16.248:10124   Online
 node-2-158373  95.217.135.143:10124  Online
 node-0-158373  95.216.140.139:10124  Online  C=D, A=B
```


**Node Unlabelling**
```
❯ kubectl-mayastor label node node-0-158373 C-
Node node-0-158373 labelled successfully. Current labels: {"A": "B"}
```

**show-labels**
```
ashish@ashish-dev-vm:~/code/rust/mayastor-extensions$ ./target/debug/kubectl-mayastor get nodes --show-labels
 ID             GRPC ENDPOINT         STATUS  LABELS
 node-1-158373  95.217.16.248:10124   Online
 node-2-158373  95.217.135.143:10124  Online
 node-0-158373  95.216.140.139:10124  Online  A=B
```

