### PR TITLE
fix(upgrade): remove etcd.initialClusterState from helm values

### DIFF
--- a/k8s/upgrade/src/common/constants.rs
+++ b/k8s/upgrade/src/common/constants.rs
@@ -57,3 +57,6 @@ pub(crate) const TWO_DOT_SIX: &str = "2.6.0";
 
 /// Version value for 2.7.2 release.
 pub(crate) const TWO_DOT_SEVEN_DOT_TWO: &str = "2.7.2";
+
+/// Version value for 2.7.3.
+pub(crate) const TWO_DOT_SEVEN_DOT_THREE: &str = "2.7.3";

--- a/k8s/upgrade/src/helm/values.rs
+++ b/k8s/upgrade/src/helm/values.rs
@@ -2,7 +2,7 @@ use crate::{
     common::{
         constants::{
             KUBE_API_PAGE_SIZE, TWO_DOT_FIVE, TWO_DOT_FOUR, TWO_DOT_ONE, TWO_DOT_O_RC_ONE,
-            TWO_DOT_SEVEN_DOT_TWO, TWO_DOT_SIX, TWO_DOT_THREE,
+            TWO_DOT_SEVEN_DOT_THREE, TWO_DOT_SEVEN_DOT_TWO, TWO_DOT_SIX, TWO_DOT_THREE,
         },
         error::{
             DeserializePromtailExtraConfig, ListCrds, Result, SemverParse,
@@ -379,6 +379,17 @@ where
     if source_version.ge(&two_dot_o_rc_zero) && source_version.lt(&two_dot_seven_dot_two) {
         yq.delete_object(
             YamlKey::try_from(".localpv-provisioner.release")?,
+            upgrade_values_file.path(),
+        )?;
+    }
+
+    // Special-case values for 2.7.3.
+    let two_dot_seven_dot_three = Version::parse(TWO_DOT_SEVEN_DOT_THREE).context(SemverParse {
+        version_string: TWO_DOT_SEVEN_DOT_THREE.to_string(),
+    })?;
+    if source_version.ge(&two_dot_o_rc_zero) && source_version.lt(&two_dot_seven_dot_three) {
+        yq.delete_object(
+            YamlKey::try_from(".etcd.initialClusterState")?,
             upgrade_values_file.path(),
         )?;
     }


### PR DESCRIPTION
Fixes https://github.com/openebs/mayastor/issues/1735

This removes the helm value for the key etcd.initialClusterState for all versions greater than or equal to 2.0.0-rc.0 and less than 2.7.3.