### PR TITLE
test: fix chart.next version on release branches by removing semver bump

### DIFF
--- a/scripts/python/generate-test-tag.sh
+++ b/scripts/python/generate-test-tag.sh
@@ -52,7 +52,7 @@ done
 
 case "$CHART_VERSION" in
 0.0.0)
-  latest_branch=$(git fetch -q && latest_release_branch $GIT_REMOTE $ROOT_DIR)
+  latest_branch=$(git fetch -q && latest_release_branch "$GIT_REMOTE" "$ROOT_DIR")
   latest=${latest_branch#release/}
   if [[ "$latest" =~ ^([0-9]+\.[0-9]+)$ ]]; then
     latest="$latest.0"
@@ -62,7 +62,7 @@ case "$CHART_VERSION" in
   ;;
 *)
   test "$(semver validate $CHART_VERSION)" = "valid"
-  TAG=$(semver bump patch $CHART_VERSION)
+  TAG=$CHART_VERSION
   ;;
 esac
 

--- a/scripts/python/tag-chart.sh
+++ b/scripts/python/tag-chart.sh
@@ -16,7 +16,7 @@ fi
 CHART_VERSION=${1#v}
 IMAGE_TAG="v$CHART_VERSION"
 CHART_DIR="$ROOT_DIR/chart"
-# TODO: tests should copy the chart and work with its own copy of the chart. Shouldn't modify the chart.
+# TODO: tests should work with its own copy of the chart. Shouldn't modify the chart.
 # chart/Chart.yaml
 yq_ibl "
   .version = \"$CHART_VERSION\" |

--- a/scripts/utils/repo.sh
+++ b/scripts/utils/repo.sh
@@ -36,3 +36,33 @@ latest_release_branch() {
 
   echo "${latest_release_branch#*$remote/}"
 }
+
+# Get the latest tag created against a commit of a specific branch
+# Args:
+# 1. Branch name
+# 2. Git remote name
+# 3. Root directory of the repository
+latest_tag_at_branch() {
+  local -r branch=$1
+  local -r remote=${2:-"origin"}
+  local -r root_dir=${3:-"$ROOTDIR"}
+
+  pushd "$root_dir" > /dev/null
+
+  git fetch --quiet --tags "$remote"
+
+  local latest_tag=""
+  local git_tag_exit_code=0
+  local -r git_tag_output=$(git tag --list --merged "$remote"/"$branch" --sort=-creatordate 2> /dev/null) || git_tag_exit_code=$?
+  if [ "$git_tag_exit_code" = 0 ]; then
+    local head_exit_code=0
+    local -r head_output=$(echo $git_tag_output | head -n 1) || head_exit_code=$?
+    if [ "$head_exit_code" = 0 ]; then
+      latest_tag=$head_output
+    fi
+  fi
+
+  popd > /dev/null
+
+  echo "$latest_tag"
+}


### PR DESCRIPTION
The tag generation logic reads the chart/Chart.yaml version and bumps it to the next patch version. This is not required since 2.7.0, as the helm chart is updated automatically after a tag is cut. Removing the semver bump patch.

Also, adds a library function to figure out the latest tag on a branch.

<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.