### PR TITLE
ci: add krew-release-bot for automated krew index updates

### DIFF
--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -19,3 +19,5 @@ jobs:
           ./scripts/github/release-artifacts.sh --tag "${{ github.event.release.tag_name }}" --repo-org "${{ github.repository_owner }}" --upload "$repos" upload
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_CI_GITHUB }}
+      - name: Update krew index
+        uses: rajatjindal/krew-release-bot@v0.0.46

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # NOTE: Update the .krew.yaml file (if required) when making changes here.
           - os: ubuntu-latest
             target: linux-musl
             arch: x86_64
@@ -63,6 +64,7 @@ jobs:
           nix-build -A utils.release.${{ matrix.arch }}.${{ matrix.target }}.kubectl-plugin --arg incremental false ${{ matrix.system }}
       - name: Archive executable
         run: |
+          # NOTE: Update the .krew.yaml file (if required) when making changes here.
           tar -czvf kubectl-mayastor-${{ matrix.arch }}-${{ matrix.target }}.tar.gz LICENSE -C result/bin kubectl-mayastor${{ matrix.suffix }}
       - uses: actions/upload-artifact@v4
         with:

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,41 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: mayastor
+spec:
+  version: {{ .TagName }}
+  homepage: https://openebs.io/docs/
+  shortDescription: Provides commands for OpenEBS Mayastor.
+  description: |
+    This plugin allows you to manage Mayastor volumes and upgrades.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/openebs/mayastor-extensions/releases/download/{{ .TagName }}/kubectl-mayastor-x86_64-apple-darwin.tar.gz" .TagName }}
+    bin: kubectl-mayastor
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/openebs/mayastor-extensions/releases/download/{{ .TagName }}/kubectl-mayastor-aarch64-apple-darwin.tar.gz" .TagName }}
+    bin: kubectl-mayastor
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/openebs/mayastor-extensions/releases/download/{{ .TagName }}/kubectl-mayastor-x86_64-linux-musl.tar.gz" .TagName }}
+    bin: kubectl-mayastor
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/openebs/mayastor-extensions/releases/download/{{ .TagName }}/kubectl-mayastor-aarch64-linux-musl.tar.gz" .TagName }}
+    bin: kubectl-mayastor
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/openebs/mayastor-extensions/releases/download/{{ .TagName }}/kubectl-mayastor-x86_64-windows-gnu.tar.gz" .TagName }}
+    bin: kubectl-mayastor.exe


### PR DESCRIPTION
Adds rajatjindal/krew-release-bot to the release-binaries GitHub Actions.


Ref:
- https://krew.sigs.k8s.io/docs/developer-guide/release/automating-updates/
- https://github.com/rajatjindal/krew-release-bot/blob/main/README.md