### PR TITLE
chore: bump localpv-provisioner dependency version to 4.1.2

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -45,6 +45,6 @@ dependencies:
     repository: https://nats-io.github.io/k8s/helm/charts/
     condition: eventing.enabled
   - name: localpv-provisioner
-    version: 4.1.0
+    version: 4.1.2
     repository: https://openebs.github.io/dynamic-localpv-provisioner
     condition: localpv-provisioner.enabled

--- a/chart/README.md
+++ b/chart/README.md
@@ -59,7 +59,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | https://grafana.github.io/helm-charts | loki-stack | 2.9.11 |
 | https://jaegertracing.github.io/helm-charts | jaeger-operator | 2.50.1 |
 | https://nats-io.github.io/k8s/helm/charts/ | nats | 0.19.14 |
-| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 4.1.0 |
+| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 4.1.2 |
 
 ## Values
 

--- a/k8s/upgrade/src/common/constants.rs
+++ b/k8s/upgrade/src/common/constants.rs
@@ -54,3 +54,6 @@ pub(crate) const TWO_DOT_FIVE: &str = "2.5.0";
 
 /// Version value for the earliest possible 2.6 release.
 pub(crate) const TWO_DOT_SIX: &str = "2.6.0";
+
+/// Version value for 2.7.2 release.
+pub(crate) const TWO_DOT_SEVEN_DOT_TWO: &str = "2.7.2";

--- a/k8s/upgrade/src/helm/values.rs
+++ b/k8s/upgrade/src/helm/values.rs
@@ -2,7 +2,7 @@ use crate::{
     common::{
         constants::{
             KUBE_API_PAGE_SIZE, TWO_DOT_FIVE, TWO_DOT_FOUR, TWO_DOT_ONE, TWO_DOT_O_RC_ONE,
-            TWO_DOT_SIX, TWO_DOT_THREE,
+            TWO_DOT_SEVEN_DOT_TWO, TWO_DOT_SIX, TWO_DOT_THREE,
         },
         error::{
             DeserializePromtailExtraConfig, ListCrds, Result, SemverParse,
@@ -368,6 +368,17 @@ where
         yq.set_literal_value(
             YamlKey::try_from(".jaeger-operator.image.tag")?,
             source_values.jaeger_operator_image_tag(),
+            upgrade_values_file.path(),
+        )?;
+    }
+
+    // Special-case values for 2.7.2.
+    let two_dot_seven_dot_two = Version::parse(TWO_DOT_SEVEN_DOT_TWO).context(SemverParse {
+        version_string: TWO_DOT_SEVEN_DOT_TWO.to_string(),
+    })?;
+    if source_version.ge(&two_dot_o_rc_zero) && source_version.lt(&two_dot_seven_dot_two) {
+        yq.delete_object(
+            YamlKey::try_from(".localpv-provisioner.release")?,
             upgrade_values_file.path(),
         )?;
     }


### PR DESCRIPTION
Ref: https://github.com/openebs/dynamic-localpv-provisioner/pull/215

Note: LocalPV version is 4.1.1 on 2.7.1, and not 4.1.0. Missed the bump on develop during 2.7.1.