### PR TITLE
chore: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners
-*                           @openebs/mayastor-approvers @openebs/org-maintainers
+*                           @openebs/mayastor-approvers
 
 # CODEOWNERS file owners
 /.github/CODEOWNERS         @openebs/org-maintainers


### PR DESCRIPTION
Changes:
- Remove requirement for an @openebs/org-maintainers member's review when merging non-policy documents.
- Settings changes:
   - Mandate code owner approval
   - Ensure required approval is set to 1