### PR TITLE
Chart changes

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -64,7 +64,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 ## Values
 
 | Key | Description | Default |
-|-----|-------------|:-------:|
+|:----|:------------|:--------|
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;capacity.&ZeroWidthSpace;thin.&ZeroWidthSpace;poolCommitment | The allowed pool commitment limit when dealing with thin provisioned volumes. Example: If the commitment is 250 and the pool is 10GiB we can overcommit the pool up to 25GiB (create 2 10GiB and 1 5GiB volume) but no further. | `"250%"` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;capacity.&ZeroWidthSpace;thin.&ZeroWidthSpace;snapshotCommitment | When creating snapshots for an existing volume, each replica pool must have at least this much free space percentage of the volume size. Example: if this value is 40, the pool has 40GiB free, then the max volume size allowed to be snapped on the pool is 100GiB. | `"40%"` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;capacity.&ZeroWidthSpace;thin.&ZeroWidthSpace;volumeCommitment | When creating replicas for an existing volume, each replica pool must have at least this much free space percentage of the volume size. Example: if this value is 40, the pool has 40GiB free, then the max volume size allowed to be created on the pool is 100GiB. | `"40%"` |
@@ -108,6 +108,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | base.&ZeroWidthSpace;metrics.&ZeroWidthSpace;enabled | Enable the metrics exporter | `true` |
 | crds.&ZeroWidthSpace;enabled | Install CRDs | `true` |
 | crds.&ZeroWidthSpace;jaeger.&ZeroWidthSpace;enabled | Install Jaeger CRDs | `false` |
+| crds.&ZeroWidthSpace;volumeSnapshots.&ZeroWidthSpace;enabled | Install Volume Snapshot CRDs | `true` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;logLevel | Log level for the csi controller | `"info"` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;preventVolumeModeConversion | Prevent modifying the volume mode when creating a PVC from an existing VolumeSnapshot | `true` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;priorityClassName | Set PriorityClass, overrides global | `""` |

--- a/chart/README.md
+++ b/chart/README.md
@@ -106,9 +106,9 @@ This removes all the Kubernetes components associated with the chart and deletes
 | base.&ZeroWidthSpace;logging.&ZeroWidthSpace;format | Valid values for format are pretty, json and compact | `"pretty"` |
 | base.&ZeroWidthSpace;logging.&ZeroWidthSpace;silenceLevel | Silence specific module components | `nil` |
 | base.&ZeroWidthSpace;metrics.&ZeroWidthSpace;enabled | Enable the metrics exporter | `true` |
-| crds.&ZeroWidthSpace;enabled | Install CRDs | `true` |
-| crds.&ZeroWidthSpace;jaeger.&ZeroWidthSpace;enabled | Install Jaeger CRDs | `false` |
-| crds.&ZeroWidthSpace;volumeSnapshots.&ZeroWidthSpace;enabled | Install Volume Snapshot CRDs | `true` |
+| crds.&ZeroWidthSpace;csi.&ZeroWidthSpace;volumeSnapshots.&ZeroWidthSpace;enabled | Install Volume Snapshot CRDs | `true` |
+| crds.&ZeroWidthSpace;enabled | Disables the installation of all CRDs if set to false | `true` |
+| crds.&ZeroWidthSpace;jaeger.&ZeroWidthSpace;enabled | Install Jaeger CRDs | `true` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;logLevel | Log level for the csi controller | `"info"` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;preventVolumeModeConversion | Prevent modifying the volume mode when creating a PVC from an existing VolumeSnapshot | `true` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;priorityClassName | Set PriorityClass, overrides global | `""` |

--- a/chart/README.md.tmpl
+++ b/chart/README.md.tmpl
@@ -56,7 +56,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 {{ template "chart.valuesHeader" . }}
 
 | Key | Description | Default |
-|-----|-------------|:-------:|
+|:----|:------------|:--------|
 {{ range .Values }}
 {{- if or .Description .AutoDescription -}}
 {{ if eq .Type "object" -}}

