### PR TITLE
feat(helm chart): add timeout for csi attacher and remove command from csi node

### DIFF
--- a/chart/templates/mayastor/csi/csi-controller-deployment.yaml
+++ b/chart/templates/mayastor/csi/csi-controller-deployment.yaml
@@ -63,6 +63,7 @@ spec:
           image: "{{ .Values.csi.image.registry }}/{{ .Values.csi.image.repo }}/csi-attacher:{{ .Values.csi.image.attacherTag }}"
           args:
             - "--v=2"
+            - "--timeout=36s"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS

--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -104,8 +104,6 @@ spec:
         {{- end }}
         - "--fmt-style={{ include "logFormat" . }}"
         - "--ansi-colors={{ .Values.base.logging.color }}"
-        command:
-        - csi-node
         volumeMounts:
         - name: device
           mountPath: /dev


### PR DESCRIPTION
### Changes

- Adds 36s timeout to csi-attacher
- Removes command from csi-node