### PR TITLE
feat(chart): prevent CRDs from being recycled

### DIFF
--- a/chart/charts/crds/README.md
+++ b/chart/charts/crds/README.md
@@ -4,8 +4,12 @@ A Helm chart that collects CustomResourceDefinitions (CRDs) from Mayastor.
 
 ## Values
 
-| Key | Description | Default |
-|:----|:------------|:--------|
-| csi.&ZeroWidthSpace;volumeSnapshots.&ZeroWidthSpace;enabled | Install Volume Snapshot CRDs | `true` |
-| jaeger.&ZeroWidthSpace;enabled | Install Jaeger CRDs | `true` |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| csi.volumeSnapshots.annotations | object | `{}` | Annotations to be added to all CRDs |
+| csi.volumeSnapshots.enabled | bool | `true` | Install Volume Snapshot CRDs |
+| csi.volumeSnapshots.keep | bool | `true` | Keep CRDs on chart uninstall |
+| jaeger.annotations | object | `{}` | Annotations to be added to all CRDs |
+| jaeger.enabled | bool | `true` | Install Jaeger CRDs |
+| jaeger.keep | bool | `true` | Keep CRDs on chart uninstall |
 

--- a/chart/charts/crds/README.md
+++ b/chart/charts/crds/README.md
@@ -4,12 +4,12 @@ A Helm chart that collects CustomResourceDefinitions (CRDs) from Mayastor.
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| csi.volumeSnapshots.annotations | object | `{}` | Annotations to be added to all CRDs |
-| csi.volumeSnapshots.enabled | bool | `true` | Install Volume Snapshot CRDs |
-| csi.volumeSnapshots.keep | bool | `true` | Keep CRDs on chart uninstall |
-| jaeger.annotations | object | `{}` | Annotations to be added to all CRDs |
-| jaeger.enabled | bool | `true` | Install Jaeger CRDs |
-| jaeger.keep | bool | `true` | Keep CRDs on chart uninstall |
+| Key | Description | Default |
+|:----|:------------|:--------|
+| csi.&ZeroWidthSpace;volumeSnapshots.&ZeroWidthSpace;annotations | Annotations to be added to all CRDs | <pre>{<br><br>}</pre> |
+| csi.&ZeroWidthSpace;volumeSnapshots.&ZeroWidthSpace;enabled | Install Volume Snapshot CRDs | `true` |
+| csi.&ZeroWidthSpace;volumeSnapshots.&ZeroWidthSpace;keep | Keep CRDs on chart uninstall | `true` |
+| jaeger.&ZeroWidthSpace;annotations | Annotations to be added to all CRDs | <pre>{<br><br>}</pre> |
+| jaeger.&ZeroWidthSpace;enabled | Install Jaeger CRDs | `true` |
+| jaeger.&ZeroWidthSpace;keep | Keep CRDs on chart uninstall | `true` |
 

--- a/chart/charts/crds/templates/_helpers.tpl
+++ b/chart/charts/crds/templates/_helpers.tpl
@@ -1,24 +1,6 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-    This returns a "1" if the CRD is absent in the cluster
-    Usage:
-      {{- if (include "crdIsAbsent" (list <crd-name>)) -}}
-      # CRD Yaml
-      {{- end -}}
-*/}}
-{{- define "crdIsAbsent" -}}
-    {{- $crdName := index . 0 -}}
-    {{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $crdName -}}
-    {{- $output := "1" -}}
-    {{- if $crd -}}
-        {{- $output = "" -}}
-    {{- end -}}
-
-    {{- $output -}}
-{{- end -}}
-
-{{/*
     Adds extra annotations to CRDs. This targets two scenarios: preventing CRD recycling in case
     the chart is removed; and adding custom annotations.
     NOTE: This function assumes the element `metadata.annotations` already exists.

--- a/chart/charts/crds/templates/_helpers.tpl
+++ b/chart/charts/crds/templates/_helpers.tpl
@@ -17,3 +17,22 @@
 
     {{- $output -}}
 {{- end -}}
+
+{{/*
+    Adds extra annotations to CRDs. This targets two scenarios: preventing CRD recycling in case
+    the chart is removed; and adding custom annotations.
+    NOTE: This function assumes the element `metadata.annotations` already exists.
+
+    Usage:
+      {{- include "crds.extraAnnotations" .Values.csi.volumeSnapshots | nindent 4 }}
+*/}}
+
+{{- define "crds.extraAnnotations" -}}
+{{- if .keep -}}
+helm.sh/resource-policy: keep
+{{ end }}
+{{- with .annotations }}
+  {{- toYaml . }}
+{{- end }}
+{{- end -}}
+

