### PR TITLE
expose replica io stats

### DIFF
--- a/metrics-exporter/src/bin/io_engine/cache/mod.rs
+++ b/metrics-exporter/src/bin/io_engine/cache/mod.rs
@@ -1,9 +1,11 @@
 mod nexus_stat;
 mod pool;
 mod pool_stat;
+mod replica_stat;
 
 use crate::client::{
     grpc_client::GrpcClient, nexus_stat::NexusIoStats, pool::Pools, pool_stat::PoolIoStats,
+    replica_stat::ReplicaIoStats,
 };
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
@@ -32,6 +34,8 @@ pub(crate) struct Data {
     pool_stats: PoolIoStats,
     /// Contains Nexus IOStats data.
     nexus_stats: NexusIoStats,
+    /// Contains Replica IOStats data.
+    replica_stats: ReplicaIoStats,
 }
 
 impl Cache {
@@ -74,6 +78,16 @@ impl Cache {
     pub(crate) fn pool_iostat(&self) -> &PoolIoStats {
         &self.data.pool_stats
     }
+
+    /// Get a reference to ReplicaIoStats.
+    pub(crate) fn replica_iostat(&self) -> &ReplicaIoStats {
+        &self.data.replica_stats
+    }
+
+    /// Get mutable reference to ReplicaIOStats.
+    pub(crate) fn replica_iostat_mut(&mut self) -> &mut ReplicaIoStats {
+        &mut self.data.replica_stats
+    }
 }
 
 impl Default for Data {
@@ -91,6 +105,9 @@ impl Data {
             nexus_stats: NexusIoStats {
                 nexus_stats: vec![],
             },
+            replica_stats: ReplicaIoStats {
+                replica_stats: vec![],
+            },
         }
     }
 }
@@ -100,4 +117,5 @@ pub(crate) async fn store_resource_data(client: &GrpcClient) {
     let _ = pool::store_pool_info_data(client).await;
     let _ = pool_stat::store_pool_stats_data(client).await;
     let _ = nexus_stat::store_nexus_stats_data(client).await;
+    let _ = replica_stat::store_replica_stats_data(client).await;
 }

--- a/metrics-exporter/src/bin/io_engine/cache/replica_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/cache/replica_stat.rs
@@ -1,0 +1,49 @@
+use super::{Cache, ResourceOps};
+use crate::client::{
+    grpc_client::GrpcClient,
+    replica_stat::{ReplicaIoStat, ReplicaIoStats},
+};
+use std::ops::DerefMut;
+use tracing::error;
+
+impl ResourceOps for ReplicaIoStats {
+    type ResourceVec = Vec<ReplicaIoStat>;
+
+    fn set(&mut self, val: Self::ResourceVec) {
+        self.replica_stats = val
+    }
+
+    fn invalidate(&mut self) {
+        self.replica_stats = vec![]
+    }
+}
+
+/// To store replica iostat data in cache.
+pub(crate) async fn store_replica_stats_data(client: &GrpcClient) -> Result<(), ()> {
+    let replica_stats = client.get_replica_iostat().await;
+    let mut cache = match Cache::get_cache().lock() {
+        Ok(cache) => cache,
+        Err(error) => {
+            error!(%error, "Error while getting cache resource");
+            return Err(());
+        }
+    };
+    let replica_cache = cache.deref_mut();
+    match replica_stats {
+        Ok(replicas) => {
+            replica_cache
+                .replica_iostat_mut()
+                .set(replicas.replica_stats);
+        }
+        // invalidate cache in case of error
+        Err(error) => {
+            error!(
+                ?error,
+                "Error getting replica stats data, invalidating replica cache"
+            );
+            replica_cache.replica_iostat_mut().invalidate();
+            return Err(());
+        }
+    };
+    Ok(())
+}

--- a/metrics-exporter/src/bin/io_engine/client/mod.rs
+++ b/metrics-exporter/src/bin/io_engine/client/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod nexus_stat;
 pub(crate) mod pool;
 /// PoolIoStats module
 pub(crate) mod pool_stat;
