### PR TITLE
feat(eventing): add k8sClusterDomain default value to nats config

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -710,6 +710,8 @@ nats:
   cluster:
     enabled: true
     replicas: 3
+  # Define if NATS is using FQDN name for clustering (i.e. nats-0.nats.default.svc.cluster.local) or short name (i.e. nats-0.nats.default).
+  useFQDN: false
   statefulSetPodLabels:
     app: nats
     openebs.io/logging: "true"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Set 'useFQDN' to 'false' in Nats config in values.yaml. Now NATS uses short names to refer to other pods within the same namespace - No domain suffix.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To make it clear of the default value being used for K8sClusterDomain in NATS config.


## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.