### PR TITLE
feat(chart): setting initialclusterState as null

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -516,7 +516,7 @@ etcd:
       pullSecrets: []
   # extra debug information on logs
   debug: false
-  initialClusterState: "new"
+  initialClusterState: ""
 
   # -- Pod anti-affinity preset
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
setting initialclusterState as null

## Description
If this values is not set, the default values below are set: -
 'new': when installing the chart ('helm install ...')
 'existing': when upgrading the chart ('helm upgrade ...')



## How Has This Been Tested?
Tested on local cluster. 

root@ip-172-31-2-31:~/mayastor-extensions/chart# helm list -n openebs
NAME    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART           APP VERSION
openebs openebs         1               2024-09-10 10:28:40.20978976 +0000 UTC  deployed        mayastor-0.0.0  0.0.0
root@ip-172-31-2-31:~/mayastor-extensions/chart# helm show values . -n openebs | grep initialClusterState
  initialClusterState: ""
root@ip-172-31-2-31:~/mayastor-extensions/chart#


root@ip-172-31-2-31:~/mayastor-extensions/chart# helm upgrade --install openebs -n openebs  . --set mayastor.etcd.replicaCount="4"
Release "openebs" has been upgraded. Happy Helming!
NAME: openebs
LAST DEPLOYED: Tue Sep 10 10:32:13 2024
NAMESPACE: openebs
STATUS: deployed
REVISION: 2
NOTES:
OpenEBS Mayastor has been installed. Check its status by running:
$ kubectl get pods -n openebs

For more information or to view the documentation, visit our website at https://openebs.io/docs/.
root@ip-172-31-2-31:~/mayastor-extensions/chart#

root@ip-172-31-2-31:~/mayastor-extensions/chart# helm upgrade --install openebs -n openebs  . --set etcd.replicaCount="4"
Release "openebs" has been upgraded. Happy Helming!
NAME: openebs
LAST DEPLOYED: Tue Sep 10 10:36:20 2024
NAMESPACE: openebs
STATUS: deployed
REVISION: 3
NOTES:
OpenEBS Mayastor has been installed. Check its status by running:
$ kubectl get pods -n openebs

For more information or to view the documentation, visit our website at https://openebs.io/docs/.


- name: ETCD_INITIAL_CLUSTER_TOKEN
          value: etcd-cluster-k8s
        - name: ETCD_INITIAL_CLUSTER_STATE
          value: existing




