### PR TITLE
fix(scripts/helm-docs): ignore dependency helm charts when generating README.md

### DIFF
--- a/scripts/helm/generate-readme.sh
+++ b/scripts/helm/generate-readme.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
 SCRIPTDIR=$(dirname "$0")
-ROOTDIR="$SCRIPTDIR"/../../
-TEMPLATE="$ROOTDIR/chart/README.md.tmpl"
-README="$ROOTDIR/chart/README.md"
+ROOTDIR="$SCRIPTDIR"/../..
+CHART_DIR_NAME="chart"
+CHART_DIR="$ROOTDIR/$CHART_DIR_NAME"
+TEMPLATE="$CHART_DIR/README.md.tmpl"
+README="$CHART_DIR/README.md"
 SKIP_GIT=${SKIP_GIT:-}
 
-set -euo pipefail
+set -euxo pipefail
 
-helm-docs --dry-run -t "$TEMPLATE" > "$README"
+helm-docs --dry-run -g "$CHART_DIR_NAME" -t "$TEMPLATE" > "$README"
 
 if [ -z "$SKIP_GIT" ]; then
   git diff --exit-code "$README"


### PR DESCRIPTION
The script `/scripts/helm/generate-readme.sh` generates documentation for all charts present inside the `/chart` directory. The `helm-docs` tool recursively walks through all charts in the directory and generates docs for them. This is inconvenient if there are dependency charts inside the `/chart/charts` directory. We don't necessarily want to add documentation for these charts to the README.md The `-g` option disables this.
```console
-g, --chart-to-generate strings    List of charts that will have documentation generated. Comma separated, no space. Empty list - generate for all charts in chart-search-root
```