--- a/chart/charts/crds/Chart.yaml
+++ b/chart/charts/crds/Chart.yaml
@@ -2,6 +2,5 @@ apiVersion: v2
 name: crds
 version: 0.0.0
 description: |
-  A Helm chart that collects custom resource definitions (CRDs) from Mayastor. It also includes one CRD
-  from Jaeger tracing when enabled.
+  A Helm chart that collects CustomResourceDefinitions (CRDs) from Mayastor.
 

--- a/chart/charts/crds/README.md
+++ b/chart/charts/crds/README.md
@@ -6,9 +6,6 @@ A Helm chart that collects CustomResourceDefinitions (CRDs) from Mayastor.
 
 | Key | Description | Default |
 |:----|:------------|:--------|
+| csi.&ZeroWidthSpace;volumeSnapshots.&ZeroWidthSpace;enabled | Install Volume Snapshot CRDs | `true` |
 | jaeger.&ZeroWidthSpace;enabled | Install Jaeger CRDs | `true` |
-| volumeSnapshots.&ZeroWidthSpace;enabled | Install Volume Snapshot CRDs | `true` |
-| volumeSnapshots.&ZeroWidthSpace;snapshotClassesEnabled | Install volumesnapshotclasses.snapshot.storage.k8s.io CRD | `true` |
-| volumeSnapshots.&ZeroWidthSpace;snapshotContentsEnabled | Install volumesnapshotcontents.snapshot.storage.k8s.io CRD | `true` |
-| volumeSnapshots.&ZeroWidthSpace;snapshotsEnabled | Install volumesnapshots.snapshot.storage.k8s.io CRD | `true` |
 

--- a/chart/charts/crds/README.md
+++ b/chart/charts/crds/README.md
@@ -1,4 +1,14 @@
-# Mayastor CRDs
+# crds
 
-This chart brings Custom Resource Definitions (CRDs) used by Mayastor.
+A Helm chart that collects CustomResourceDefinitions (CRDs) from Mayastor.
+
+## Values
+
+| Key | Description | Default |
+|:----|:------------|:--------|
+| jaeger.&ZeroWidthSpace;enabled | Install Jaeger CRDs | `true` |
+| volumeSnapshots.&ZeroWidthSpace;enabled | Install Volume Snapshot CRDs | `true` |
+| volumeSnapshots.&ZeroWidthSpace;snapshotClassesEnabled | Install volumesnapshotclasses.snapshot.storage.k8s.io CRD | `true` |
+| volumeSnapshots.&ZeroWidthSpace;snapshotContentsEnabled | Install volumesnapshotcontents.snapshot.storage.k8s.io CRD | `true` |
+| volumeSnapshots.&ZeroWidthSpace;snapshotsEnabled | Install volumesnapshots.snapshot.storage.k8s.io CRD | `true` |
 

--- a/chart/charts/crds/README.md.tmpl
+++ b/chart/charts/crds/README.md.tmpl
@@ -1,0 +1,16 @@
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+{{ template "chart.valuesHeader" . }}
+
+| Key | Description | Default |
+|:----|:------------|:--------|
+{{ range .Values }}
+{{- if or .Description .AutoDescription -}}
+{{ if eq .Type "object" -}}
+| {{ .Key | replace "." ".&ZeroWidthSpace;" }} | {{ .Description | default .AutoDescription }} | <pre>{{ replace "}" "<br>}" (replace "{" "{<br>" (replace "," ",<br>" (toJson (fromJson (trimAll "`" (.Default | default .AutoDefault)))))) }}</pre> |
+{{ else -}}
+| {{ .Key | replace "." ".&ZeroWidthSpace;" }} | {{ .Description | default .AutoDescription }} | {{ .Default | default .AutoDefault }} |
+{{ end -}}
+{{ end }}
+{{- end }}

