### PR TITLE
fix(chart): allow scaling etcd via replicaCount and Helm upgrade

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -516,7 +516,6 @@ etcd:
       pullSecrets: []
   # extra debug information on logs
   debug: false
-  initialClusterState: "new"
 
   # -- Pod anti-affinity preset
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity


### PR DESCRIPTION
## Description

The [etcd chart dynamically sets this value based on whether Helm is installing or upgrading](https://github.com/bitnami/charts/blob/etcd/8.6.0/bitnami/etcd/templates/statefulset.yaml#L195). We shouldn't pin it to `"new"`

## Motivation and Context
See https://github.com/openebs/mayastor/issues/1732 and fixes https://github.com/openebs/mayastor/issues/1659

It's supposed to be possible to scale etcd via the replica count with Helm.

## How Has This Been Tested?
Tested via setting both `initialClusterState` to `"existing"` and changing `replicaCount`.

We then see on `etcd-1` something like:

```
etcd 15:04:14.85
etcd 15:04:14.85 Welcome to the Bitnami etcd container
etcd 15:04:14.85 Subscribe to project updates by watching https://github.com/bitnami/containers
etcd 15:04:14.85 Submit issues and feature requests at https://github.com/bitnami/containers/issues
etcd 15:04:14.85
etcd 15:04:14.85 INFO  ==> ** Starting etcd setup **
etcd 15:04:14.86 INFO  ==> Validating settings in ETCD_* env vars..
etcd 15:04:14.86 WARN  ==> You set the environment variable ALLOW_NONE_AUTHENTICATION=yes. For safety reasons, do not use this flag in a production environment.
etcd 15:04:14.87 INFO  ==> Initializing etcd
etcd 15:04:14.87 INFO  ==> Generating etcd config file using env variables
etcd 15:04:14.88 INFO  ==> There is no data from previous deployments
etcd 15:04:14.88 INFO  ==> Adding new member to existing cluster
etcd 15:04:14.98 INFO  ==> Loading env vars of existing cluster
etcd 15:04:14.99 INFO  ==> Obtaining cluster member ID
etcd 15:04:14.99 INFO  ==> Starting etcd in background
etcd 15:04:28.10 INFO  ==> Stored member ID: 2c17af324709f873
etcd 15:04:28.10 INFO  ==> Stopping etcd
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.