### PR TITLE
feat(topology): add/remove label to pool

### DIFF
--- a/k8s/plugin/README.md
+++ b/k8s/plugin/README.md
@@ -107,14 +107,26 @@ Options:
  pool-1-kworker1  aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  true     kworker1  Online  500GiB    100GiB     400GiB
  ```
 
-7. Select pools based on labels. Filer labels must be provided in `key1=value1,key2=value2` format.
+7. Pool Labelling
 ```
-❯ kubectl mayastor get pools --selector  type=hhd
- ID               DISKS                                                     MANAGED  NODE      STATUS  CAPACITY  ALLOCATED  AVAILABLE
- pool-1-kworker3  aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  true     kworker3  Online  500GiB    100GiB     400GiB
+❯ kubectl mayastor label pool pool-1-kworker1 zone-us=east-1
+Pool pool pool-1-kworker1 labelled successfully. Current labels: {"openebs.io/created-by": "operator-diskpool", "zone-us": "east-1"}
  ```
 
-8. Get Nodes
+8. Select pools based on labels. Filer labels must be provided in `zone-us=east-1` format.
+```
+❯ kubectl mayastor get pools --selector zone-us=east-1
+ ID               DISKS                                                     MANAGED  NODE      STATUS  CAPACITY  ALLOCATED  AVAILABLE
+pool-1-kworker1   aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  true     kworker3  Online  500GiB    100GiB     400GiB
+ ```
+
+9. Pool Unlabelling
+```
+❯ kubectl mayastor label pool pool-1-kworker1 zone-us-
+Pool pool-1-kworker1 labelled successfully. Current labels: {"openebs.io/created-by": "operator-diskpool"}
+ ```
+
+10. Get Nodes
 ```
 ❯ kubectl mayastor get nodes
  ID           GRPC ENDPOINT   STATUS                     VERSION
@@ -122,14 +134,14 @@ Options:
  io-engine-3  10.1.0.7:10124  Online, Cordoned, Drained  v2.7.0
  io-engine-2  10.1.0.6:10124  Online                     v2.7.0
 ```
-9. Get Node by ID
+11. Get Node by ID
 ```
 ❯ kubectl mayastor get node io-engine-1
  ID           GRPC ENDPOINT   STATUS            VERSION
  io-engine-1  10.1.0.5:10124  Online, Cordoned  v2.7.0
 ```
 
-10. Get Volume(s)/Pool(s)/Node(s) to a specific Output Format
+12. Get Volume(s)/Pool(s)/Node(s) to a specific Output Format
 ```
 ❯ kubectl mayastor -ojson get volumes
 [{"spec":{"num_replicas":2,"size":67108864,"status":"Created","target":{"node":"ksnode-2","protocol":"nvmf"},"uuid":"5703e66a-e5e5-4c84-9dbe-e5a9a5c805db","topology":{"explicit":{"allowed_nodes":["ksnode-1","ksnode-3","ksnode-2"],"preferred_nodes":["ksnode-2","ksnode-3","ksnode-1"]}},"policy":{"self_heal":true}},"state":{"target":{"children":[{"state":"Online","uri":"bdev:///ac02cf9e-8f25-45f0-ab51-d2e80bd462f1?uuid=ac02cf9e-8f25-45f0-ab51-d2e80bd462f1"},{"state":"Online","uri":"nvmf://192.168.122.6:8420/nqn.2019-05.io.openebs:7b0519cb-8864-4017-85b6-edd45f6172d8?uuid=7b0519cb-8864-4017-85b6-edd45f6172d8"}],"deviceUri":"nvmf://192.168.122.234:8420/nqn.2019-05.io.openebs:nexus-140a1eb1-62b5-43c1-acef-9cc9ebb29425","node":"ksnode-2","rebuilds":0,"protocol":"nvmf","size":67108864,"state":"Online","uuid":"140a1eb1-62b5-43c1-acef-9cc9ebb29425"},"size":67108864,"status":"Online","uuid":"5703e66a-e5e5-4c84-9dbe-e5a9a5c805db"}}]
@@ -191,7 +203,7 @@ Options:
     used: 3258974208
     committed: 3258974208
 ```
-11. Replica topology for a specific volume
+13. Replica topology for a specific volume
 ```
 ❯ kubectl mayastor get volume-replica-topology ec4e66fd-3b33-4439-b504-d49aba53da26
  ID                                    NODE      POOL             STATUS  CAPACITY  ALLOCATED SNAPSHOTS  CHILD-STATUS  REASON  REBUILD
