### PR TITLE
Add workflow to update the HelmChart post-release

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -28,6 +28,7 @@ jobs:
             branch="${{ github.ref_name }}"
             nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --check-chart "$branch"" ./scripts/helm/shell.nix
           fi
+          nix-shell --pure --run "SKIP_GIT=1 ./scripts/helm/generate-readme.sh" ./scripts/helm/shell.nix
       - name: Publish Mayastor Helm chart
         uses: stefanprodan/helm-gh-pages@v1.7.0
         if: ${{ github.ref_type == 'tag' }}

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -24,15 +24,66 @@ jobs:
             # Publish the Chart.yaml locally
             # Note this does not commit the Chart.yaml changes this the branch
             nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --app-tag "$tag"" ./scripts/helm/shell.nix
-            echo "PUBLISH_CHART=1" >> $GITHUB_ENV
           else
             branch="${{ github.ref_name }}"
             nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --check-chart "$branch"" ./scripts/helm/shell.nix
           fi
       - name: Publish Mayastor Helm chart
         uses: stefanprodan/helm-gh-pages@v1.7.0
-        if: ${{ env.PUBLISH_CHART }}
+        if: ${{ github.ref_type == 'tag' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           charts_dir: .
 
+  update-chart:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref_type == 'tag' }}
+    needs:
+      - release-chart
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@v22
+      - name: Pre-populate nix-shell
+        run: |
+          export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
+          echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
+          nix-shell --pure --run "echo" ./scripts/helm/shell.nix
+      - name: Publish locally in the workspace
+        run: |
+          tag="${{ github.ref_name }}"
+          nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --released "$tag"" ./scripts/helm/shell.nix
+          nix-shell --pure --run "SKIP_GIT=1 ./scripts/helm/generate-readme.sh" ./scripts/helm/shell.nix
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "chore(ci): update future helm chart versions"
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          title: Bump future helm chart version on the release branch
+          labels: |
+            update-release-branch
+            automated-pr
+          draft: false
+          signoff: true
+          token: ${{ secrets.ORG_CI_GITHUB }}
+      - name: Approve Pull Request by CI Bot
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          gh pr review ${{ steps.cpr.outputs.pull-request-number }} --approve
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Approve Pull Request by CI User
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          gh pr review ${{ steps.cpr.outputs.pull-request-number }} --approve
+        env:
+          GH_TOKEN: ${{ secrets.ORG_CI_GITHUB_2 }}
+      - name: Bors Merge Pull Request
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          gh pr comment ${{ steps.cpr.outputs.pull-request-number }} --body "bors merge"
+        env:
+          GH_TOKEN: ${{ secrets.ORG_CI_GITHUB }}

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -21,6 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
-*.md
+README.md.tmpl
 # Nix Shell
 *.nix

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -16,17 +16,17 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.0
+version: 2.7.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.7.0"
+appVersion: "2.7.2"
 
 dependencies:
   - name: crds
-    version: 2.7.0
+    version: 2.7.2
     condition: crds.enabled
   - name: etcd
     repository: https://charts.bitnami.com/bitnami

--- a/chart/README.md
+++ b/chart/README.md
@@ -2,7 +2,7 @@
 
 Mayastor Helm chart for Kubernetes
 
-![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 2.7.2](https://img.shields.io/badge/Version-2.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
 
 ## Installation Guide
 
@@ -54,7 +54,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | crds | 2.7.0 |
+|  | crds | 2.7.2 |
 | https://charts.bitnami.com/bitnami | etcd | 8.6.0 |
 | https://grafana.github.io/helm-charts | loki-stack | 2.9.11 |
 | https://jaegertracing.github.io/helm-charts | jaeger-operator | 2.50.1 |

--- a/chart/charts/crds/Chart.yaml
+++ b/chart/charts/crds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: crds
-version: 2.7.0
+version: 2.7.2
 description: |
   A Helm chart that collects CustomResourceDefinitions (CRDs) from Mayastor.
 

--- a/chart/doc.yaml
+++ b/chart/doc.yaml
@@ -8,7 +8,7 @@ repository:
   name: mayastor
 chart:
   name: mayastor
-  version: 2.7.0
+  version: 2.7.2
   values: "-- generate from values file --"
   valuesExample: "-- generate from values file --"
 prerequisites:

--- a/nix/pkgs/extensions/cargo-project.nix
+++ b/nix/pkgs/extensions/cargo-project.nix
@@ -65,6 +65,7 @@ let
     "constants"
     "dependencies/control-plane/openapi/Cargo.toml"
     "dependencies/control-plane/openapi/build.rs"
+    "dependencies/control-plane/openapi/src/lib.rs"
     "dependencies/control-plane/control-plane/plugin"
     "dependencies/control-plane/control-plane/rest/openapi-specs"
     "dependencies/control-plane/scripts/rust/generate-openapi-bindings.sh"


### PR DESCRIPTION
    build: update control-plane submodule
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    chore: manually bump chart to v2.7.2
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(helm-chart): package README.md in the chart
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci: bump release chart version
    
    When a tag is pushed on a release branch we update the future
    chart release version by bumping it's patch.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
