### PR TITLE
chore: fix helm-testing versioning in publish-chart-yaml

### DIFF
--- a/scripts/helm/publish-chart-yaml.sh
+++ b/scripts/helm/publish-chart-yaml.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 # On a new appTag, update the Chart.yaml which is used to publish the chart to the appropriate
 # version and appVersion.
 # For this first iteration version and appVersion in the Chart.yaml *MUST* point to the stable
@@ -78,9 +77,9 @@ helm_testing_branch_version() {
 
   local latest_version="${release_branch#*release/}"
   if [[ "$latest_version" =~ ^[0-9]+$ ]]; then
-    latest_version=${latest_version}.0.0
+    latest_version=${latest_version}.$(semver get minor ${CHART_VERSION}).$(semver get patch ${CHART_VERSION})
   elif [[ "$latest_version" =~ ^[0-9]+.[0-9]+$ ]]; then
-    latest_version=${latest_version}.0
+      latest_version=${latest_version}.$(semver get patch ${CHART_VERSION})
   elif [[ "$latest_version" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
     latest_version=${latest_version}
   else


### PR DESCRIPTION
Fix helm testing version generation 

## Description
Replace hard coded patch and minor values of 0,
with values derived from the chart version

That way we get versions derived from chart/Chart.yaml, like 2.7.2-... instead of hard coded values like 2.7.0-... or 2.0.0-....

## Motivation and Context
This change is required to build with version numbers that monotonically increase
This makes is possible to test upgrades with setting override flags.


## Regression
Is this PR fixing a regression?  No

## How Has This Been Tested?
tested by executing the modified script using the command line
```
nix-shell --pure --run './scripts/helm/publish-chart-yaml.sh  --helm-testing helm-testing/release/2.7 --date-time 2024-12-11-10-21-41' ./scripts/helm/shell.nix
```

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.