### PR TITLE
feat(chart): use system-critical priorityClass for localpv dsp-operator and csi ctrl

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -45,6 +45,6 @@ dependencies:
     repository: https://nats-io.github.io/k8s/helm/charts/
     condition: eventing.enabled
   - name: localpv-provisioner
-    version: 4.1.2
+    version: 4.1.4
     repository: https://openebs.github.io/dynamic-localpv-provisioner
     condition: localpv-provisioner.enabled

--- a/chart/README.md
+++ b/chart/README.md
@@ -59,7 +59,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | https://grafana.github.io/helm-charts | loki-stack | 2.9.11 |
 | https://jaegertracing.github.io/helm-charts | jaeger-operator | 2.50.1 |
 | https://nats-io.github.io/k8s/helm/charts/ | nats | 0.19.14 |
-| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 4.1.2 |
+| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 4.1.4 |
 
 ## Values
 
@@ -190,6 +190,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | io_engine.&ZeroWidthSpace;tolerations | Set tolerations, overrides global | `[]` |
 | localpv-provisioner.&ZeroWidthSpace;enabled | Enables the openebs dynamic-localpv-provisioner. If disabled, modify etcd and loki-stack storage class accordingly. | `true` |
 | localpv-provisioner.&ZeroWidthSpace;hostpathClass.&ZeroWidthSpace;enabled | Enable default hostpath localpv StorageClass. | `false` |
+| localpv-provisioner.&ZeroWidthSpace;localpv.&ZeroWidthSpace;priorityClassName | Set the PriorityClass for the LocalPV Hostpath provisioner Deployment. | `"{{ .Release.Name }}-cluster-critical"` |
 | loki-stack.&ZeroWidthSpace;enabled | Enable loki log collection for our components | `true` |
 | loki-stack.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;basePath | Host path where local etcd data is stored in. | `"/var/local/{{ .Release.Name }}/localpv-hostpath/loki"` |
 | loki-stack.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;reclaimPolicy | ReclaimPolicy of loki's localpv hostpath storage class. | `"Delete"` |

--- a/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
+++ b/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
         {{ include "label_prefix" . }}/logging: "true"
     spec:
-      serviceAccount: {{ .Release.Name }}-service-account
+      serviceAccountName: {{ .Release.Name }}-service-account
       imagePullSecrets:
         {{- include "base_pull_secrets" . }}
       initContainers:

--- a/chart/templates/mayastor/csi/csi-controller-deployment.yaml
+++ b/chart/templates/mayastor/csi/csi-controller-deployment.yaml
@@ -21,14 +21,14 @@ spec:
         {{ include "label_prefix" . }}/logging: "true"
     spec:
       hostNetwork: true
-      serviceAccount: {{ .Release.Name }}-service-account
+      serviceAccountName: {{ .Release.Name }}-service-account
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:
         {{- include "base_pull_secrets" . }}
       initContainers:
         {{- include "jaeger_collector_init_container" . }}
         {{- include "rest_agent_init_container" . }}
-      {{- if $pcName := include "priority_class" (dict "template" . "localPriorityClass" .Values.csi.controller.priorityClassName) }}
+      {{- if $pcName := include "priority_class_with_default" (dict "template" . "localPriorityClass" .Values.csi.controller.priorityClassName) }}
       priorityClassName: {{ $pcName }}
       {{- end }}
       {{- if .Values.nodeSelector }}

--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
         {{ include "label_prefix" . }}/logging: "true"
     spec:
-      serviceAccount: {{ .Release.Name }}-service-account
+      serviceAccountName: {{ .Release.Name }}-service-account
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:

--- a/chart/templates/mayastor/operators/operator-diskpool-deployment.yaml
+++ b/chart/templates/mayastor/operators/operator-diskpool-deployment.yaml
@@ -20,12 +20,12 @@ spec:
         {{ include "label_prefix" . }}/version: {{ .Chart.Version }}
         {{ include "label_prefix" . }}/logging: "true"
     spec:
-      serviceAccount: {{ .Release.Name }}-service-account
+      serviceAccountName: {{ .Release.Name }}-service-account
       imagePullSecrets:
         {{- include "base_pull_secrets" . }}
       initContainers:
         {{- include "base_init_containers" . }}
-      {{- if $pcName := include "priority_class" (dict "template" . "localPriorityClass" .Values.operators.pool.priorityClassName) }}
+      {{- if $pcName := include "priority_class_with_default" (dict "template" . "localPriorityClass" .Values.operators.pool.priorityClassName) }}
       priorityClassName: {{ $pcName }}
       {{- end }}
       {{- if .Values.nodeSelector }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -835,6 +835,11 @@ storageClass:
 localpv-provisioner:
   # -- Enables the openebs dynamic-localpv-provisioner. If disabled, modify etcd and loki-stack storage class accordingly.
   enabled: true
+
+  localpv:
+    # -- Set the PriorityClass for the LocalPV Hostpath provisioner Deployment.
+    priorityClassName: "{{ .Release.Name }}-cluster-critical"
+
   hostpathClass:
     # -- Enable default hostpath localpv StorageClass.
     enabled: false


### PR DESCRIPTION
One way of using the system-critical priorityClass with the localpv provisioner could be
```
--set localpv-provisioner.localpv.priorityClassName="mayastor-system-critical"
```

However, it's difficult to set the localpv parameters dynamically.
WDYT @tiagolobocastro  @Abhinandan-Purkait?