### PR TITLE
feat(upgrade-job): use 'crds' subchart toggles to disable existing CRDs

### DIFF
--- a/k8s/upgrade/src/bin/upgrade-job/common/error.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/error.rs
@@ -384,10 +384,6 @@ pub(crate) enum Error {
     ))]
     NotAKnownHelmChart { chart_name: String },
 
-    /// Error for when namespace option is not set when building KubeClientSet.
-    #[snafu(display("Mandatory KubeClientSetBuilder option 'namespace' not set"))]
-    KubeClientSetBuilderNs,
-
     /// Error for when mandatory options for an EventRecorder are missing when building.
     #[snafu(display("Mandatory options for EventRecorder were not given"))]
     EventRecorderOptionsAbsent,
@@ -695,6 +691,9 @@ pub(crate) enum Error {
         args: Vec<String>,
         std_err: String,
     },
+
+    #[snafu(display("failed to list CustomResourceDefinitions: {source}"))]
+    ListCrds { source: kube::Error },
 }
 
 /// A wrapper type to remove repeated Result<T, Error> returns.

--- a/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/upgrade.rs
@@ -229,7 +229,8 @@ impl HelmUpgraderBuilder {
                 source_values_buf,
                 target_values_filepath.as_path(),
                 chart_dir.as_path(),
-            )?;
+            )
+            .await?;
 
             // helm upgrade .. -f <values-yaml> --set <a> --set-file <args> --atomic
             let helm_upgrade_extra_args = vec_to_strings![

--- a/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/helm/values.rs
@@ -4,20 +4,22 @@ use crate::{
             TWO_DOT_FIVE, TWO_DOT_FOUR, TWO_DOT_ONE, TWO_DOT_O_RC_ONE, TWO_DOT_SIX, TWO_DOT_THREE,
         },
         error::{
-            DeserializePromtailExtraConfig, Result, SemverParse,
+            DeserializePromtailExtraConfig, ListCrds, Result, SemverParse,
             SerializePromtailConfigClientToJson, SerializePromtailExtraConfigToJson,
             SerializePromtailInitContainerToJson,
         },
         file::write_to_tempfile,
+        kube_client as KubeClient,
     },
     helm::{
         chart::{CoreValues, PromtailConfigClient},
         yaml::yq::{YamlKey, YqV4},
     },
 };
+use kube::{api::ListParams, ResourceExt};
 use semver::Version;
 use snafu::ResultExt;
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 use tempfile::NamedTempFile as TempFile;
 
 /// This compiles all of the helm values options to be passed during the helm chart upgrade.
@@ -43,7 +45,7 @@ use tempfile::NamedTempFile as TempFile;
 ///     chart_dir --> This is the path to a directory that yq-go may use to write its output file
 /// into. The output file will be a merged values.yaml with special values set as per requirement
 /// (based on source_version and target_version).