--- a/chart/charts/crds/templates/csi-volume-snapshot-class.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot-class.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
+    {{- include "crds.extraAnnotations" .Values.csi.volumeSnapshots | nindent 4 }}
   creationTimestamp: null
   name: volumesnapshotclasses.snapshot.storage.k8s.io
 spec:

--- a/chart/charts/crds/templates/csi-volume-snapshot-class.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot-class.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.csi.volumeSnapshots.enabled -}}
-{{- $crdName := "volumesnapshotclasses.snapshot.storage.k8s.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -149,5 +147,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/chart/charts/crds/templates/csi-volume-snapshot-content.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot-content.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.csi.volumeSnapshots.enabled -}}
-{{- $crdName := "volumesnapshotcontents.snapshot.storage.k8s.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -487,5 +485,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/chart/charts/crds/templates/csi-volume-snapshot-content.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot-content.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
+    {{- include "crds.extraAnnotations" .Values.csi.volumeSnapshots | nindent 4 }}
   creationTimestamp: null
   name: volumesnapshotcontents.snapshot.storage.k8s.io
 spec:

--- a/chart/charts/crds/templates/csi-volume-snapshot.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
+    {{- include "crds.extraAnnotations" .Values.csi.volumeSnapshots | nindent 4 }}
   creationTimestamp: null
   name: volumesnapshots.snapshot.storage.k8s.io
 spec:

--- a/chart/charts/crds/templates/csi-volume-snapshot.yaml
+++ b/chart/charts/crds/templates/csi-volume-snapshot.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.csi.volumeSnapshots.enabled -}}
-{{- $crdName := "volumesnapshots.snapshot.storage.k8s.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -389,5 +387,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/chart/charts/crds/templates/jaeger.yaml
+++ b/chart/charts/crds/templates/jaeger.yaml
@@ -5,6 +5,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: jaegers.jaegertracing.io
+  {{- if or (.Values.jaeger.keep) (.Values.jaeger.annotations) }}
+  annotations:
+    {{- include "crds.extraAnnotations" .Values.jaeger | nindent 4 }}
+  {{- end }}
   labels:
     app: jaeger-operator
 spec:

--- a/chart/charts/crds/templates/jaeger.yaml
+++ b/chart/charts/crds/templates/jaeger.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.jaeger.enabled -}}
-{{- $crdName := "jaegers.jaegertracing.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -49,5 +47,4 @@ spec:
       storage: true
       subresources:
         status: {}
-{{- end -}}
 {{- end -}}

--- a/chart/charts/crds/values.yaml
+++ b/chart/charts/crds/values.yaml
@@ -1,8 +1,21 @@
 jaeger:
   # -- Install Jaeger CRDs
   enabled: true
+  # -- Keep CRDs on chart uninstall
+  keep: true
+  # -- Annotations to be added to all CRDs
+  annotations: {}
+    # Example for Argo CD to prevent CRDs from being recycled
+    # argocd.argoproj.io/sync-options: Prune=false
 
 csi:
   volumeSnapshots:
     # -- Install Volume Snapshot CRDs
     enabled: true
+    # -- Keep CRDs on chart uninstall
+    keep: true
+    # -- Annotations to be added to all CRDs
+    annotations: {}
+    # Example for Argo CD to prevent CRDs from being recycled
+    # argocd.argoproj.io/sync-options: Prune=false
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description

With current implementation a chart uninstall also removes the CRDs, which triggers deletion of all created CRs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Add a configuration to keep CRDs by default, instructing Helm to not delete such resources. Also add the possibility to specify extra annotations. This is especially interesting for Argo CD users, as Argo CD does not install charts the Helm way. In such a case, an extra annotation to prevent prunning resources is required.

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Case 1: keep all CRDs**

```shell
helm chart template
```

**Case 2: keep CSI VolumeSnaphots CRDs only**

```shell
helm chart template --set crds.jaeger.keep=false
```

**Case 3: keep Jaeger CRDs only**

```shell
helm chart template --set crds.csi.volumeSnapshots.keep=false
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.