### PR TITLE
feat(scripts/helm/install): make installation idempotent

### DIFF
--- a/scripts/helm/install.sh
+++ b/scripts/helm/install.sh
@@ -65,8 +65,9 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+DEP_UPDATE_ARG=
 if [ -n "$DEP_UPDATE" ]; then
-  helm dependency update "$CHART_DIR"
+  DEP_UPDATE_ARG="--dependency-update"
 fi
 
 if [ -n "$WAIT" ]; then
@@ -80,7 +81,7 @@ helm install mayastor "$CHART_DIR" -n mayastor --create-namespace \
      --set="etcd.livenessProbe.initialDelaySeconds=5,etcd.readinessProbe.initialDelaySeconds=5,etcd.replicaCount=1" \
      --set="obs.callhome.enabled=true,obs.callhome.sendReport=false,localpv-provisioner.analytics.enabled=false" \
      --set="eventing.enabled=false" \
-     $DRY_RUN $WAIT_ARG
+     $DRY_RUN $WAIT_ARG $DEP_UPDATE_ARG
 set +x
 
 kubectl get pods -n mayastor -o wide

--- a/scripts/helm/install.sh
+++ b/scripts/helm/install.sh
@@ -9,6 +9,10 @@ CHART=
 SCRIPT_DIR="$(dirname "$0")"
 CHART_DIR="$SCRIPT_DIR"/../../chart
 DEP_UPDATE=
+RELEASE_NAME="mayastor"
+K8S_NAMESPACE="mayastor"
+FAIL_IF_INSTALLED=
+
 help() {
   cat <<EOF
 Usage: $(basename "$0") [COMMAND] [OPTIONS]
@@ -19,6 +23,7 @@ Options:
   --wait                                Wait for helm to complete install.
   --dry-run                             Install helm with --dry-run.
   --dep-update                          Run helm dependency update.
+  --fail-if-installed                   Fail with a status code 1 if the helm release '$RELEASE_NAME' already exists in the $K8S_NAMESPACE namespace.
 
 Examples:
   $(basename "$0")
@@ -59,6 +64,9 @@ while [ "$#" -gt 0 ]; do
     --dep-update)
       DEP_UPDATE="y"
       shift;;
+    --fail-if-installed)
+      FAIL_IF_INSTALLED="y"
+      shift;;
     *)
       die "Unknown argument $1!"
       shift;;
@@ -74,14 +82,21 @@ if [ -n "$WAIT" ]; then
   WAIT_ARG=" --wait --timeout $TIMEOUT"
 fi
 
-echo "Installing Mayastor Chart"
-
-set -x
-helm install mayastor "$CHART_DIR" -n mayastor --create-namespace \
-     --set="etcd.livenessProbe.initialDelaySeconds=5,etcd.readinessProbe.initialDelaySeconds=5,etcd.replicaCount=1" \
-     --set="obs.callhome.enabled=true,obs.callhome.sendReport=false,localpv-provisioner.analytics.enabled=false" \
-     --set="eventing.enabled=false" \
-     $DRY_RUN $WAIT_ARG $DEP_UPDATE_ARG
-set +x
+if [ "$(helm ls -n openebs -o json | jq --arg release_name "$RELEASE_NAME" 'any(.[]; .name == $release_name)')" = "true" ]; then
+  already_exists_log= "Helm release $RELEASE_NAME already exists in namespace $K8S_NAMESPACE"
+  if [ -n "$FAIL_IF_INSTALLED" ]; then
+    die "ERROR: $already_exists_log" 1
+  fi
+  echo "$already_exists_log"
+else
+  echo "Installing Mayastor Chart"
+  set -x
+  helm install "$RELEASE_NAME" "$CHART_DIR" -n "$K8S_NAMESPACE" --create-namespace \
+       --set="etcd.livenessProbe.initialDelaySeconds=5,etcd.readinessProbe.initialDelaySeconds=5,etcd.replicaCount=1" \
+       --set="obs.callhome.enabled=true,obs.callhome.sendReport=false,localpv-provisioner.analytics.enabled=false" \
+       --set="eventing.enabled=false" \
+       $DRY_RUN $WAIT_ARG $DEP_UPDATE_ARG
+  set +x
+fi
 
 kubectl get pods -n mayastor -o wide


### PR DESCRIPTION
The helm/install.sh script should succeed if the release already exists.
Adds a flag to choose failure if that's a failure scenario for the user.

This may be used when adding tests after the nixOsTest for helm install