@@ -199,7 +211,7 @@ Options:
  d3856829-22b3-414d-a01b-4b6467db14fb  kworker2  pool-1-kworker2  Online  384MiB    8MiB      64MiB      Online        <none>  <none>
 ```
 
-12. Replica topology for all volumes
+14. Replica topology for all volumes
 ```
 ❯ kubectl mayastor get volume-replica-topologies
 VOLUME-ID                              ID                                    NODE      POOL             STATUS  CAPACITY  ALLOCATED SNAPSHOTS CHILD-STATUS  REASON      REBUILD
@@ -211,7 +223,7 @@ VOLUME-ID                              ID                                    NOD
  └─                                    39431c11-0eea-48e7-970f-a2359ebbb9d1  kworker3  pool-1-kworker3  Online  60MiB     60MiB     0MiB      Online        <none>      <none>
 ```
 
-13. Volume Snapshots by volumeID
+15. Volume Snapshots by volumeID
 ```
 ❯ kubectl mayastor get volume-snapshots --volume ec4e66fd-3b33-4439-b504-d49aba53da26
  ID                                    TIMESTAMP             SOURCE-SIZE  ALLOCATED-SIZE  TOTAL-ALLOCATED-SIZE  SOURCE-VOL                            RESTORES
@@ -219,7 +231,7 @@ VOLUME-ID                              ID                                    NOD
 
 ```
 
-14. Get Volume Snapshots
+16. Get Volume Snapshots
 ```
 ❯ kubectl mayastor get volume-snapshots
  ID                                    TIMESTAMP             SOURCE-SIZE  ALLOCATED-SIZE  TOTAL-ALLOCATED-SIZE  SOURCE-VOL                            RESTORES
@@ -228,7 +240,7 @@ VOLUME-ID                              ID                                    NOD
 
 ```
 
-15. Volume Rebuild History by volumeID
+17. Volume Rebuild History by volumeID
 ```
 ❯ kubectl mayastor get rebuild-history e898106d-e735-4edf-aba2-932d42c3c58d
 DST                                   SRC                                   STATE      TOTAL  RECOVERED  TRANSFERRED  IS-PARTIAL  START-TIME            END-TIME
@@ -242,7 +254,7 @@ b5de71a6-055d-433a-a1c5-2b39ade05d86  0dafa450-7a19-4e21-a919-89c6f9bd2a97  Comp
 
 **NOTE: The above command lists volume snapshots for all volumes if `--volume` or `--snapshot` or a combination of both flags is not used.**
 
-16. Get BlockDevices by NodeID
+18. Get BlockDevices by NodeID
 ```
 ❯ kubectl mayastor get block-devices kworker1 --all
  DEVNAME          DEVTYPE    SIZE       AVAILABLE  MODEL                       DEVPATH                                                         FSTYPE  FSUUID  MOUNTPOINT  PARTTYPE                              MAJOR            MINOR                                     DEVLINKS
@@ -257,7 +269,7 @@ b5de71a6-055d-433a-a1c5-2b39ade05d86  0dafa450-7a19-4e21-a919-89c6f9bd2a97  Comp
 ```
 **NOTE: The above command lists usable blockdevices if `--all` flag is not used, but currently since there isn't a way to identify whether the `disk` has a blobstore pool, `disks` not used by `pools` created by `control-plane` are shown as usable if they lack any filesystem uuid.**
 
-17. Snapshot topology for a specific volume
+19. Snapshot topology for a specific volume
 ```
 ❯ kubectl mayastor get volume-snapshot-topology --volume ec4e66fd-3b33-4439-b504-d49aba53da26
  SNAPSHOT-ID                           ID                                    POOL    SNAPSHOT_STATUS  SIZE      ALLOCATED_SIZE  SOURCE


### PR DESCRIPTION
```
$ ./target/debug/kubectl-mayastor label pool pool-on-node-0 zone-us=east-1  -n openebs
Pool pool-on-node-0 labelled successfully. Current labels: {"zone-us": "east-1", "openebs.io/created-by": "operator-diskpool"}

 ./target/debug/kubectl-mayastor get  pools --selector zone-us=east-1  -n openebs
 ID              DISKS                                                     MANAGED  NODE           STATUS  CAPACITY  ALLOCATED  AVAILABLE  COMMITTED
 pool-on-node-0  aio:///dev/sdb?uuid=f58ee524-8e67-4c0d-9e43-1d2c7b10d76c  true     node-0-222640  Online  10GiB     64MiB      9.9GiB     1GiB

 ./target/debug/kubectl-mayastor label pool pool-on-node-0 zone-us-  -n openebs
Pool pool-on-node-0 labelled successfully. Current labels: {"openebs.io/created-by": "operator-diskpool"}
