### PR TITLE
ci: skip krew release bot workflow for pre-release

### DIFF
--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -20,4 +20,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_CI_GITHUB }}
       - name: Update krew index
-        uses: rajatjindal/krew-release-bot@v0.0.46
+        if: "!github.event.release.prerelease"
+        uses: rajatjindal/krew-release-bot@v0.0.47


### PR DESCRIPTION
The `rajatjindal/krew-release-bot` workflow skips creating its PR for pre-release releases. This fails the workflow step on GitHub Actions. This PR adds a condition to skip the workflow for pre-release release creations.

Also, bumps the workflow to the latest version.