### PR TITLE
feat(csi/node): add nvme-tcp init container

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -61,6 +61,17 @@ Usage:
 {{- end -}}
 
 {{/*
+Renders the csi node init containers, if enabled
+Usage:
+{{ include "csi_node_init_containers" . }}
+*/}}
+{{- define "csi_node_init_containers" -}}
+    {{- if .Values.csi.node.initContainers.enabled }}
+    {{- include "render" (dict "value" .Values.csi.node.initContainers.containers "context" $) | nindent 8 }}
+    {{- end }}
+{{- end -}}
+
+{{/*
 Renders the base image pull secrets for all deployments, if any
 Usage:
 {{ include "base_pull_secrets" . }}

--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -47,6 +47,8 @@ spec:
       {{- if $tolerations := include "tolerations" (dict "template" . "localTolerations" .Values.csi.node.tolerations) }}
       tolerations: {{ $tolerations }}
       {{- end }}
+      initContainers:
+        {{- include "csi_node_init_containers" . }}
       # NOTE: Each container must have mem/cpu limits defined in order to
       # belong to Guaranteed QoS class, hence can never get evicted in case of
       # pressure unless they exceed those limits. limits and requests must be

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -327,6 +327,12 @@ csi:
     tolerations: []
     # -- Set PriorityClass, overrides global
     priorityClassName: ""
+    initContainers:
+      enabled: false
+      containers:
+        - name: nvme-tcp-probe
+          image: busybox:latest
+          command: ['sh', '-c', 'trap "exit 1" TERM; until $(lsmod | grep nvme_tcp &>/dev/null); do [ -z "$WARNED" ] && echo "nvme_tcp module not loaded..."; WARNED=1; sleep 60; done;']
 
 io_engine:
   # -- Log level for the io-engine service


### PR DESCRIPTION
Adds init container which waits on the nvme-tcp kernel module to be loaded. 
It's disabled by default.
todo: use common init container image

<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This would allow an umbrella chart to enable the init container, preventing errors when starting the csi-node container.

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.