### PR TITLE
feat(topology): add show-labels to pools

### DIFF
--- a/k8s/plugin/README.md
+++ b/k8s/plugin/README.md
@@ -113,20 +113,31 @@ Options:
 Pool pool pool-1-kworker1 labelled successfully. Current labels: {"openebs.io/created-by": "operator-diskpool", "zone-us": "east-1"}
  ```
 
-8. Select pools based on labels. Filer labels must be provided in `zone-us=east-1` format.
+8. Show pool labels.
+```
+❯ kubectl mayastor get pools --show-labels
+ ID               DISKS                                                     MANAGED  NODE      STATUS  CAPACITY  ALLOCATED  AVAILABLE  LABELS
+pool-1-kworker1   aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  true     kworker3  Online  500GiB    100GiB     400GiB  zone-us=east-1
+
+kubectl mayastor get pool pool-1-kworker1 --show-labels
+ ID               DISKS                                                     MANAGED  NODE      STATUS  CAPACITY  ALLOCATED  AVAILABLE  LABELS
+pool-1-kworker1   aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  true     kworker3  Online  500GiB    100GiB     400GiB  zone-us=east-1
+ ```
+
+9. Select pools based on labels. Filer labels must be provided in `zone-us=east-1` format.
 ```
 ❯ kubectl mayastor get pools --selector zone-us=east-1
  ID               DISKS                                                     MANAGED  NODE      STATUS  CAPACITY  ALLOCATED  AVAILABLE
 pool-1-kworker1   aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  true     kworker3  Online  500GiB    100GiB     400GiB
  ```
 
-9. Pool Unlabelling
+10. Pool Unlabelling
 ```
 ❯ kubectl mayastor label pool pool-1-kworker1 zone-us-
 Pool pool-1-kworker1 labelled successfully. Current labels: {"openebs.io/created-by": "operator-diskpool"}
  ```
 
-10. Get Nodes
+11. Get Nodes
 ```
 ❯ kubectl mayastor get nodes
  ID           GRPC ENDPOINT   STATUS                     VERSION
