### PR TITLE
build: build static binaries with latest pkgs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,6 +2144,7 @@ dependencies = [
  "kube 0.94.2",
  "serde_json",
  "shutdown",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tower 0.5.1",
@@ -2162,8 +2163,10 @@ dependencies = [
  "kube 0.94.2",
  "kube-forward",
  "openapi",
+ "thiserror",
  "tonic",
  "tower 0.5.1",
+ "url",
  "utils",
 ]
 
@@ -2231,6 +2234,7 @@ dependencies = [
  "console-logger",
  "constants",
  "humantime",
+ "kube-forward",
  "kube-proxy",
  "openapi",
  "rest-plugin",

--- a/k8s/plugin/Cargo.toml
+++ b/k8s/plugin/Cargo.toml
@@ -25,6 +25,7 @@ console-logger = { path = "../../console-logger" }
 supportability = { path = "../supportability" }
 upgrade = { path = "../upgrade" }
 kube-proxy = { path = "../../dependencies/control-plane/k8s/proxy" }
+kube-forward = { path = "../../dependencies/control-plane/k8s/forward" }
 tokio = { version = "1.41.0" }
 anyhow = "1.0.92"
 clap = { version = "4.5.20", features = ["color", "derive"] }

--- a/k8s/supportability/src/collect/persistent_store/mod.rs
+++ b/k8s/supportability/src/collect/persistent_store/mod.rs
@@ -13,7 +13,7 @@ pub(crate) enum EtcdError {
     K8sResource(K8sResourceError),
     IOError(std::io::Error),
     Custom(String),
-    CreateClient(anyhow::Error),
+    CreateClient(kube_proxy::Error),
 }
 
 impl From<StoreError> for EtcdError {

--- a/k8s/upgrade/src/plugin/error.rs
+++ b/k8s/upgrade/src/plugin/error.rs
@@ -206,7 +206,7 @@ pub enum Error {
 
     /// Openapi configuration error.
     #[snafu(display("openapi configuration Error: {}", source))]
-    OpenapiClientConfiguration { source: anyhow::Error },
+    OpenapiClientConfiguration { source: kube_proxy::Error },
 
     /// Error when opening a file.
     #[snafu(display("Failed to open file {}: {}", filepath.display(), source))]

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -1,6 +1,7 @@
 { pkgs }:
 let
   lib = pkgs.lib;
+  sources = import ../sources.nix;
 in
 rec {
   makeRustTarget = platform: pkgs.rust.toRustTargetSpec platform;
@@ -30,7 +31,7 @@ rec {
     os = platform: builtins.replaceStrings [ "${platform.qemuArch}-" ] [ "" ] platform.system;
     hostPlatform = "${pkgs.rust.toRustTargetSpec pkgs.pkgsStatic.hostPlatform}";
     targetPlatform = "${pkgs.rust.toRustTargetSpec pkgs.pkgsCross."${target}".hostPlatform}";
-    pkgsTarget = if hostPlatform == targetPlatform then pkgs.pkgsStatic else pkgs.pkgsCross."${target}";
+    pkgsTarget = if hostPlatform == targetPlatform then pkgs else pkgs.pkgsCross."${target}";
     pkgsTargetNative = if hostPlatform == targetPlatform then pkgs else if hostOs == targetOs then
       import sources.nixpkgs
         {
@@ -63,14 +64,7 @@ rec {
     addPreBuild = "";
     nativeBuildInputs = with pkgs;
       [ pkg-config protobuf paperclip which git ] ++
-        [ rustPlatformDeps.pkgsTarget.stdenv.cc ] ++
-        lib.optional (rustPlatformDeps.pkgsTarget.hostPlatform.isDarwin)
-          [
-            (rustPlatformDeps.pkgsTarget.libiconv.override {
-              enableStatic = true;
-              enableShared = false;
-            })
-          ];
+        [ rustPlatformDeps.pkgsTarget.stdenv.cc ];
     addNativeBuildInputs = [ ];
     buildInputs = if (rustPlatformDeps.pkgsTarget.hostPlatform.isWindows) then with rustPlatformDeps.pkgsTargetNative.windows; [ mingw_w64_pthreads pthreads ] else [ ];
   };

--- a/nix/pkgs/utils/default.nix
+++ b/nix/pkgs/utils/default.nix
@@ -15,19 +15,9 @@ let
   buildKubectlPlugin = { target, release, addBuildOptions ? [ ] }:
     let
       platformDeps = channel.rustPlatformDeps { inherit target sources; };
-      # required for darwin because its pkgsStatic is not static!
-      static_ssl = (platformDeps.pkgsTarget.pkgsStatic.openssl.override {
-        static = true;
-      });
       rustBuildOpts = channel.rustBuilderOpts { rustPlatformDeps = platformDeps; } // {
         buildOptions = [ "-p" "kubectl-plugin" ] ++ addBuildOptions;
-        ${if !pkgs.hostPlatform.isDarwin then "addNativeBuildInputs" else null} = [ platformDeps.pkgsTargetNative.pkgsStatic.openssl.dev ];
-        addPreBuild = preBuildOpenApi + ''
-          export OPENSSL_STATIC=1
-        '' + lib.optionalString (pkgs.hostPlatform.isDarwin) ''
-          export OPENSSL_LIB_DIR=${static_ssl.out}/lib
-          export OPENSSL_INCLUDE_DIR=${static_ssl.dev}/include
-        '';
+        addPreBuild = preBuildOpenApi;
       };
       name = "kubectl-plugin";
     in


### PR DESCRIPTION
On nixpkgs bug where windows platform is set incorrectly for static
packages: 281596
This can be worked around by using pkgStatic.pkgsCross rather than
the other way around, or simply by replacing the package.
As it happens, the tls build for windows doesn't need openssl, so
we can remove it entirely and skip this issue altogether.
On darwin, libiconv is failing to build, but also seems to not be
required anymore, and so also removing it!
