### PR TITLE
fix(upgrade-job): look for crds in charts dir

### DIFF
--- a/k8s/upgrade/src/bin/upgrade-job/opts/validators.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/opts/validators.rs
@@ -189,7 +189,7 @@ fn validate_core_helm_chart_variant_in_dir(dir_path: PathBuf) -> Result<()> {
 
     // Validate crds directory.
     let mut crds_dir_path = dir_path.clone();
-    crds_dir_path.push("crds");
+    crds_dir_path.push("charts/crds");
     ensure!(
         path_exists_and_is_dir(crds_dir_path.clone())?,
         NotADirectory {


### PR DESCRIPTION
The upgrade-job validates the chart that it's got by checking if all the right directories are where they're supposed to be. Recent changes to the CRD installation method (ref: #414) has resulted in the upgrade-job failing, because things aren't how it expects. This PR changes the CRDs directory path to that of the subchart which encapsulates the CRDs now.