@@ -134,14 +145,14 @@ Pool pool-1-kworker1 labelled successfully. Current labels: {"openebs.io/created
  io-engine-3  10.1.0.7:10124  Online, Cordoned, Drained  v2.7.0
  io-engine-2  10.1.0.6:10124  Online                     v2.7.0
 ```
-11. Get Node by ID
+12. Get Node by ID
 ```
 ❯ kubectl mayastor get node io-engine-1
  ID           GRPC ENDPOINT   STATUS            VERSION
  io-engine-1  10.1.0.5:10124  Online, Cordoned  v2.7.0
 ```
 
-12. Get Volume(s)/Pool(s)/Node(s) to a specific Output Format
+13. Get Volume(s)/Pool(s)/Node(s) to a specific Output Format
 ```
 ❯ kubectl mayastor -ojson get volumes
 [{"spec":{"num_replicas":2,"size":67108864,"status":"Created","target":{"node":"ksnode-2","protocol":"nvmf"},"uuid":"5703e66a-e5e5-4c84-9dbe-e5a9a5c805db","topology":{"explicit":{"allowed_nodes":["ksnode-1","ksnode-3","ksnode-2"],"preferred_nodes":["ksnode-2","ksnode-3","ksnode-1"]}},"policy":{"self_heal":true}},"state":{"target":{"children":[{"state":"Online","uri":"bdev:///ac02cf9e-8f25-45f0-ab51-d2e80bd462f1?uuid=ac02cf9e-8f25-45f0-ab51-d2e80bd462f1"},{"state":"Online","uri":"nvmf://192.168.122.6:8420/nqn.2019-05.io.openebs:7b0519cb-8864-4017-85b6-edd45f6172d8?uuid=7b0519cb-8864-4017-85b6-edd45f6172d8"}],"deviceUri":"nvmf://192.168.122.234:8420/nqn.2019-05.io.openebs:nexus-140a1eb1-62b5-43c1-acef-9cc9ebb29425","node":"ksnode-2","rebuilds":0,"protocol":"nvmf","size":67108864,"state":"Online","uuid":"140a1eb1-62b5-43c1-acef-9cc9ebb29425"},"size":67108864,"status":"Online","uuid":"5703e66a-e5e5-4c84-9dbe-e5a9a5c805db"}}]
@@ -203,7 +214,7 @@ Pool pool-1-kworker1 labelled successfully. Current labels: {"openebs.io/created
     used: 3258974208
     committed: 3258974208
 ```
-13. Replica topology for a specific volume
+14. Replica topology for a specific volume
 ```
 ❯ kubectl mayastor get volume-replica-topology ec4e66fd-3b33-4439-b504-d49aba53da26
  ID                                    NODE      POOL             STATUS  CAPACITY  ALLOCATED SNAPSHOTS  CHILD-STATUS  REASON  REBUILD
@@ -211,7 +222,7 @@ Pool pool-1-kworker1 labelled successfully. Current labels: {"openebs.io/created
  d3856829-22b3-414d-a01b-4b6467db14fb  kworker2  pool-1-kworker2  Online  384MiB    8MiB      64MiB      Online        <none>  <none>
 ```
 
-14. Replica topology for all volumes
+15. Replica topology for all volumes
 ```
 ❯ kubectl mayastor get volume-replica-topologies
 VOLUME-ID                              ID                                    NODE      POOL             STATUS  CAPACITY  ALLOCATED SNAPSHOTS CHILD-STATUS  REASON      REBUILD
@@ -223,7 +234,7 @@ VOLUME-ID                              ID                                    NOD
  └─                                    39431c11-0eea-48e7-970f-a2359ebbb9d1  kworker3  pool-1-kworker3  Online  60MiB     60MiB     0MiB      Online        <none>      <none>
 ```
 
-15. Volume Snapshots by volumeID
+16. Volume Snapshots by volumeID
 ```
 ❯ kubectl mayastor get volume-snapshots --volume ec4e66fd-3b33-4439-b504-d49aba53da26
  ID                                    TIMESTAMP             SOURCE-SIZE  ALLOCATED-SIZE  TOTAL-ALLOCATED-SIZE  SOURCE-VOL                            RESTORES
@@ -231,7 +242,7 @@ VOLUME-ID                              ID                                    NOD
 
 ```
 
-16. Get Volume Snapshots
+17. Get Volume Snapshots
 ```
 ❯ kubectl mayastor get volume-snapshots
  ID                                    TIMESTAMP             SOURCE-SIZE  ALLOCATED-SIZE  TOTAL-ALLOCATED-SIZE  SOURCE-VOL                            RESTORES
@@ -240,7 +251,7 @@ VOLUME-ID                              ID                                    NOD
 
 ```
 
-17. Volume Rebuild History by volumeID
+18. Volume Rebuild History by volumeID
 ```
 ❯ kubectl mayastor get rebuild-history e898106d-e735-4edf-aba2-932d42c3c58d
 DST                                   SRC                                   STATE      TOTAL  RECOVERED  TRANSFERRED  IS-PARTIAL  START-TIME            END-TIME
@@ -254,7 +265,7 @@ b5de71a6-055d-433a-a1c5-2b39ade05d86  0dafa450-7a19-4e21-a919-89c6f9bd2a97  Comp
 
 **NOTE: The above command lists volume snapshots for all volumes if `--volume` or `--snapshot` or a combination of both flags is not used.**
 
-18. Get BlockDevices by NodeID
+19. Get BlockDevices by NodeID
 ```
 ❯ kubectl mayastor get block-devices kworker1 --all
  DEVNAME          DEVTYPE    SIZE       AVAILABLE  MODEL                       DEVPATH                                                         FSTYPE  FSUUID  MOUNTPOINT  PARTTYPE                              MAJOR            MINOR                                     DEVLINKS
@@ -269,7 +280,7 @@ b5de71a6-055d-433a-a1c5-2b39ade05d86  0dafa450-7a19-4e21-a919-89c6f9bd2a97  Comp
 ```
 **NOTE: The above command lists usable blockdevices if `--all` flag is not used, but currently since there isn't a way to identify whether the `disk` has a blobstore pool, `disks` not used by `pools` created by `control-plane` are shown as usable if they lack any filesystem uuid.**
 
-19. Snapshot topology for a specific volume
+20. Snapshot topology for a specific volume
 ```
 ❯ kubectl mayastor get volume-snapshot-topology --volume ec4e66fd-3b33-4439-b504-d49aba53da26
  SNAPSHOT-ID                           ID                                    POOL    SNAPSHOT_STATUS  SIZE      ALLOCATED_SIZE  SOURCE


### PR DESCRIPTION
Get pool 
```
[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get pool pool-on-node-1 -n openebs --show-labels
 ID              DISKS                                                     MANAGED  NODE           STATUS  CAPACITY  ALLOCATED  AVAILABLE  COMMITTED  LABELS
 pool-on-node-1  aio:///dev/sdb?uuid=b324aa79-c8b3-4859-a6e8-1a51fbc5d944  true     node-1-237668  Online  10GiB     0 B        10GiB      0 B        topology-key=topology-value
```
List pools 
```
[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get pools  -n openebs --show-labels
 ID              DISKS                                                     MANAGED  NODE           STATUS  CAPACITY  ALLOCATED  AVAILABLE  COMMITTED  LABELS
 pool-on-node-2  aio:///dev/sdb?uuid=8045fe61-ae51-429b-9c73-4f8f60c42d44  true     node-2-237668  Online  10GiB     0 B        10GiB      0 B
 pool-on-node-0  aio:///dev/sdb?uuid=4b12de79-fa6c-4bfd-9ed0-4f5f57cfeb4c  true     node-0-237668  Online  10GiB     0 B        10GiB      0 B        zone=us-east-1
 pool-on-node-1  aio:///dev/sdb?uuid=b324aa79-c8b3-4859-a6e8-1a51fbc5d944  true     node-1-237668  Online  10GiB     0 B        10GiB      0 B        topology-key=topology-value
 ```
List Pools with node filter
```
[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get pools  -n openebs --show-labels --node  node-2-237668
 ID              DISKS                                                     MANAGED  NODE           STATUS  CAPACITY  ALLOCATED  AVAILABLE  COMMITTED  LABELS
 pool-on-node-2  aio:///dev/sdb?uuid=8045fe61-ae51-429b-9c73-4f8f60c42d44  true     node-2-237668  Online  10GiB     0 B        10GiB      0 B

[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get pools  -n openebs --show-labels --node  node-1-237668
 ID              DISKS                                                     MANAGED  NODE           STATUS  CAPACITY  ALLOCATED  AVAILABLE  COMMITTED  LABELS
 pool-on-node-1  aio:///dev/sdb?uuid=b324aa79-c8b3-4859-a6e8-1a51fbc5d944  true     node-1-237668  Online  10GiB     0 B        10GiB      0 B        topology-key=topology-value

[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get pools  -n openebs --show-labels --node  node-0-237668
 ID              DISKS                                                     MANAGED  NODE           STATUS  CAPACITY  ALLOCATED  AVAILABLE  COMMITTED  LABELS
 pool-on-node-0  aio:///dev/sdb?uuid=4b12de79-fa6c-4bfd-9ed0-4f5f57cfeb4c  true     node-0-237668  Online  10GiB     0 B        10GiB      0 B        zone=us-east-1
```
