### PR TITLE
fix(supportability): skip logs for pods with missing details

### DIFF
--- a/k8s/supportability/src/collect/logs/mod.rs
+++ b/k8s/supportability/src/collect/logs/mod.rs
@@ -14,8 +14,12 @@ use crate::collect::{
     utils::log,
 };
 use async_trait::async_trait;
-use k8s_openapi::api::core::v1::Pod;
-use std::{collections::HashSet, iter::Iterator, path::PathBuf};
+use k8s_openapi::api::core::v1::{Node, Pod};
+use std::{
+    collections::{HashMap, HashSet},
+    iter::Iterator,
+    path::PathBuf,
+};
 
 /// Error that can occur while interacting with logs module
 #[derive(Debug)]
@@ -109,6 +113,93 @@ impl LogCollection {
         }))
     }
 
+    async fn pod_logging_resources(
+        &self,
+        pod: Pod,
+        nodes_map: &HashMap<String, Node>,
+    ) -> Result<HashSet<LogResource>, LogError> {
+        let mut logging_resources = HashSet::new();
+        let service_name = pod
+            .metadata
+            .labels
+            .as_ref()
+            .ok_or_else(|| {
+                K8sResourceError::invalid_k8s_resource_value(format!(
+                    "No labels found in pod {:?}",
+                    pod.metadata.name
+                ))
+            })?
+            .get("app")
+            .unwrap_or(&"".to_string())
+            .clone();
+
+        let mut hostname = None;
+        if is_host_name_required(service_name.clone()) {
+            let node_name = pod
+                .spec
+                .clone()
+                .ok_or_else(|| {
+                    K8sResourceError::invalid_k8s_resource_value(format!(
+                        "Pod spec not found in pod {:?} resource",
+                        pod.metadata.name
+                    ))
+                })?
+                .node_name
+                .as_ref()
+                .ok_or_else(|| {
+                    K8sResourceError::invalid_k8s_resource_value(
+                        "Node name not found in running pod resource".to_string(),
+                    )
+                })?
+                .clone();
+            hostname = Some(
+                nodes_map
+                    .get(node_name.as_str())
+                    .ok_or_else(|| {
+                        K8sResourceError::invalid_k8s_resource_value(format!(
+                            "Unable to find node: {} object",
+                            node_name.clone()
+                        ))
+                    })?
+                    .metadata
+                    .labels
+                    .as_ref()
+                    .ok_or_else(|| {
+                        K8sResourceError::invalid_k8s_resource_value(format!(
+                            "No labels found in node {}",
+                            node_name.clone()
+                        ))
+                    })?
+                    .get(KUBERNETES_HOST_LABEL_KEY)
+                    .ok_or_else(|| {
+                        K8sResourceError::invalid_k8s_resource_value(format!(
+                            "Hostname not found for node {}",
+                            node_name.clone()
+                        ))
+                    })?
+                    .clone(),
+            );
+        }
+        // Since pod object fetched from Kube-apiserver there will be always
+        // spec associated to pod
+        let containers = pod
+            .spec
+            .ok_or_else(|| {
+                K8sResourceError::invalid_k8s_resource_value("Pod spec not found".to_string())
+            })?
+            .containers;
+
+        for container in containers {
+            logging_resources.insert(LogResource {
+                container_name: container.name,
+                host_name: hostname.clone(),
+                label_selector: format!("app={}", service_name.clone()),
+                service_type: service_name.clone(),
+            });
+        }
+        Ok(logging_resources)
+    }
+
     async fn get_logging_resources(
         &self,
         pods: Vec<Pod>,
@@ -121,83 +212,12 @@ impl LogCollection {
         let mut logging_resources = HashSet::new();
 
         for pod in pods {
-            let service_name = pod
-                .metadata
-                .labels
-                .as_ref()
-                .ok_or_else(|| {
-                    K8sResourceError::invalid_k8s_resource_value(format!(
-                        "No labels found in pod {:?}",
-                        pod.metadata.name
-                    ))
-                })?
-                .get("app")
-                .unwrap_or(&"".to_string())
-                .clone();
-
-            let mut hostname = None;
-            if is_host_name_required(service_name.clone()) {
-                let node_name = pod
-                    .spec
-                    .clone()
-                    .ok_or_else(|| {
-                        K8sResourceError::invalid_k8s_resource_value(format!(
-                            "Pod spec not found in pod {:?} resource",
-                            pod.metadata.name
-                        ))
-                    })?
-                    .node_name
-                    .as_ref()
-                    .ok_or_else(|| {
-                        K8sResourceError::invalid_k8s_resource_value(
-                            "Node name not found in running pod resource".to_string(),
-                        )
-                    })?
-                    .clone();
-                hostname = Some(
-                    nodes_map
-                        .get(node_name.as_str())
-                        .ok_or_else(|| {
-                            K8sResourceError::invalid_k8s_resource_value(format!(
-                                "Unable to find node: {} object",
-                                node_name.clone()
-                            ))
-                        })?
-                        .metadata
-                        .labels
-                        .as_ref()
-                        .ok_or_else(|| {
-                            K8sResourceError::invalid_k8s_resource_value(format!(
-                                "No labels found in node {}",
-                                node_name.clone()
-                            ))
-                        })?
-                        .get(KUBERNETES_HOST_LABEL_KEY)
-                        .ok_or_else(|| {
-                            K8sResourceError::invalid_k8s_resource_value(format!(
-                                "Hostname not found for node {}",
-                                node_name.clone()
-                            ))
-                        })?
-                        .clone(),
-                );
-            }
-            // Since pod object fetched from Kube-apiserver there will be always
-            // spec associated to pod
-            let containers = pod
-                .spec
-                .ok_or_else(|| {
-                    K8sResourceError::invalid_k8s_resource_value("Pod sepc not found".to_string())
-                })?
-                .containers;
-
-            for container in containers {
-                logging_resources.insert(LogResource {
-                    container_name: container.name,
-                    host_name: hostname.clone(),
-                    label_selector: format!("app={}", service_name.clone()),
-                    service_type: service_name.clone(),
-                });
+            match self.pod_logging_resources(pod.clone(), &nodes_map).await {
+                Ok(resources) => logging_resources.extend(resources),
+                Err(error) => log(format!(
+                    "Skipping the pod {:?} due to error: {error:?}",
+                    pod.metadata.name
+                )),
             }
         }
         Ok(logging_resources)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The supoortability logs errors out if some of the pods are in pending state as the node is not populated for those pods. 

![image](https://github.com/user-attachments/assets/32d2a45f-5c00-45fc-ad2d-410dcea57354)

In this case the etcd is in pending state . the command `kubectl mayastor system dump ` doesnt create the logs folder and error out  stating 
`Error occurred while collecting logs`

In-oder to rectify , the supportability collects logs for pods if its not in pending state . 

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.