+pub(crate) mod replica_stat;
 
 /// Convert ticks to time in microseconds.
 fn ticks_to_time(tick: u64, tick_rate: u64) -> u64 {

--- a/metrics-exporter/src/bin/io_engine/client/replica_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/client/replica_stat.rs
@@ -1,0 +1,96 @@
+use super::ticks_to_time;
+use crate::error::ExporterError;
+use serde::{Deserialize, Serialize};
+
+/// This stores IoStat information of a replica.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub(crate) struct ReplicaIoStat {
+    name: String,
+    entity_id: String,
+    bytes_read: u64,
+    num_read_ops: u64,
+    bytes_written: u64,
+    num_write_ops: u64,
+    read_latency_us: u64,
+    write_latency_us: u64,
+}
+
+impl ReplicaIoStat {
+    /// Get name of the replica.
+    pub(crate) fn name(&self) -> &String {
+        &self.name
+    }
+
+    /// Get used bytes read of the replica.
+    pub(crate) fn bytes_read(&self) -> u64 {
+        self.bytes_read
+    }
+
+    /// Get total number of read ops performed by the replica.
+    pub(crate) fn num_read_ops(&self) -> u64 {
+        self.num_read_ops
+    }
+
+    /// Get the total bytes written in bytes.
+    pub(crate) fn bytes_written(&self) -> u64 {
+        self.bytes_written
+    }
+
+    /// Get total number of write ops performed by the replica.
+    pub(crate) fn num_write_ops(&self) -> u64 {
+        self.num_write_ops
+    }
+
+    /// Get total read latency in usec on the replica.
+    pub(crate) fn read_latency_us(&self) -> u64 {
+        self.read_latency_us
+    }
+
+    /// Get total write latency in usec on the replica.
+    pub(crate) fn write_latency_us(&self) -> u64 {
+        self.write_latency_us
+    }
+
+    /// Get entity_id of the replica.
+    pub(crate) fn entity_id(&self) -> String {
+        self.entity_id.clone()
+    }
+}
+
+/// Array of NexusIoStat objects.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub(crate) struct ReplicaIoStats {
+    pub(crate) replica_stats: Vec<ReplicaIoStat>,
+}
+
+impl TryFrom<rpc::v1::stats::ReplicaIoStats> for ReplicaIoStat {
+    type Error = ExporterError;
+
+    fn try_from(value: rpc::v1::stats::ReplicaIoStats) -> Result<Self, Self::Error> {
+        let stats = match value.stats {
+            Some(stats) => stats,
+            None => {
+                return Err(ExporterError::GrpcResponseError(
+                    "Stats is None for replica stats".to_string(),
+                ))
+            }
+        };
+        Ok(Self {
+            name: stats.name,
+            entity_id: match value.entity_id {
+                Some(id) => id,
+                None => {
+                    return Err(ExporterError::GrpcResponseError(
+                        "entity_id is not set for replica stat".to_string(),
+                    ))
+                }
+            },
+            bytes_read: stats.bytes_read,
+            num_read_ops: stats.num_read_ops,
+            bytes_written: stats.bytes_written,
+            num_write_ops: stats.num_write_ops,
+            read_latency_us: ticks_to_time(stats.read_latency_ticks, stats.tick_rate),
+            write_latency_us: ticks_to_time(stats.write_latency_ticks, stats.tick_rate),
+        })
+    }
+}

