### PR TITLE
fix(kubectl/dump/etcd): use correct namespace

### DIFF
--- a/k8s/supportability/src/collect/k8s_resources/client.rs
+++ b/k8s/supportability/src/collect/k8s_resources/client.rs
@@ -97,6 +97,10 @@ impl ClientSet {
     pub(crate) fn kube_client(&self) -> kube::Client {
         self.client.clone()
     }
+    /// Get a reference to the namespace.
+    pub(crate) fn namespace(&self) -> &str {
+        &self.namespace
+    }
 
     /// Get a new api for a `dynamic_object` for the provided GVK.
     pub(crate) async fn dynamic_object_api(

--- a/k8s/supportability/src/collect/persistent_store/etcd.rs
+++ b/k8s/supportability/src/collect/persistent_store/etcd.rs
@@ -21,9 +21,10 @@ impl EtcdStore {
         namespace: String,
     ) -> Result<Self, EtcdError> {
         let client_set = ClientSet::new(kube_config_path.clone(), namespace.clone()).await?;
-        let platform_info = platform::k8s::K8s::from(client_set.kube_client())
-            .await
-            .map_err(|e| EtcdError::Custom(format!("Failed to get k8s platform info: {e}")))?;
+        let platform_info =
+            platform::k8s::K8s::from_custom(client_set.kube_client(), client_set.namespace())
+                .await
+                .map_err(|e| EtcdError::Custom(format!("Failed to get k8s platform info: {e}")))?;
         let key_prefix = pstor::build_key_prefix(&platform_info, API_VERSION);
 
         // if an endpoint is provided it will be used, else the kubeconfig path will be used


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Etcd dump failing since an etcd bugfix, which had etcd return all data rather than keys matching a prefix.

## Description
<!--- Describe your changes in detail -->
Namespace for etcd is not available in k8s env variables as the plugin runs outside the cluster.
A better solution is perhaps to simply ensure we create clients with the correct namespace as default?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.