-pub(crate) fn generate_values_yaml_file<P, Q>(
+pub(crate) async fn generate_values_yaml_file<P, Q>(
     source_version: &Version,
     target_version: &Version,
     source_values: &CoreValues,
@@ -402,6 +404,9 @@ where
         upgrade_values_file.path(),
     )?;
 
+    // Disable CRD installation in case they already exist using helm values.
+    safe_crd_install(upgrade_values_file.path(), &yq).await?;
+
     // helm upgrade .. --set image.tag=<version> --set image.repoTags.controlPlane= --set
     // image.repoTags.dataPlane= --set image.repoTags.extensions=
 
@@ -470,6 +475,62 @@ fn loki_address_to_clients(
         YamlKey::try_from(".loki-stack.promtail.config.lokiAddress")?,
         upgrade_values_filepath,
     )?;
+
+    Ok(())
+}
+
+/// Use pre-defined helm chart templating to disable CRD installation if they already exist.
+async fn safe_crd_install(upgrade_values_filepath: &Path, yq: &YqV4) -> Result<()> {
+    const MAX_ENTRIES: u32 = 500;
+
+    let mut crd_set_to_helm_toggle: HashMap<Vec<&str>, YamlKey> = HashMap::new();
+    // These 3 CRDs usually exist together.
+    crd_set_to_helm_toggle.insert(
+        vec![
+            "volumesnapshotclasses.snapshot.storage.k8s.io",
+            "volumesnapshotcontents.snapshot.storage.k8s.io",
+            "volumesnapshots.snapshot.storage.k8s.io",
+        ],
+        YamlKey::try_from(".crds.csi.volumeSnapshots.enabled")?,
+    );
+    crd_set_to_helm_toggle.insert(
+        vec!["jaegers.jaegertracing.io"],
+        YamlKey::try_from(".crds.jaeger.enabled")?,
+    );
+
+    let crds_api = KubeClient::crds_api().await?;
+    let mut all_crd_names: Vec<String> = Vec::with_capacity(MAX_ENTRIES as usize);
+    let mut list_params = ListParams::default().limit(MAX_ENTRIES);
+
+    loop {
+        let crd_list = crds_api
+            .list_metadata(&list_params)
+            .await
+            .context(ListCrds)?;
+
+        all_crd_names = all_crd_names
+            .into_iter()
+            .chain(crd_list.iter().map(|metadata| metadata.name_unchecked()))
+            .collect();
+
+        match crd_list.metadata.continue_ {
+            Some(token) => {
+                list_params = list_params.continue_token(token.as_str());
+            }
+            None => break,
+        }
+    }
+
+    for (crd_set, helm_toggle) in crd_set_to_helm_toggle.into_iter() {
+        // Uses an OR logical check to disable set installation, i.e. disable if
+        // at least one exists. Does not make sure if all exist.
+        if all_crd_names
+            .iter()
+            .any(|name| crd_set.contains(&name.as_str()))
+        {
+            yq.set_literal_value(helm_toggle, false, upgrade_values_filepath)?
+        }
+    }
 
     Ok(())
 }

--- a/k8s/upgrade/src/bin/upgrade-job/opts/validators.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/opts/validators.rs
@@ -7,7 +7,7 @@ use crate::{
             RegexCompile, Result, U8VectorToString, ValidateDirPath, ValidateFilePath,
             YamlParseFromFile,
         },
-        kube_client::KubeClientSet,
+        kube_client as KubeClient,
         rest_client::RestClientSet,
     },
     helm::chart::Chart,
@@ -214,13 +214,9 @@ fn validate_core_helm_chart_variant_in_dir(dir_path: PathBuf) -> Result<()> {
 /// - if the kubernetes API is reachable.
 /// - if the input namespace exists.
 pub(crate) async fn validate_namespace(ns: String) -> Result<()> {
-    let k8s_client = KubeClientSet::builder()
-        .with_namespace(ns.as_str())
-        .build()
-        .await?;
+    let ns_api = KubeClient::namespaces_api().await?;
 
-    k8s_client
-        .namespaces_api()
+    ns_api
         .get(ns.as_str())
         .await
         .context(GetNamespace { namespace: ns })?;

--- a/k8s/upgrade/src/bin/upgrade-job/upgrade/path.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/upgrade/path.rs
@@ -5,7 +5,7 @@ use crate::{
             ListDeploymentsWithLabel, NoRestDeployment, NoVersionLabelInDeployment, ReadingFile,
             Result, SemverParse, YamlParseBufferForUnsupportedVersion, YamlParseFromFile,
         },
-        kube_client::KubeClientSet,
+        kube_client as KubeClient,
     },
     helm::chart::Chart,
 };
@@ -42,9 +42,8 @@ pub(crate) fn version_from_chart_yaml_file(path: PathBuf) -> Result<Version> {
 pub(crate) async fn version_from_rest_deployment_label(ns: &str) -> Result<Version> {
     let labels = format!("{API_REST_LABEL},{CHART_VERSION_LABEL_KEY}");
 
-    let k8s_client = KubeClientSet::builder().with_namespace(ns).build().await?;
-    let mut deploy_list = k8s_client
-        .deployments_api()
+    let deployments_api = KubeClient::deployments_api(ns).await?;
+    let mut deploy_list = deployments_api
         .list(&ListParams::default().labels(labels.as_str()))
         .await
         .context(ListDeploymentsWithLabel {


### PR DESCRIPTION
Changes:
- adds a CRDs API client
- uses the crds subchart's enable toggles to disable CRDs which already exist in the cluster.