### PR TITLE
Bump the version of the allowed umbrella chart for upgrade when a release/x.y branch is created

### DIFF
--- a/.github/workflows/develop-to-release.yml
+++ b/.github/workflows/develop-to-release.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           branch="${{ github.ref_name }}"
           nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --check-chart "$branch" --develop-to-release" ./scripts/helm/shell.nix
+          nix-shell --pure --run "./scripts/upgrade/develop-to-release.sh" ./shell.nix
           nix-shell --pure --run "SKIP_GIT=1 ./scripts/helm/generate-readme.sh" ./scripts/helm/shell.nix
       - name: Check if the submodules are correct
         run: |

--- a/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/common/constants.rs
@@ -27,7 +27,7 @@ pub fn cordon_ana_check() -> String {
 }
 
 /// This is the allowed upgrade to-version/to-version-range for the Umbrella chart.
-pub(crate) const TO_UMBRELLA_SEMVER: &str = "4.0.1";
+pub(crate) const TO_UMBRELLA_SEMVER: &str = "4.1.1"; /* @@@UPGRADE_PREP@@@ */
 
 /// This is the user docs URL for the Umbrella chart.
 pub(crate) const UMBRELLA_CHART_UPGRADE_DOCS_URL: &str = constants::UMBRELLA_CHART_UPGRADE_DOCS_URL;

--- a/scripts/upgrade/develop_to_release.sh
+++ b/scripts/upgrade/develop_to_release.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]:-"$0"}")")"
+ROOT_DIR="$SCRIPT_DIR/../.."
+
+source "$ROOT_DIR/scripts/utils/log.sh"
+
+echo "Updating allowed umbrella-chart version..."
+echo "============================================"
+UPGRADE_CONSTANTS_FILE_PATH="$ROOT_DIR/k8s/upgrade/src/bin/upgrade-job/common/constants.rs"
+test -f "$UPGRADE_CONSTANTS_FILE_PATH" || log_fatal "couldn't find file $UPGRADE_CONSTANTS_FILE_PATH"
+
+# There is templating on the $UPGRADE_CONSTANTS_FILE_PATH file to mark the line where this change needs to happen.
+DEVELOP_UMBRELLA_VERSION=$(awk '/\/\* @@@UPGRADE_PREP@@@ \*\// {
+    match($0, /"([0-9]+\.[0-9]+\.[0-9]+)"/, ver);
+    print ver[1];
+}' "$UPGRADE_CONSTANTS_FILE_PATH")
+echo "Found current allowed umbrella-chart version: '$DEVELOP_UMBRELLA_VERSION'"
+
+# Typically a release branch is cut to make a new minor release.
+# Raise a PR to manually change the allowed umbrella chart version if it's a major/patch release.
+RELEASE_UMBRELLA_VERSION=$(semver bump minor "$DEVELOP_UMBRELLA_VERSION")
+echo "Bumped allowed umbrella-chart version: '$RELEASE_UMBRELLA_VERSION'"
+
+# This requires GNU sed. If you're on Mac, you'd get BSD sed by default. You'd need GNU coreutils to get GNU sed.
+# Check if sed is GNU sed.
+sed --version &> /dev/null || log_fatal "couldn't find GNU 'sed'"
+# Update constants module in upgrade-job.
+sed -i "s/\(\"\)$DEVELOP_UMBRELLA_VERSION\(\";\ \/\*\ @@@UPGRADE_PREP@@@\ \*\/\)/\1$RELEASE_UMBRELLA_VERSION\2/" $UPGRADE_CONSTANTS_FILE_PATH


### PR DESCRIPTION
It is easy to miss this when a release branch is cut. We do not have automated tests for umbrella chart upgrade at the moment. This change should bring this change to notice (if the version is not bumped correctly).