### PR TITLE
Upgrade change for unified upgrade

### DIFF
--- a/k8s/upgrade/src/bin/upgrade-job/product_upgrade.rs
+++ b/k8s/upgrade/src/bin/upgrade-job/product_upgrade.rs
@@ -62,7 +62,9 @@ async fn upgrade_product(opts: &CliArgs, event: &mut EventRecorder) -> Result<()
     let dry_run_result: Result<HelmUpgradeRunner> = helm_upgrader.dry_run().await;
     let run_helm_upgrade = match dry_run_result {
         Err(error) => {
-            event.publish_unrecoverable(&error, true).await;
+            event
+                .publish_fatal(&error, EventAction::ValidationFailed)
+                .await;
             Err(error)
         }
         Ok(run_helm_upgrade) => Ok(run_helm_upgrade),
@@ -86,7 +88,7 @@ async fn upgrade_product(opts: &CliArgs, event: &mut EventRecorder) -> Result<()
     let final_values = match run_helm_upgrade.await {
         Ok(values) => values,
         Err(error) => {
-            event.publish_unrecoverable(&error, false).await;
+            event.publish_fatal(&error, EventAction::Failed).await;
             return Err(error);
         }
     };
@@ -139,7 +141,7 @@ async fn upgrade_product(opts: &CliArgs, event: &mut EventRecorder) -> Result<()
         )
         .await
         {
-            event.publish_unrecoverable(&error, false).await;
+            event.publish_fatal(&error, EventAction::Failed).await;
             return Err(error);
         }
 

--- a/k8s/upgrade/src/events/event_recorder.rs
+++ b/k8s/upgrade/src/events/event_recorder.rs
@@ -236,15 +236,11 @@ impl EventRecorder {
     }
 
     /// This method is intended for use when upgrade fails.
-    pub async fn publish_unrecoverable<Error>(&self, err: &Error, validation_error: bool)
+    pub async fn publish_fatal<Error, K>(&self, err: &Error, action: K)
     where
         Error: Display,
+        K: ToString,
     {
-        let action = if validation_error {
-            EventAction::ValidationFailed
-        } else {
-            EventAction::Failed
-        };
         let _ = self
             .publish_warning(format!("Failed to upgrade: {err}"), action)
             .await

--- a/k8s/upgrade/src/helm/chart.rs
+++ b/k8s/upgrade/src/helm/chart.rs
@@ -33,15 +33,34 @@ pub trait HelmValuesCollection {
     fn ha_is_enabled(&self) -> bool;
     /// This is a getter for the partial-rebuild toggle value.
     fn partial_rebuild_is_enabled(&self) -> bool;
+
+    fn mayastor_is_enabled(&self) -> bool;
 }
 
 /// UmbrellaValues is used to deserialize the helm values.yaml for the Umbrella chart. The Core
 /// chart is a sub-chart for the Umbrella chart, so the Core chart values structure is embedded
 /// into the UmbrellaValues structure.
 #[derive(Deserialize)]
-pub(crate) struct UmbrellaValues {
+pub struct UmbrellaValues {
     #[serde(rename(deserialize = "mayastor"))]
     core: CoreValues,
+    #[serde(default)]
+    engines: UmbrellaEngines,
+}
+
+#[derive(Default, Deserialize)]
+pub(crate) struct UmbrellaEngines {
+    replicated: UmbrellaEnginesReplicated,
+}
+
+#[derive(Default, Deserialize)]
+pub(crate) struct UmbrellaEnginesReplicated {
+    mayastor: UmbrellaEnginesReplicatedMayastor,
+}
+
+#[derive(Default, Deserialize)]
+pub(crate) struct UmbrellaEnginesReplicatedMayastor {
+    enabled: bool,
 }
 
 impl TryFrom<&[u8]> for UmbrellaValues {
@@ -62,11 +81,17 @@ impl HelmValuesCollection for UmbrellaValues {
     fn partial_rebuild_is_enabled(&self) -> bool {
         self.core.partial_rebuild_is_enabled()
     }
+
+    fn mayastor_is_enabled(&self) -> bool {
+        self.engines.replicated.mayastor.enabled || self.core.enabled
+    }
 }
 
 /// This is used to deserialize the values.yaml of the Core chart.
 #[derive(Deserialize)]
 pub(crate) struct CoreValues {
+    #[serde(default)]
+    enabled: bool,
     /// This contains values for all the agents.
     agents: Agents,
     /// This contains values for all the base components.
@@ -123,6 +148,10 @@ impl HelmValuesCollection for CoreValues {
 
     fn partial_rebuild_is_enabled(&self) -> bool {
         self.agents.partial_rebuild_is_enabled()
+    }
+
+    fn mayastor_is_enabled(&self) -> bool {
+        true
     }
 }
 

--- a/k8s/upgrade/src/helm/client.rs
+++ b/k8s/upgrade/src/helm/client.rs
@@ -158,7 +158,7 @@ impl HelmReleaseClientBuilder {
 
 /// This type has functions which execute helm commands to fetch info about and modify helm
 /// releases.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct HelmReleaseClient {
     pub namespace: String,
     /// This is the information that Helm stores on the cluster about the state of a helm release.


### PR DESCRIPTION
Changes:
- Move crate::helm::chart::UmbrellaValues to the pub scope
- Add types to deserialize the helm values toggle switch from openebs-3.x and openebs-4.x
- Add `derive(Debug)` attribute for crate::helm::client::HelmReleaseClient
- Allow calling crate::events::event_recorder::publish_unrecoverable with custom `action` values
- Rename crate::events::event_recorder::publish_unrecoverable to crate::events::event_recorder::publish_fatal