### PR TITLE
fix: build kubectl-plugin binary

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,7 +13,7 @@ fi
 
 IMAGES="metrics.exporter.io-engine obs.callhome stats.aggregator upgrade.job"
 HELM_DEPS_IMAGES="upgrade.job"
-DEFAULT_BINARIES="kubectl-plugin"
+BUILD_BINARIES="kubectl-plugin"
 PROJECT="extensions"
 . "$SOURCE_REL"
 


### PR DESCRIPTION
Wrong env variable was used to set the plugin.