### PR TITLE
CherryPick PR635: Krew fix - only push the latest version

### DIFF
--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -1,11 +1,21 @@
 name: Publish Release Artifacts
 on:
   release:
-    types: [published]
+    types: [ published ]
+
 jobs:
   publish-artifacts:
     runs-on: ubuntu-latest
     steps:
+      - name: Get Latest Release Tag
+        id: latest-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LATEST_VERSION=$(gh api repos/${{ github.repository_owner }}/mayastor-extensions/releases/latest | jq -r '.tag_name')
+          echo "Latest published version:$LATEST_VERSION"
+          echo "ShouldUpdateKrew:"${{ !github.event.release.prerelease && (steps.latest-release.outputs.latestTag == github.event.release.tag_name) }}
+          echo "latestTag=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v4
       - name: Download Artifacts
         run: |
@@ -20,5 +30,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_CI_GITHUB }}
       - name: Update krew index
-        if: "!github.event.release.prerelease"
+        if: ${{ !github.event.release.prerelease && (steps.latest-release.outputs.latestTag == github.event.release.tag_name) }}
         uses: rajatjindal/krew-release-bot@v0.0.47

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -18,10 +18,10 @@ jobs:
       matrix:
         include:
           # NOTE: Update the .krew.yaml file (if required) when making changes here.
-          - os: ubuntu-latest
+          - os: ubuntu-latest-8-cores
             target: linux-musl
             arch: x86_64
-          - os: ubuntu-latest
+          - os: ubuntu-latest-8-cores
             target: linux-musl
             arch: aarch64
           - os: macos-14
@@ -30,7 +30,7 @@ jobs:
           - os: macos-13
             target: apple-darwin
             arch: x86_64
-          - os: ubuntu-latest
+          - os: ubuntu-latest-8-cores
             target: windows-gnu
             arch: x86_64
             suffix: .exe


### PR DESCRIPTION
Push to Krew only if it's the latest version, otherwise skip it. This is because krew doesn't support it.
Also speed up the plugin build with a more powerful runner.