### PR TITLE
feat(metrics-exporter): support IPv6 Pod IPs

### DIFF
--- a/metrics-exporter/src/bin/io_engine/client/grpc_client.rs
+++ b/metrics-exporter/src/bin/io_engine/client/grpc_client.rs
@@ -7,7 +7,7 @@ use crate::client::{
     replica_stat::{ReplicaIoStat, ReplicaIoStats},
 };
 use actix_web::http::Uri;
-use std::time::Duration;
+use std::{net::SocketAddr, time::Duration};
 use tokio::time::sleep;
 use tonic::transport::Channel;
 use tracing::error;
@@ -112,7 +112,7 @@ pub(crate) async fn init_client() -> Result<GrpcClient, ExporterError> {
     let _ = get_node_name()?;
     let endpoint = Uri::builder()
         .scheme("https")
-        .authority(format!("{pod_ip}:10124"))
+        .authority(SocketAddr::new(pod_ip, 10124).to_string())
         .path_and_query("")
         .build()
         .map_err(|error| ExporterError::InvalidURI(error.to_string()))?;

--- a/metrics-exporter/src/bin/io_engine/main.rs
+++ b/metrics-exporter/src/bin/io_engine/main.rs
@@ -6,7 +6,10 @@ use crate::{
 use actix_web::{middleware, HttpServer};
 use clap::Parser;
 use once_cell::sync::OnceCell;
-use std::{env, net::SocketAddr};
+use std::{
+    env,
+    net::{IpAddr, SocketAddr},
+};
 use utils::tracing_telemetry::{FmtLayer, FmtStyle};
 
 /// Cache module for exporter.
@@ -26,8 +29,11 @@ async fn initialize_cache() {
 }
 
 /// Get pod ip from env.
-fn get_pod_ip() -> Result<String, ExporterError> {
-    env::var("MY_POD_IP").map_err(|_| ExporterError::PodIPError("Unable to get pod ip".to_string()))
+fn get_pod_ip() -> Result<IpAddr, ExporterError> {
+    let ip = env::var("MY_POD_IP")
+        .map_err(|_| ExporterError::PodIPError("Unable to get pod ip".to_string()))?;
+    ip.parse::<IpAddr>()
+        .map_err(|_| ExporterError::PodIPError("Invalid pod ip".to_string()))
 }
 
 /// Get node name from env.


### PR DESCRIPTION
## Description

Related to https://github.com/openebs/mayastor/issues/1731. The metrics exporter can't connect to the gRPC client if it's an IPv6 address because there's raw string manipulation that fails in the case of IPv6, no surrounding `[]` are added.

## Motivation and Context
It allows the metrics exporter to connect to IPv6 Pod IPs.


## Regression
No

## How Has This Been Tested?
Hasn't yet.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.