### PR TITLE
Volume expansion changes

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -107,6 +107,7 @@ $ helm install my-release openebs/mayastor
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;registrarTag | csi-node-driver-registrar image release tag | `"v2.10.0"` |
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;registry | Image registry to pull all CSI Sidecar images | `"registry.k8s.io"` |
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;repo | Image registry's namespace | `"sig-storage"` |
+| csi.&ZeroWidthSpace;image.&ZeroWidthSpace;resizerTag | csi-resizer image release tag | `"v1.9.3"` |
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;snapshotControllerTag | csi-snapshot-controller image release tag | `"v6.3.3"` |
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;snapshotterTag | csi-snapshotter image release tag | `"v6.3.3"` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;kubeletDir | The kubeletDir directory for the csi-node plugin | `"/var/lib/kubelet"` |
@@ -189,5 +190,6 @@ $ helm install my-release openebs/mayastor
 | operators.&ZeroWidthSpace;pool.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;memory | Memory requests for diskpool operator | `"16Mi"` |
 | operators.&ZeroWidthSpace;pool.&ZeroWidthSpace;tolerations | Set tolerations, overrides global | `[]` |
 | priorityClassName | Pod scheduling priority. Setting this value will apply to all components except the external Chart dependencies. If any component has `priorityClassName` set, then this value would be overridden for that component. For external components like etcd, jaeger or loki-stack, PriorityClass can only be set at component level. | `""` |
+| storageClass.&ZeroWidthSpace;allowVolumeExpansion | Enable volume expansion for the default StorageClass. | `true` |
 | tolerations | Tolerations to be applied to all components except external Chart dependencies. If any component has tolerations set, then it would override this value. For external components like etcd, jaeger and loki-stack, tolerations can only be set at component level. | `[]` |
 

--- a/chart/templates/mayastor/csi/csi-controller-deployment.yaml
+++ b/chart/templates/mayastor/csi/csi-controller-deployment.yaml
@@ -92,6 +92,18 @@ spec:
             {{- end }}
           image: "{{ .Values.csi.image.registry }}/{{ .Values.csi.image.repo }}/snapshot-controller:{{ .Values.csi.image.snapshotControllerTag }}"
           imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
+        - name: csi-resizer
+          args:
+            - "--v=2"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          image: "{{ .Values.csi.image.registry }}/{{ .Values.csi.image.repo }}/csi-resizer:{{ .Values.csi.image.resizerTag }}"
+          imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-controller
           resources:
             limits:

--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
   {{- end }}
+allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
 parameters:
 {{/*
   Set StorageClass parameters by adding to the values.yaml 'storageClass.parameters' map.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -271,6 +271,8 @@ csi:
     snapshotControllerTag: v6.3.3
     # -- csi-node-driver-registrar image release tag
     registrarTag: v2.10.0
+    # -- csi-resizer image release tag
+    resizerTag: v1.9.3
 
   controller:
     # -- Log level for the csi controller
@@ -731,6 +733,8 @@ storageClass:
   enabled: true
   nameSuffix: single-replica
   default: false
+  # -- Enable volume expansion for the default StorageClass.
+  allowVolumeExpansion: true
   parameters:
     protocol: nvmf
     repl: 1

--- a/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/chart.rs
@@ -172,6 +172,11 @@ impl CoreValues {
         self.csi.node_driver_registrar_image_tag()
     }
 
+    /// This is a getter for the sig-storage/csi-resizer image tag.
+    pub(crate) fn csi_resizer_image_tag(&self) -> &str {
+        self.csi.resizer_image_tag()
+    }
+
     /// This is a getter for the CSI node's NVMe io_timeout.
     pub(crate) fn csi_node_nvme_io_timeout(&self) -> &str {
         self.csi.node_nvme_io_timeout()
@@ -461,6 +466,11 @@ impl Csi {
         self.image.node_driver_registrar_tag()
     }
 
+    /// This is a getter for the sig-storage/csi-resizer image tag.
+    fn resizer_image_tag(&self) -> &str {
+        self.image.resizer_tag()
+    }
+
     /// This is a getter for the CSI node NVMe io_timeout.
     fn node_nvme_io_timeout(&self) -> &str {
         self.node.nvme_io_timeout()
@@ -483,6 +493,9 @@ struct CsiImage {
     snapshot_controller_tag: String,
     /// This is the image tag for the csi-node-driver-registrar container.
     registrar_tag: String,
+    /// This is the image tag for the csi-resizer container.
+    #[serde(default)]
+    resizer_tag: String,
 }
 
 impl CsiImage {
@@ -509,6 +522,11 @@ impl CsiImage {
     /// This is a getter for registrarTag.
     fn node_driver_registrar_tag(&self) -> &str {
         self.registrar_tag.as_str()
+    }
+
+    /// This is a getter for resizerTag.
+    fn resizer_tag(&self) -> &str {
+        self.resizer_tag.as_str()
     }
 }
 

--- a/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
@@ -398,6 +398,11 @@ where
         target_values.csi_node_driver_registrar_image_tag(),
         upgrade_values_file.path(),
     )?;
+    yq.set_literal_value(
+        YamlKey::try_from(".csi.image.resizerTag")?,
+        target_values.csi_resizer_image_tag(),
+        upgrade_values_file.path(),
+    )?;
 
     // helm upgrade .. --set image.tag=<version> --set image.repoTags.controlPlane= --set
     // image.repoTags.dataPlane= --set image.repoTags.extensions=


### PR DESCRIPTION
Changes:
- Adds `allowVolumeExpansion` to the default StorageClass. Value is set to true by default.
- Adds the resizer to the CSI controller Deployment. Leader-election is disabled, log verbosity is set to `v=2`, timeout and retry durations are left unchanged. Uses v1.9.3.
- Adds upgrade changes to prefer target helm chart's resizer version, instead of source helm chart's.