--- a/metrics-exporter/src/bin/io_engine/collector/mod.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/mod.rs
@@ -6,6 +6,7 @@ use prometheus::{
 pub(crate) mod nexus_stat;
 pub(crate) mod pool;
 pub(crate) mod pool_stat;
+pub(crate) mod replica_stat;
 
 /// Initializes a GaugeVec metric for diskpool with the provided metric name, description and
 /// descriptors.
@@ -30,6 +31,22 @@ fn init_volume_gauge_vec(metric_name: &str, metric_desc: &str, descs: &mut Vec<D
         .subsystem("volume")
         .variable_labels(vec!["node".to_string(), "pv_name".to_string()]);
     let gauge_vec = GaugeVec::new(opts, &["node", "pv_name"])
+        .unwrap_or_else(|_| panic!("Unable to create gauge metric type for {}", metric_name));
+    descs.extend(gauge_vec.desc().into_iter().cloned());
+    gauge_vec
+}
+
+/// Initializes a GaugeVec metric for replica with the provided metric name, description and
+/// descriptors.
+fn init_replica_gauge_vec(metric_name: &str, metric_desc: &str, descs: &mut Vec<Desc>) -> GaugeVec {
+    let opts = Opts::new(metric_name, metric_desc)
+        .subsystem("replica")
+        .variable_labels(vec![
+            "node".to_string(),
+            "name".to_string(),
+            "pv_name".to_string(),
+        ]);
+    let gauge_vec = GaugeVec::new(opts, &["node", "name", "pv_name"])
         .unwrap_or_else(|_| panic!("Unable to create gauge metric type for {}", metric_name));
     descs.extend(gauge_vec.desc().into_iter().cloned());
     gauge_vec

--- a/metrics-exporter/src/bin/io_engine/collector/replica_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/replica_stat.rs
@@ -1,0 +1,201 @@
+use super::init_replica_gauge_vec;
+use crate::{cache::Cache, get_node_name};
+use prometheus::{
+    core::{Collector, Desc},
+    GaugeVec,
+};
+use std::{fmt::Debug, ops::Deref};
+use tracing::error;
+
+/// Collects Replica IoStat metrics from cache.
+#[derive(Clone, Debug)]
+pub(crate) struct ReplicaIoStatsCollector {
+    replica_bytes_read: GaugeVec,
+    replica_num_read_ops: GaugeVec,
+    replica_bytes_written: GaugeVec,
+    replica_num_write_ops: GaugeVec,
+    replica_read_latency_us: GaugeVec,
+    replica_write_latency_us: GaugeVec,
+    descs: Vec<Desc>,
+}
+
+impl Default for ReplicaIoStatsCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+/// Initialize all the metrics to be defined for replicas iostat collector.
+impl ReplicaIoStatsCollector {
+    /// Initialize all the metrics to be defined for replicas iostat collector.
+    pub fn new() -> Self {
+        let mut descs = Vec::new();
+
+        let replica_bytes_read =
+            init_replica_gauge_vec("bytes_read", "Total bytes read on the replica", &mut descs);
+        let replica_num_read_ops = init_replica_gauge_vec(
+            "num_read_ops",
+            "Number of read operations on the replica",
+            &mut descs,
+        );
+        let replica_bytes_written = init_replica_gauge_vec(
+            "bytes_written",
+            "Total bytes written on the replica",
+            &mut descs,
+        );
+        let replica_num_write_ops = init_replica_gauge_vec(
+            "num_write_ops",
+            "Number of write operations on the replica",
+            &mut descs,
+        );
+        let replica_read_latency_us = init_replica_gauge_vec(
+            "read_latency_us",
+            "Total read latency on the replica in usec",
+            &mut descs,
+        );
+        let replica_write_latency_us = init_replica_gauge_vec(
+            "write_latency_us",
+            "Total write latency on the replica in usec",
+            &mut descs,
+        );
+
+        Self {
+            replica_bytes_read,
+            replica_num_read_ops,
+            replica_bytes_written,
+            replica_num_write_ops,
+            replica_read_latency_us,
+            replica_write_latency_us,
+            descs,
+        }
+    }
+}
+
+impl Collector for ReplicaIoStatsCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        self.descs.iter().collect()
+    }
+
+    fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
+        let cache = match Cache::get_cache().lock() {
+            Ok(cache) => cache,
+            Err(error) => {
+                error!(%error,"Error while getting cache resource");
+                return Vec::new();
+            }
+        };
+        let cache_deref = cache.deref();
+        let mut metric_family =
+            Vec::with_capacity(6 * cache_deref.replica_iostat().replica_stats.capacity());
+        let node_name = match get_node_name() {
+            Ok(name) => name,
+            Err(error) => {
+                error!(?error, "Unable to get node name");
+                return metric_family;
+            }
+        };
+
+        for replica_stat in &cache_deref.replica_iostat().replica_stats {
+            let pv_name = format!("pvc-{}", replica_stat.entity_id());
+            let replica_bytes_read = match self.replica_bytes_read.get_metric_with_label_values(&[
+                node_name.as_str(),
+                replica_stat.name().as_str(),
+                pv_name.as_str(),
+            ]) {
+                Ok(replica_bytes_read) => replica_bytes_read,
+                Err(error) => {
+                    error!(%error, "Error while creating replica_bytes_read counter with label values");
+                    return metric_family;
+                }
+            };
+            replica_bytes_read.set(replica_stat.bytes_read() as f64);
+            let mut metric_vec = replica_bytes_read.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let replica_num_read_ops = match self.replica_num_read_ops.get_metric_with_label_values(
+                &[
+                    node_name.as_str(),
+                    replica_stat.name().as_str(),
+                    pv_name.as_str(),
+                ],
+            ) {
+                Ok(replica_num_read_ops) => replica_num_read_ops,
+                Err(error) => {
+                    error!(%error, "Error while creating replica_num_read_ops counter with label values");
+                    return metric_family;
+                }
+            };
+            replica_num_read_ops.set(replica_stat.num_read_ops() as f64);
+            let mut metric_vec = replica_num_read_ops.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let replica_bytes_written = match self
+                .replica_bytes_written
+                .get_metric_with_label_values(&[
+                    node_name.as_str(),
+                    replica_stat.name().as_str(),
+                    pv_name.as_str(),
+                ]) {
+                Ok(replica_bytes_written) => replica_bytes_written,
+                Err(error) => {
+                    error!(%error, "Error while creating replica_bytes_written counter with label values");
+                    return metric_family;
+                }
+            };
+            replica_bytes_written.set(replica_stat.bytes_written() as f64);
+            let mut metric_vec = replica_bytes_written.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let replica_num_write_ops = match self
+                .replica_num_write_ops
+                .get_metric_with_label_values(&[
+                    node_name.as_str(),
+                    replica_stat.name().as_str(),
+                    pv_name.as_str(),
+                ]) {
+                Ok(replica_num_write_ops) => replica_num_write_ops,
+                Err(error) => {
+                    error!(%error, "Error while creating replica_num_write_ops counter with label values");
+                    return metric_family;
+                }
+            };
+            replica_num_write_ops.set(replica_stat.num_write_ops() as f64);
+            let mut metric_vec = replica_num_write_ops.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let replica_read_latency_us = match self
+                .replica_read_latency_us
+                .get_metric_with_label_values(&[
+                    node_name.as_str(),
+                    replica_stat.name().as_str(),
+                    pv_name.as_str(),
+                ]) {
+                Ok(replica_read_latency_us) => replica_read_latency_us,
+                Err(error) => {
+                    error!(%error, "Error while creating replica_read_latency counter with label values");
+                    return metric_family;
+                }
+            };
+            replica_read_latency_us.set(replica_stat.read_latency_us() as f64);
+            let mut metric_vec = replica_read_latency_us.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let replica_write_latency_us = match self
+                .replica_write_latency_us
+                .get_metric_with_label_values(&[
+                    node_name.as_str(),
+                    replica_stat.name().as_str(),
+                    pv_name.as_str(),
+                ]) {
+                Ok(replica_write_latency_us) => replica_write_latency_us,
+                Err(error) => {
+                    error!(%error, "Error while creating replica_write_latency counter with label values");
+                    return metric_family;
+                }
+            };
+            replica_write_latency_us.set(replica_stat.write_latency_us() as f64);
+            let mut metric_vec = replica_write_latency_us.collect();
+            metric_family.extend(metric_vec.pop());
+        }
+        metric_family
+    }
+}

