### PR TITLE
feat(charts): add values to control etcd and loki hostpath sc creation

### DIFF
--- a/chart/templates/etcd/storage/localpv-storageclass.yaml
+++ b/chart/templates/etcd/storage/localpv-storageclass.yaml
@@ -1,4 +1,4 @@
-{{ if and (index .Values "localpv-provisioner" "enabled") .Values.etcd.persistence.enabled }}
+{{ if and .Values.etcd.localpvScConfig.enabled .Values.etcd.persistence.enabled }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/chart/templates/loki-stack/storage/localpv-storageclass.yaml
+++ b/chart/templates/loki-stack/storage/localpv-storageclass.yaml
@@ -1,4 +1,4 @@
-{{ if and (index .Values "localpv-provisioner" "enabled") (index .Values "loki-stack" "loki" "persistence" "enabled") (index .Values "loki-stack" "enabled") }}
+{{ if and (index .Values "loki-stack" "localpvScConfig" "enabled") (index .Values "loki-stack" "loki" "persistence" "enabled") (index .Values "loki-stack" "enabled") }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -422,6 +422,7 @@ io_engine:
 etcd:
   # Configuration for etcd's localpv hostpath storage class.
   localpvScConfig:
+    enabled: true
     # Name of etcd's localpv hostpath storage class.
     name: "mayastor-etcd-localpv"
     # -- Host path where local etcd data is stored in.
@@ -522,6 +523,7 @@ loki-stack:
   enabled: true
   # Configuration for loki's localpv hostpath storage class.
   localpvScConfig:
+    enabled: true
     # Name of loki's localpv hostpath storage class.
     name: "mayastor-loki-localpv"
     # -- Host path where local etcd data is stored in.


### PR DESCRIPTION
## Description
Add `etcd.localpvScConfig.enabled` and `loki-stack.localpvScConfig.enabled` values so that we can control the creation of storage classes for etcd and loki, for cases when localpv is installed from the umbrella helm chart.