### PR TITLE
feat(build): add support for release branch helm-core tag

### DIFF
--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -55,7 +55,7 @@ let
     # Script doesn't need to be used with main branch `--alias-tag <main-branch-style-tag>`.
     # The repo chart is already prepared.
     if [[ "$(semver validate ${tag})" == "valid" ]] &&
-      [[ ! ${tag} =~ ^(v?[0-9]+\.[0-9]+\.[0-9]+-0-main-unstable(-[0-9]+){6}-0)$ ]]; then
+      [[ ! ${tag} =~ ^(v?[0-9]+\.[0-9]+\.[0-9]+-0-(main|release)-unstable(-[0-9]+){6}-0)$ ]]; then
       CHART_FILE=build/chart/Chart.yaml build/scripts/helm/publish-chart-yaml.sh --app-tag ${tag} --override-index ""
     fi
 


### PR DESCRIPTION
This PR extends the regular expression on the upgrade-job's nix-build which transforms the repo helm chart into a production helm chart. This will allow release branch helm core to test the repo chart without changing the chart into a production chart. Production chart is only required for production, and no other semver tag, especially not the known testing tag.