### PR TITLE
fix: use heck instead of covert_case for Train-Case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,9 +581,9 @@ dependencies = [
  "chrono",
  "clap",
  "constants",
- "convert_case",
  "events-api",
  "futures",
+ "heck",
  "humantime",
  "jsonpath_lib",
  "k8s-openapi",
@@ -705,7 +705,7 @@ checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 name = "constants"
 version = "0.1.0"
 dependencies = [
- "convert_case",
+ "heck",
  "utils",
 ]
 

--- a/call-home/Cargo.toml
+++ b/call-home/Cargo.toml
@@ -19,7 +19,6 @@ path = "src/bin/stats/main.rs"
 
 [dependencies]
 constants = { path = "../constants" }
-convert_case = "0.4.0"
 openapi = {path = "../dependencies/control-plane/openapi"}
 kube = { version = "0.85.0", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.19.0", features = ["v1_20"] }
@@ -56,3 +55,4 @@ mime = "0.3.17"
 
 # parse prometheus output
 prometheus-parse = "0.2.4"
+heck = "0.4.1"

--- a/call-home/src/common/constants.rs
+++ b/call-home/src/common/constants.rs
@@ -1,4 +1,4 @@
-use convert_case::{Case::Train, Casing};
+use heck::ToTrainCase;
 use std::{
     env,
     path::{Path, PathBuf},
@@ -13,7 +13,7 @@ pub fn product() -> String {
     env::var(CALLHOME_PRODUCT_NAME_ENV)
         .ok()
         .filter(|v| !v.is_empty())
-        .map(|v| v.to_case(Train))
+        .map(|v| v.to_train_case())
         .unwrap_or(::constants::product_train())
 }
 
@@ -153,6 +153,9 @@ mod tests {
     fn test_product() {
         use crate::common::constants::{product, CALLHOME_PRODUCT_NAME_ENV};
         use std::env::{remove_var as unset, set_var as set};
+
+        set(CALLHOME_PRODUCT_NAME_ENV, "ma8");
+        assert_eq!(product(), "Ma8".to_string());
 
         set(CALLHOME_PRODUCT_NAME_ENV, "foo bar");
         assert_eq!(product(), "Foo-Bar".to_string());

--- a/constants/Cargo.toml
+++ b/constants/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 utils = {path = "../dependencies/control-plane/utils/utils-lib" }
-convert_case = "0.4.0"
+heck = "0.4.1"

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -1,10 +1,10 @@
-use convert_case::Casing;
+use heck::ToTrainCase;
 use utils::constants::PRODUCT_DOMAIN_NAME;
 pub use utils::PRODUCT_NAME;
 
 /// Name of the product.
 pub fn product_train() -> String {
-    PRODUCT_NAME.to_case(convert_case::Case::Train)
+    PRODUCT_NAME.to_train_case()
 }
 
 /// Helm release name label's key.


### PR DESCRIPTION
The Train-Case implementation on the covert_case crate seems to convert 'ma8' to 'Ma-8'. This isn't the expected result. Heck seems to get it right, 'Ma8'.