--- a/chart/charts/crds/templates/_helpers.tpl
+++ b/chart/charts/crds/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+    This returns a "1" if the CRD is absent in the cluster
+    Usage:
+      {{- if (include "crdIsAbsent" (list <crd-name>)) -}}
+      # CRD Yaml
+      {{- end -}}
+*/}}
+{{- define "crdIsAbsent" -}}
+    {{- $crdName := index . 0 -}}
+    {{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $crdName -}}
+    {{- $output := "1" -}}
+    {{- if $crd -}}
+        {{- $output = "" -}}
+    {{- end -}}
+
+    {{- $output -}}
+{{- end -}}

--- a/chart/charts/crds/templates/csi-volume-snapshot-class.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot-class.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.volumeSnapshots.enabled .Values.volumeSnapshots.snapshotClassesEnabled -}}
+{{- $crdName := "volumesnapshotclasses.snapshot.storage.k8s.io" -}}
+{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -146,4 +148,5 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end -}}
 {{- end -}}

--- a/chart/charts/crds/templates/csi-volume-snapshot-class.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot-class.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.volumeSnapshots.enabled .Values.volumeSnapshots.snapshotClassesEnabled -}}
+{{- if .Values.csi.volumeSnapshots.enabled -}}
 {{- $crdName := "volumesnapshotclasses.snapshot.storage.k8s.io" -}}
 {{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1

--- a/chart/charts/crds/templates/csi-volume-snapshot-class.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot-class.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.volumeSnapshots.enabled -}}
+{{- if and .Values.volumeSnapshots.enabled .Values.volumeSnapshots.snapshotClassesEnabled -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/chart/charts/crds/templates/csi-volume-snapshot-content.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot-content.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.volumeSnapshots.enabled .Values.volumeSnapshots.snapshotContentsEnabled -}}
+{{- $crdName := "volumesnapshotcontents.snapshot.storage.k8s.io" -}}
+{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -484,4 +486,5 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end -}}
 {{- end -}}

--- a/chart/charts/crds/templates/csi-volume-snapshot-content.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot-content.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.volumeSnapshots.enabled -}}
+{{- if and .Values.volumeSnapshots.enabled .Values.volumeSnapshots.snapshotContentsEnabled -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/chart/charts/crds/templates/csi-volume-snapshot-content.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot-content.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.volumeSnapshots.enabled .Values.volumeSnapshots.snapshotContentsEnabled -}}
+{{- if .Values.csi.volumeSnapshots.enabled -}}
 {{- $crdName := "volumesnapshotcontents.snapshot.storage.k8s.io" -}}
 {{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1

--- a/chart/charts/crds/templates/csi-volume-snapshot.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.volumeSnapshots.enabled -}}
+{{- if and .Values.volumeSnapshots.enabled .Values.volumeSnapshots.snapshotsEnabled -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/chart/charts/crds/templates/csi-volume-snapshot.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.volumeSnapshots.enabled .Values.volumeSnapshots.snapshotsEnabled -}}
+{{- if .Values.csi.volumeSnapshots.enabled -}}
 {{- $crdName := "volumesnapshots.snapshot.storage.k8s.io" -}}
 {{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1

--- a/chart/charts/crds/templates/csi-volume-snapshot.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.volumeSnapshots.enabled .Values.volumeSnapshots.snapshotsEnabled -}}
+{{- $crdName := "volumesnapshots.snapshot.storage.k8s.io" -}}
+{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -386,4 +388,5 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end -}}
 {{- end -}}

