### PR TITLE
fix(upgrade-job): explicitly set localpv image tags always

### DIFF
--- a/k8s/upgrade/src/helm/chart.rs
+++ b/k8s/upgrade/src/helm/chart.rs
@@ -259,11 +259,6 @@ impl CoreValues {
         self.loki_stack.grafana_sidecar_image_tag()
     }
 
-    /// This is a getter for the localpv-provisioner sub-chart's release version.
-    pub(crate) fn localpv_release_version(&self) -> &str {
-        self.localpv_provisioner.release_version()
-    }
-
     /// This is a getter for the container image tag of the hostpath localpv provisioner.
     pub(crate) fn localpv_provisioner_image_tag(&self) -> &str {
         self.localpv_provisioner.provisioner_image_tag()
@@ -1062,17 +1057,11 @@ impl PromtailConfigClient {
 #[derive(Default, Deserialize)]
 #[serde(default, rename_all(deserialize = "camelCase"))]
 struct LocalpvProvisioner {
-    release: LocalpvProvisionerRelease,
     localpv: LocalpvProvisionerLocalpv,
     helper_pod: LocalpvProvisionerHelperPod,
 }
 
 impl LocalpvProvisioner {
-    /// This is a getter for the localpv-provisioner helm chart's release version.
-    fn release_version(&self) -> &str {
-        self.release.version()
-    }
-
     /// This is a getter for the container image tag of the provisioner-localpv container.
     fn provisioner_image_tag(&self) -> &str {
         self.localpv.image_tag()
@@ -1081,22 +1070,6 @@ impl LocalpvProvisioner {
     /// This is a getter for the linux-utils helper container's image tag.
     fn helper_image_tag(&self) -> &str {
         self.helper_pod.image_tag()
-    }
-}
-
-/// This is used to deserialize the 'release.version' yaml object in the localpv-provisioner helm
-/// chart.
-#[derive(Default, Deserialize)]
-struct LocalpvProvisionerRelease {
-    #[serde(default)]
-    version: String,
-}
-
-impl LocalpvProvisionerRelease {
-    /// This is a getter for the release version for the localpv-provisioner helm chart.
-    /// This value is set as the value of the 'openebs.io/version' label.
-    fn version(&self) -> &str {
-        self.version.as_str()
     }
 }
 

--- a/k8s/upgrade/src/helm/values.rs
+++ b/k8s/upgrade/src/helm/values.rs
@@ -218,35 +218,20 @@ where
         version_string: TWO_DOT_SIX.to_string(),
     })?;
     if source_version.ge(&two_dot_o_rc_zero) && source_version.lt(&two_dot_six) {
-        // Update localpv-provisioner helm chart.
-        // This change is meant for versions from 2.0.0 to 2.4.0. However, this code wasn't checked
-        // into 2.5.0, and likely users of upgrade-job 2.5.0 are using the localpv image tag
-        // from 2.4.0 (i.e. 3.4.0) with the 3.5.0 localpv helm chart. So these options should
-        // also be set for source version 2.5.0.
-        let localpv_version_to_replace = "3.4.0";
-        if source_values
-            .localpv_release_version()
-            .eq(localpv_version_to_replace)
-            && target_values
-                .localpv_release_version()
-                .ne(localpv_version_to_replace)
-        {
-            yq.set_literal_value(
-                YamlKey::try_from(".localpv-provisioner.release.version")?,
-                target_values.localpv_release_version(),
-                upgrade_values_file.path(),
-            )?;
-            yq.set_literal_value(
-                YamlKey::try_from(".localpv-provisioner.localpv.image.tag")?,
-                target_values.localpv_provisioner_image_tag(),
-                upgrade_values_file.path(),
-            )?;
-            yq.set_literal_value(
-                YamlKey::try_from(".localpv-provisioner.helperPod.image.tag")?,
-                target_values.localpv_helper_image_tag(),
-                upgrade_values_file.path(),
-            )?;
-        }
+        // LocalPV Device mode was removed in OpenEBS/Dynamic LocalPV v4.0.0.
+        // Mayastor 2.6 uses Dynamic LocalPV v4.0.0 as a dependency.
+        yq.delete_object(
+            YamlKey::try_from(".localpv-provisioner.deviceClass")?,
+            upgrade_values_file.path(),
+        )?;
+        yq.delete_object(
+            YamlKey::try_from(".localpv-provisioner.localpv.waitForBDBindTimeoutRetryCount")?,
+            upgrade_values_file.path(),
+        )?;
+        yq.delete_object(
+            YamlKey::try_from(".localpv-provisioner.openebsNDM")?,
+            upgrade_values_file.path(),
+        )?;
 
         // Switch out image tag for the latest one.
         yq.set_literal_value(
@@ -432,6 +417,16 @@ where
     yq.set_literal_value(
         YamlKey::try_from(".csi.image.resizerTag")?,
         target_values.csi_resizer_image_tag(),
+        upgrade_values_file.path(),
+    )?;
+    yq.set_literal_value(
+        YamlKey::try_from(".localpv-provisioner.localpv.image.tag")?,
+        target_values.localpv_provisioner_image_tag(),
+        upgrade_values_file.path(),
+    )?;
+    yq.set_literal_value(
+        YamlKey::try_from(".localpv-provisioner.helperPod.image.tag")?,
+        target_values.localpv_helper_image_tag(),
         upgrade_values_file.path(),
     )?;
 


### PR DESCRIPTION
The upgrade-job isn't setting the localpv-provisioner dependency helm chart's openebs/provisioner-localpv image tag when upgrading. Due to the preference for existing configuration, the localpv-provisioner chart is being configured to use the source chart's openebs/provisioner-localpv container image with the target chart's helm templates.

This change adds value sets for openebs/provisioner-localpv image tag and the openebs/linux-utils image tag.

This also removes `localpv-provisioner.deviceClass`, `localpv-provisioner.localpv.waitForBDBindTimeoutRetryCount` and `localpv-provisioner.openebsNDM` helm values keys when upgrading from Mayastor <2.6.0's LocalPV 3.x to Mayastor 2.8's LocalPV v4. These keys were removed from the LocalPV v4 chart. This cleans up the values yaml a bit. Because, these values are no longer used, removing them doesn't affect any behavior.