--- a/metrics-exporter/src/bin/io_engine/serve/handler.rs
+++ b/metrics-exporter/src/bin/io_engine/serve/handler.rs
@@ -4,6 +4,7 @@ use crate::{
         nexus_stat::NexusIoStatsCollector,
         pool::{PoolCapacityCollector, PoolStatusCollector},
         pool_stat::PoolIoStatsCollector,
+        replica_stat::ReplicaIoStatsCollector,
     },
     grpc_client,
 };
@@ -20,6 +21,7 @@ pub(crate) async fn metrics_handler() -> impl Responder {
     let pool_status_collector = PoolStatusCollector::default();
     let pool_iostat_collector = PoolIoStatsCollector::default();
     let nexus_iostat_collector = NexusIoStatsCollector::default();
+    let replica_iostat_collector = ReplicaIoStatsCollector::default();
     // Create a new registry for prometheus.
     let registry = Registry::default();
     // Register all collectors to the registry.
@@ -34,6 +36,9 @@ pub(crate) async fn metrics_handler() -> impl Responder {
     }
     if let Err(error) = Registry::register(&registry, Box::new(nexus_iostat_collector)) {
         warn!(%error, "Nexus IoStat collector already registered");
+    }
+    if let Err(error) = Registry::register(&registry, Box::new(replica_iostat_collector)) {
+        warn!(%error, "Replica IoStat collector already registered");
     }
 
     let mut buffer = Vec::new();


### PR DESCRIPTION
This PR exposes replica stats via exporter:

After FIO completes and atleast a poll cycle elapses this is what is expected. considering num_write_ops for all resources.

Volume/Nexus:

![image](https://github.com/openebs/mayastor-extensions/assets/95069770/5530a60f-bba9-4004-a37f-f002f10f4687)


Replicas:
![image](https://github.com/openebs/mayastor-extensions/assets/95069770/df95ed85-9257-4284-be5b-b02adccc5e77)


DiskPools:
![image](https://github.com/openebs/mayastor-extensions/assets/95069770/df87f926-90da-4628-bac8-410c1403cfa2)

