### PR TITLE
feat(topology): filter pools by volume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.10.2",
  "tonic-build",
  "tower",
  "tower-service",
@@ -1102,7 +1102,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tonic-build",
  "tracing",
  "uuid",
@@ -1304,6 +1304,12 @@ dependencies = [
  "quote",
  "syn 2.0.38",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -1846,7 +1852,7 @@ dependencies = [
  "humantime",
  "kube-proxy",
  "openapi",
- "opentelemetry",
+ "opentelemetry 0.20.0",
  "rest-plugin",
  "shutdown",
  "supportability",
@@ -1972,7 +1978,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tracing",
  "utils",
 ]
@@ -2127,7 +2133,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-tls",
- "opentelemetry",
+ "opentelemetry 0.22.0",
  "opentelemetry-http",
  "opentelemetry-jaeger",
  "pin-project",
@@ -2200,44 +2206,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
  "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.20.0",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.9.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7594ec0e11d8e33faf03530a4c49af7064ebba81c1480e01be67d90b356508b"
+checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry_api",
+ "opentelemetry 0.22.0",
 ]
 
 [[package]]
 name = "opentelemetry-jaeger"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876958ba9084f390f913fcf04ddf7bbbb822898867bb0a51cc28f2b9e5c1b515"
+checksum = "fb7f5ef13427696ae8382c6f3bb7dcdadb5994223d6b983c7c50a46df7d19277"
 dependencies = [
  "async-trait",
  "futures-core",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.22.0",
  "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk 0.22.1",
  "thrift",
  "tokio",
 ]
 
 [[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.12.0"
+name = "opentelemetry-otlp"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
 dependencies = [
- "opentelemetry",
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry 0.22.0",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk 0.22.1",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic 0.11.0",
 ]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+dependencies = [
+ "opentelemetry 0.22.0",
+ "opentelemetry_sdk 0.22.1",
+ "prost",
+ "tonic 0.11.0",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
 
 [[package]]
 name = "opentelemetry_api"
@@ -2271,7 +2321,28 @@ dependencies = [
  "ordered-float 3.9.2",
  "percent-encoding",
  "rand",
- "regex",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry 0.22.0",
+ "ordered-float 4.2.0",
+ "percent-encoding",
+ "rand",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2291,6 +2362,15 @@ name = "ordered-float"
 version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -2605,7 +2685,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tracing",
  "url",
  "utils",
@@ -2878,7 +2958,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "tonic",
+ "tonic 0.10.2",
  "tonic-build",
 ]
 
@@ -3723,6 +3803,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.5",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3830,29 +3937,31 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75327c6b667828ddc28f5e3f169036cb793c3f588d83bf0f262a7f062ffed3c8"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
 dependencies = [
+ "js-sys",
  "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.22.0",
+ "opentelemetry_sdk 0.22.1",
  "smallvec",
  "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -3867,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term 0.46.0",
@@ -4049,8 +4158,11 @@ version = "0.1.0"
 dependencies = [
  "event-publisher",
  "git-version-macro",
- "opentelemetry",
- "opentelemetry-jaeger",
+ "heck",
+ "opentelemetry 0.22.0",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk 0.22.1",
  "strum",
  "strum_macros",
  "tracing",
@@ -4198,6 +4310,16 @@ name = "web-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/call-home/src/bin/callhome/main.rs
+++ b/call-home/src/bin/callhome/main.rs
@@ -202,7 +202,7 @@ async fn generate_report(
         }
     };
 
-    let pools = http_client.pools_api().get_pools().await;
+    let pools = http_client.pools_api().get_pools(None).await;
     match pools {
         Ok(ref pools) => report.pools = Pools::new(pools.clone().into_body(), event_data.clone()),
         Err(ref err) => {

--- a/k8s/plugin/README.md
+++ b/k8s/plugin/README.md
@@ -95,19 +95,26 @@ Options:
 
 5. Get Pool by Node ID
 ```
-❯ kubectl mayastor get pools --node-id kworker1
+❯ kubectl mayastor get pools --node kworker1
  ID               DISKS                                                     MANAGED  NODE      STATUS  CAPACITY  ALLOCATED  AVAILABLE
  pool-1-kworker1  aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  true     kworker1  Online  500GiB    100GiB     400GiB
  ```
 
-6. Select pools based on labels. Filer labels must be provided in `key1=value1,key2=value2` format.
+6. Get Pool used by volume
+```
+❯ kubectl mayastor get pools --volume ec4e66fd-3b33-4439-b504-d49aba53da26
+ ID               DISKS                                                     MANAGED  NODE      STATUS  CAPACITY  ALLOCATED  AVAILABLE
+ pool-1-kworker1  aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  true     kworker1  Online  500GiB    100GiB     400GiB
+ ```
+
+7. Select pools based on labels. Filer labels must be provided in `key1=value1,key2=value2` format.
 ```
 ❯ kubectl mayastor get pools --selector  type=hhd
  ID               DISKS                                                     MANAGED  NODE      STATUS  CAPACITY  ALLOCATED  AVAILABLE
  pool-1-kworker3  aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  true     kworker3  Online  500GiB    100GiB     400GiB
  ```
 
-7. Get Nodes
+8. Get Nodes
 ```
 ❯ kubectl mayastor get nodes
  ID           GRPC ENDPOINT   STATUS
@@ -115,14 +122,14 @@ Options:
  io-engine-3  10.1.0.7:10124  Online, Cordoned, Drained
  io-engine-2  10.1.0.6:10124  Online
 ```
-8. Get Node by ID
+9. Get Node by ID
 ```
 ❯ kubectl mayastor get node io-engine-1
  ID           GRPC ENDPOINT   STATUS
  io-engine-1  10.1.0.5:10124  Online, Cordoned
 ```
 
-9. Get Volume(s)/Pool(s)/Node(s) to a specific Output Format
+10. Get Volume(s)/Pool(s)/Node(s) to a specific Output Format
 ```
 ❯ kubectl mayastor -ojson get volumes
 [{"spec":{"num_replicas":2,"size":67108864,"status":"Created","target":{"node":"ksnode-2","protocol":"nvmf"},"uuid":"5703e66a-e5e5-4c84-9dbe-e5a9a5c805db","topology":{"explicit":{"allowed_nodes":["ksnode-1","ksnode-3","ksnode-2"],"preferred_nodes":["ksnode-2","ksnode-3","ksnode-1"]}},"policy":{"self_heal":true}},"state":{"target":{"children":[{"state":"Online","uri":"bdev:///ac02cf9e-8f25-45f0-ab51-d2e80bd462f1?uuid=ac02cf9e-8f25-45f0-ab51-d2e80bd462f1"},{"state":"Online","uri":"nvmf://192.168.122.6:8420/nqn.2019-05.io.openebs:7b0519cb-8864-4017-85b6-edd45f6172d8?uuid=7b0519cb-8864-4017-85b6-edd45f6172d8"}],"deviceUri":"nvmf://192.168.122.234:8420/nqn.2019-05.io.openebs:nexus-140a1eb1-62b5-43c1-acef-9cc9ebb29425","node":"ksnode-2","rebuilds":0,"protocol":"nvmf","size":67108864,"state":"Online","uuid":"140a1eb1-62b5-43c1-acef-9cc9ebb29425"},"size":67108864,"status":"Online","uuid":"5703e66a-e5e5-4c84-9dbe-e5a9a5c805db"}}]
@@ -184,7 +191,7 @@ Options:
     used: 3258974208
     committed: 3258974208
 ```
-10. Replica topology for a specific volume
+11. Replica topology for a specific volume
 ```
 ❯ kubectl mayastor get volume-replica-topology ec4e66fd-3b33-4439-b504-d49aba53da26
  ID                                    NODE      POOL             STATUS  CAPACITY  ALLOCATED SNAPSHOTS  CHILD-STATUS  REASON  REBUILD
@@ -192,7 +199,7 @@ Options:
  d3856829-22b3-414d-a01b-4b6467db14fb  kworker2  pool-1-kworker2  Online  384MiB    8MiB      64MiB      Online        <none>  <none>
 ```
 
-11. Replica topology for all volumes
+12. Replica topology for all volumes
 ```
 ❯ kubectl mayastor get volume-replica-topologies
 VOLUME-ID                              ID                                    NODE      POOL             STATUS  CAPACITY  ALLOCATED SNAPSHOTS CHILD-STATUS  REASON      REBUILD
@@ -204,7 +211,7 @@ VOLUME-ID                              ID                                    NOD
  └─                                    39431c11-0eea-48e7-970f-a2359ebbb9d1  kworker3  pool-1-kworker3  Online  60MiB     60MiB     0MiB      Online        <none>      <none>
 ```
 
-12. Volume Snapshots by volumeID
+13. Volume Snapshots by volumeID
 ```
 ❯ kubectl mayastor get volume-snapshots --volume ec4e66fd-3b33-4439-b504-d49aba53da26
  ID                                    TIMESTAMP             SOURCE-SIZE  ALLOCATED-SIZE  TOTAL-ALLOCATED-SIZE  SOURCE-VOL                            RESTORES
@@ -212,7 +219,7 @@ VOLUME-ID                              ID                                    NOD
 
 ```
 
-13. Get Volume Snapshots
+14. Get Volume Snapshots
 ```
 ❯ kubectl mayastor get volume-snapshots
  ID                                    TIMESTAMP             SOURCE-SIZE  ALLOCATED-SIZE  TOTAL-ALLOCATED-SIZE  SOURCE-VOL                            RESTORES
@@ -221,7 +228,7 @@ VOLUME-ID                              ID                                    NOD
 
 ```
 
-14. Volume Rebuild History by volumeID
+15. Volume Rebuild History by volumeID
 ```
 ❯ kubectl mayastor get rebuild-history e898106d-e735-4edf-aba2-932d42c3c58d
 DST                                   SRC                                   STATE      TOTAL  RECOVERED  TRANSFERRED  IS-PARTIAL  START-TIME            END-TIME
@@ -235,7 +242,7 @@ b5de71a6-055d-433a-a1c5-2b39ade05d86  0dafa450-7a19-4e21-a919-89c6f9bd2a97  Comp
 
 **NOTE: The above command lists volume snapshots for all volumes if `--volume` or `--snapshot` or a combination of both flags is not used.**
 
-15. Get BlockDevices by NodeID
+16. Get BlockDevices by NodeID
 ```
 ❯ kubectl mayastor get block-devices kworker1 --all
  DEVNAME          DEVTYPE    SIZE       AVAILABLE  MODEL                       DEVPATH                                                         FSTYPE  FSUUID  MOUNTPOINT  PARTTYPE                              MAJOR            MINOR                                     DEVLINKS
@@ -250,7 +257,7 @@ b5de71a6-055d-433a-a1c5-2b39ade05d86  0dafa450-7a19-4e21-a919-89c6f9bd2a97  Comp
 ```
 **NOTE: The above command lists usable blockdevices if `--all` flag is not used, but currently since there isn't a way to identify whether the `disk` has a blobstore pool, `disks` not used by `pools` created by `control-plane` are shown as usable if they lack any filesystem uuid.**
 
-16. Snapshot topology for a specific volume
+17. Snapshot topology for a specific volume
 ```
 ❯ kubectl mayastor get volume-snapshot-topology --volume ec4e66fd-3b33-4439-b504-d49aba53da26
  SNAPSHOT-ID                           ID                                    POOL    SNAPSHOT_STATUS  SIZE      ALLOCATED_SIZE  SOURCE

--- a/k8s/supportability/src/collect/resources/pool.rs
+++ b/k8s/supportability/src/collect/resources/pool.rs
@@ -134,8 +134,8 @@ impl PoolClientWrapper {
 
     // TODO: Add pagination support when REST service supports it
     async fn list_pools(&self) -> Result<Vec<Pool>, ResourceError> {
-        let pools = self.rest_client.pools_api().get_pools().await?.into_body();
-        Ok(pools)
+        let pools = self.rest_client.pools_api().get_pools(None).await?;
+        Ok(pools.into_body())
     }
 
     async fn get_pool(&self, id: String) -> Result<Pool, ResourceError> {


### PR DESCRIPTION
```
[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get pools --volume bdc2941c-a79f-4134-b1d5-7e5c911a1b1d
 ID              DISKS                                                     MANAGED  NODE           STATUS  CAPACITY  ALLOCATED  AVAILABLE  COMMITTED
 pool-on-node-1  aio:///dev/sdb?uuid=0a65bbd0-32a5-4f5c-a3dd-c59f0f9da8f4  true     node-1-184487  Online  10GiB     1GiB       9GiB       1GiB
 ```