--- a/chart/charts/crds/templates/jaeger.yaml
+++ b/chart/charts/crds/templates/jaeger.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.jaeger.enabled -}}
+{{- $crdName := "jaegers.jaegertracing.io" -}}
+{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -43,4 +45,5 @@ spec:
       storage: true
       subresources:
         status: {}
+{{- end -}}
 {{- end -}}

--- a/chart/charts/crds/values.yaml
+++ b/chart/charts/crds/values.yaml
@@ -2,12 +2,7 @@ jaeger:
   # -- Install Jaeger CRDs
   enabled: true
 
-volumeSnapshots:
-  # -- Install Volume Snapshot CRDs
-  enabled: true
-  # -- Install volumesnapshots.snapshot.storage.k8s.io CRD
-  snapshotsEnabled: true
-  # -- Install volumesnapshotclasses.snapshot.storage.k8s.io CRD
-  snapshotClassesEnabled: true
-  # -- Install volumesnapshotcontents.snapshot.storage.k8s.io CRD
-  snapshotContentsEnabled: true
+csi:
+  volumeSnapshots:
+    # -- Install Volume Snapshot CRDs
+    enabled: true

--- a/chart/charts/crds/values.yaml
+++ b/chart/charts/crds/values.yaml
@@ -1,6 +1,13 @@
 jaeger:
   # -- Install Jaeger CRDs
   enabled: true
-# -- Install Volume Snapshots CRD
+
 volumeSnapshots:
+  # -- Install Volume Snapshot CRDs
   enabled: true
+  # -- Install volumesnapshots.snapshot.storage.k8s.io CRD
+  snapshotsEnabled: true
+  # -- Install volumesnapshotclasses.snapshot.storage.k8s.io CRD
+  snapshotClassesEnabled: true
+  # -- Install volumesnapshotcontents.snapshot.storage.k8s.io CRD
+  snapshotContentsEnabled: true

--- a/chart/shell.nix
+++ b/chart/shell.nix
@@ -11,10 +11,11 @@ in
 mkShell {
   name = "helm-scripts-shell";
   buildInputs = [
+    coreutils
     git
-    semver-tool
-    yq-go
     helm-docs
     kubernetes-helm-wrapped
+    semver-tool
+    yq-go
   ];
 }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,6 +4,9 @@ crds:
   jaeger:
     # -- Install Jaeger CRDs
     enabled: false
+  volumeSnapshots:
+    # -- Install Volume Snapshot CRDs
+    enabled: true
 
 image:
   # -- Image registry to pull our product images

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,12 +1,13 @@
 crds:
-  # -- Install CRDs
+  # -- Disables the installation of all CRDs if set to false
   enabled: true
   jaeger:
     # -- Install Jaeger CRDs
-    enabled: false
-  volumeSnapshots:
-    # -- Install Volume Snapshot CRDs
     enabled: true
+  csi:
+    volumeSnapshots:
+      # -- Install Volume Snapshot CRDs
+      enabled: true
 
 image:
   # -- Image registry to pull our product images

--- a/k8s/upgrade/src/bin/upgrade-job/common/error.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/error.rs
@@ -695,33 +695,6 @@ pub(crate) enum Error {
         args: Vec<String>,
         std_err: String,
     },
-
-    /// Error for when we fail to read the entries of a directory.
-    #[snafu(display("Failed to read the contents of directory {}: {}", path.display(), source))]
-    ReadingDirectoryContents {
-        source: std::io::Error,
-        path: PathBuf,
-    },
-
-    /// Error for when the 'crds' directory inside a helm chart directory is either not a
-    /// directory, or it does not exist.
-    #[snafu(display("Helm chart 'crds' directory {} is invalid", path.display()))]
-    InvalidHelmChartCrdDir { path: PathBuf },
-
-    /// Error for when CRD creation fails.
-    #[snafu(display("Failed to create CustomResourceDefinition '{}': {}", name, source))]
-    CreateCrd { source: kube::Error, name: String },
-
-    /// Error for when unwraping of Result<DirEntry, std::io::Error> fails.
-    #[snafu(display(
-        "Failed to collect DirEntry list from read_dir() into a Vec<_> for directory {}: {}",
-        path.display(),
-        source
-    ))]
-    CollectDirEntries {
-        source: std::io::Error,
-        path: PathBuf,
-    },
 }
 
 /// A wrapper type to remove repeated Result<T, Error> returns.

--- a/k8s/upgrade/src/bin/upgrade-job/common/kube_client.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/kube_client.rs
@@ -1,10 +1,7 @@
 use crate::common::error::{K8sClientGeneration, KubeClientSetBuilderNs, Result};
-use k8s_openapi::{
-    api::{
-        apps::v1::Deployment,
-        core::v1::{Namespace, Node, Pod},
-    },
-    apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
+use k8s_openapi::api::{
+    apps::v1::Deployment,
+    core::v1::{Namespace, Node, Pod},
 };
 use kube::{api::Api, Client};
 use snafu::ResultExt;
@@ -40,7 +37,6 @@ impl KubeClientSetBuilder {
             pods_api: Api::namespaced(client.clone(), namespace.as_str()),
             namespaces_api: Api::all(client.clone()),
             deployments_api: Api::namespaced(client.clone(), namespace.as_str()),
-            crd_api: Api::all(client),
         });
     }
 }
@@ -52,7 +48,6 @@ pub(crate) struct KubeClientSet {
     pods_api: Api<Pod>,
     namespaces_api: Api<Namespace>,
     deployments_api: Api<Deployment>,
-    crd_api: Api<CustomResourceDefinition>,
 }
 
 impl KubeClientSet {
@@ -78,11 +73,6 @@ impl KubeClientSet {
     /// Generate the Deployment api client.
     pub(crate) fn deployments_api(&self) -> &Api<Deployment> {
         &self.deployments_api
-    }
-
-    /// Generate the CustomResourceDefinition api client.
-    pub(crate) fn crd_api(&self) -> &Api<CustomResourceDefinition> {
-        &self.crd_api
     }
 
     /// Get a clone of the kube::Client.

--- a/k8s/upgrade/src/bin/upgrade-job/helm/client.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/client.rs
@@ -1,29 +1,15 @@
 use crate::{
-    common::{
-        error::{
-            CollectDirEntries, CreateCrd, HelmClientNs, HelmCommand, HelmGetValuesCommand,
-            HelmListCommand, HelmRelease, HelmUpgradeCommand, InvalidHelmChartCrdDir,
-            ReadingDirectoryContents, ReadingFile, Result, U8VectorToString, YamlParseFromFile,
-            YamlParseFromSlice,
-        },
-        kube_client::KubeClientSet,
+    common::error::{
+        HelmClientNs, HelmCommand, HelmGetValuesCommand, HelmListCommand, HelmRelease,
+        HelmUpgradeCommand, Result, U8VectorToString, YamlParseFromSlice,
     },
     vec_to_strings,
 };
-use k8s_openapi::{
-    apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition as Crd, serde,
-};
-use kube::ResourceExt;
-use kube_client::{api::PostParams, Api};
+use k8s_openapi::serde;
 use serde::Deserialize;
-use snafu::{ensure, IntoError, ResultExt};
-use std::{
-    fs,
-    path::{Path, PathBuf},
-    process::Command,
-    str,
-};
-use tracing::{debug, info};
+use snafu::{ensure, ResultExt};
+use std::{path::Path, process::Command, str};
+use tracing::debug;
 
 /// This struct is used to deserialize the output of `helm list -n <namespace> --deployed -o yaml`.
 #[derive(Clone, Deserialize)]
@@ -190,24 +176,12 @@ impl HelmReleaseClient {
         release_name: A,
         chart_dir: P,
         maybe_extra_args: Option<Vec<B>>,
-        install_crds: bool,
     ) -> Result<()>
     where
         A: ToString,
         B: ToString,
         P: AsRef<Path>,
     {
-        // Install CRDs which may be missing from older release.
-        let k8s_client = KubeClientSet::builder()
-            .with_namespace(self.namespace.as_str())
-            .build()
-            .await?;
-
-        if install_crds {
-            // Ref: https://helm.sh/docs/chart_best_practices/custom_resource_definitions
-            install_missing_crds(k8s_client.crd_api(), chart_dir.as_ref().join("crds")).await?;
-        }
-
         let command: &str = "helm";
         let mut args: Vec<String> = vec_to_strings![
             "upgrade",
@@ -272,65 +246,4 @@ impl HelmReleaseClient {
         }
         .fail()
     }
-}
-
-/// Installs CRDs which are missing from the target helm chart cluster which are missing
-/// from the cluster.
-async fn install_missing_crds(crd_client: &Api<Crd>, crd_dir_path: PathBuf) -> Result<()> {
-    ensure!(
-        crd_dir_path.is_dir(),
-        InvalidHelmChartCrdDir { path: crd_dir_path }
-    );
-    // List the entries in the 'crds' directory.
-    let entries = fs::read_dir(crd_dir_path.as_path())
-        .context(ReadingDirectoryContents {
-            path: crd_dir_path.clone(),
-        })?
-        .map(|res| res.map(|e| e.path()))
-        .collect::<Result<Vec<_>, std::io::Error>>()
-        .context(CollectDirEntries { path: crd_dir_path })?;
-
-    // Walk through the entries in the directory and create the CRDs.
-    // This errors out if a file is not a CRD, but that is okay because the 'crds' directory
-    // is meant for use with CRDs only.
-    for entry in entries {
-        if entry.is_file() {
-            let crd_yaml = fs::read(entry.as_path()).context(ReadingFile {
-                filepath: entry.clone(),
-            })?;
-
-            let crd: Crd = serde_yaml::from_slice(crd_yaml.as_slice())
-                .context(YamlParseFromFile { filepath: entry })?;
-
-            // Create CRDs, and ignore creation failures due to the CRD already
-            // existing in the cluster.
-            let pp = PostParams::default();
-            let creation_result = crd_client.create(&pp, &crd).await;
-            if let Err(err) = creation_result {
-                match err {
-                    // Return early if creation has failed due to the CRD already existing in the
-                    // cluster.
-                    // Ref: https://github.com/kubernetes/apimachinery/blob/v0.27.3/pkg/apis/meta/v1/types.go#L846
-                    // TODO: It could be that the existing CRD registers a CR of a different version
-                    //       than the one bundled with the target helm chart. This needs to be
-                    // handled.
-                    kube::Error::Api(response) if response.reason.eq("AlreadyExists") => {
-                        info!(
-                            "CustomResourceDefinition '{}' already exists",
-                            crd.name_any()
-                        );
-                        continue;
-                    }
-                    _ => {
-                        return Err(CreateCrd {
-                            name: crd.name_any(),
-                        }
-                        .into_error(err))
-                    }
-                }
-            }
-            info!("Created CustomResourceDefinition '{}'", crd.name_any());
-        }
-    }
-    Ok(())
 }

--- a/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
@@ -304,7 +304,6 @@ is the same as that of this upgrade-job's helm chart"
                 self.release_name.as_str(),
                 self.chart_dir.as_path(),
                 Some(dry_run_extra_args),
-                false,
             )
             .await?;
         info!("Helm upgrade dry-run succeeded!");
@@ -323,7 +322,6 @@ is the same as that of this upgrade-job's helm chart"
                     self.release_name,
                     self.chart_dir,
                     Some(self.helm_upgrade_extra_args),
-                    true,
                 )
                 .await?;
             info!("Helm upgrade successful!");

--- a/scripts/helm/generate-readme.sh
+++ b/scripts/helm/generate-readme.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
 SCRIPTDIR=$(dirname "$0")
-ROOTDIR="$SCRIPTDIR"/../..
-CHART_DIR_NAME="chart"
-CHART_DIR="$ROOTDIR/$CHART_DIR_NAME"
-TEMPLATE="$CHART_DIR/README.md.tmpl"
-README="$CHART_DIR/README.md"
+ROOTDIR="$(realpath $SCRIPTDIR/../..)"
+CHART_DIR="$ROOTDIR/chart"
+CRDS_CHART_DIR="$CHART_DIR/charts/crds"
+TEMPLATE="README.md.tmpl"
+README="README.md"
 SKIP_GIT=${SKIP_GIT:-}
 
 set -euo pipefail
 
-helm-docs --dry-run -g "$CHART_DIR_NAME" -t "$TEMPLATE" > "$README"
+helm-docs -c "$ROOTDIR" -g "$CHART_DIR,$CRDS_CHART_DIR" -t "$TEMPLATE" -o $README
 
 if [ -z "$SKIP_GIT" ]; then
-  git diff --exit-code "$README"
+  git diff --exit-code "$CHART_DIR/$README" "$CRDS_CHART_DIR/$README"
 fi

--- a/scripts/helm/publish-chart-yaml.sh
+++ b/scripts/helm/publish-chart-yaml.sh
@@ -214,6 +214,7 @@ ROOTDIR="$SCRIPTDIR/../.."
 CHART_FILE=${CHART_FILE:-"$ROOTDIR/chart/Chart.yaml"}
 CHART_VALUES=${CHART_VALUES:-"$ROOTDIR/chart/values.yaml"}
 CHART_DOC=${CHART_DOC:-"$ROOTDIR/chart/doc.yaml"}
+CRDS_SUBCHART_CHART_FILE="${CHART_FILE%Chart.yaml}charts/crds/Chart.yaml"
 CHART_NAME="mayastor"
 # Tag that has been pushed
 APP_TAG=
@@ -371,6 +372,8 @@ if [ -n "$CHECK_BRANCH" ]; then
     if [ -z "$DRY_RUN" ]; then
       sed -i "s/^version:.*$/version: $newChartVersion/" "$CHART_FILE"
       sed -i "s/^appVersion:.*$/appVersion: \"$newChartAppVersion\"/" "$CHART_FILE"
+      # Set same versions on the CRD subchart
+      sed -i "s/^version:.*/version: $newChartVersion/" "$CRDS_SUBCHART_CHART_FILE"
       # Set image tag to empty because main branch uses repoTags.
       yq_ibl '.image.tag |= ""' "$CHART_VALUES"
       # always pull since image changes with commits to the branch
@@ -388,6 +391,8 @@ if [ -n "$CHECK_BRANCH" ]; then
       if [ -z "$DRY_RUN" ]; then
         sed -i "s/^version:.*$/version: $newChartVersion/" "$CHART_FILE"
         sed -i "s/^appVersion:.*$/appVersion: \"$newChartAppVersion\"/" "$CHART_FILE"
+        # Set same versions on the CRD subchart
+        sed -i "s/^version:.*/version: $newChartVersion/" "$CRDS_SUBCHART_CHART_FILE"
         # point image tag to the release branch images
         yq_ibl ".image.tag |= \"${CHECK_BRANCH////-}\"" "$CHART_VALUES"
         # always pull since image changes with commits to the branch
@@ -473,6 +478,8 @@ echo "NEW_CHART_APP_VERSION: $newChartAppVersion"
 if [ -z "$DRY_RUN" ]; then
   sed -i "s/^version:.*$/version: $newChartVersion/" "$CHART_FILE"
   sed -i "s/^appVersion:.*$/appVersion: \"$newChartAppVersion\"/" "$CHART_FILE"
+  # Set same versions on the CRD subchart
+  sed -i "s/^version:.*/version: $newChartVersion/" "$CRDS_SUBCHART_CHART_FILE"
   yq_ibl ".image.tag |= \"v$newChartAppVersion\"" "$CHART_VALUES"
   # tags are stable so we don't need to pull always
   yq_ibl ".image.pullPolicy |= \"IfNotPresent\"" "$CHART_VALUES"

--- a/shell.nix
+++ b/shell.nix
@@ -23,6 +23,7 @@ mkShell {
     cargo-udeps
     clang
     commitlint
+    coreutils
     cowsay
     git
     helm-docs


### PR DESCRIPTION
- add README.md helm-docs template for crds subchart
- add values to toggle install of all CRDs
- coreutils to nix-shells
- add value option to toggle installation of snapshot CRDs
- refactor generate-readme.sh script to work with CRDs subchart
- add templates to crds chart to avoid installation if CRDs already exists, because otherwise install/upgrade fails because these template-style CRDs carry a release-name label.
- remove CRD-install functionality during upgrade, as the above templating takes care of that at install/upgrade time.