### PR TITLE
Orphan Volumes Handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.34"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b9470d453346108f93a59222a9a1a5724db32d0a4727b7ab7ace4b4d822dc9"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -3257,15 +3257,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -3763,12 +3762,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,6 +2198,7 @@ dependencies = [
  "async-trait",
  "clap",
  "constants",
+ "k8s-openapi",
  "kube",
  "kube-forward",
  "kube-proxy",

--- a/chart/templates/mayastor/csi/csi-controller-deployment.yaml
+++ b/chart/templates/mayastor/csi/csi-controller-deployment.yaml
@@ -126,6 +126,7 @@ spec:
             - "--ansi-colors={{ .Values.base.logging.color }}"
             - "--fmt-style={{ include "logFormat" . }}"
             - "--create-volume-limit={{ .Values.csi.controller.maxCreateVolume }}"
+            - "--enable-orphan-vol-gc={{- .Values.csi.controller.enableDangerousRetainGC | default false }}"
           env:
             - name: RUST_LOG
               value: {{ .Values.csi.controller.logLevel }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -352,6 +352,10 @@ csi:
     priorityClassName: ""
     # -- Prevent modifying the volume mode when creating a PVC from an existing VolumeSnapshot
     preventVolumeModeConversion: true
+    # Enable auto garbage collection of volume resources which were associated with `Retain` PV's.
+    # Before enabling this, make sure you're well aware of the dangerous downsides.
+    # For more information see: <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#retain>.
+    enableDangerousRetainGC: false
   node:
     logLevel: info
     topology:

--- a/k8s/plugin/Cargo.toml
+++ b/k8s/plugin/Cargo.toml
@@ -24,6 +24,7 @@ rest-plugin = { path = "../../dependencies/control-plane/control-plane/plugin", 
 supportability = { path = "../supportability" }
 upgrade = { path = "../upgrade" }
 kube = { version = "0.94.2", features = ["derive", "runtime"] }
+k8s-openapi = "0.22.0"
 kube-proxy = { path = "../../dependencies/control-plane/k8s/proxy" }
 kube-forward = { path = "../../dependencies/control-plane/k8s/forward" }
 tokio = { version = "1.41.0" }

--- a/k8s/plugin/src/main.rs
+++ b/k8s/plugin/src/main.rs
@@ -40,9 +40,7 @@ impl CliArgs {
         args.args.namespace = if let Some(namespace) = &args.namespace {
             namespace.to_string()
         } else if args.namespace_from_context {
-            let client = kube_proxy::client_from_kubeconfig(args.kube_config_path.clone())
-                .await
-                .map_err(|err| anyhow::anyhow!("{err}"))?;
+            let client = kube_proxy::client_from_kubeconfig(args.kube_config_path.clone()).await?;
             client.default_namespace().to_string()
         } else {
             constants::DEFAULT_PLUGIN_NAMESPACE.to_string()

--- a/k8s/plugin/src/resources/mod.rs
+++ b/k8s/plugin/src/resources/mod.rs
@@ -1,6 +1,8 @@
 use anyhow::anyhow;
 use clap::Parser;
+use k8s_openapi::api::core::v1 as core_v1;
 use openapi::tower::client::Url;
+use plugin::resources::VolumeId;
 use plugin::{
     resources::{
         CordonResources, DrainResources, GetResources, LabelResources, ScaleResources,
@@ -11,8 +13,9 @@ use plugin::{
 };
 use std::{ops::Deref, path::PathBuf};
 use supportability::DumpArgs;
+use upgrade::upgrade::DeleteUpgradeArgs;
 use upgrade::{
-    plugin::upgrade::{DeleteResources, GetUpgradeArgs, UpgradeArgs},
+    plugin::upgrade::{GetUpgradeArgs, UpgradeArgs},
     preflight_validations,
 };
 
@@ -33,6 +36,21 @@ pub struct CliArgs {
 
     #[clap(flatten)]
     pub cli_args: plugin::CliArgs,
+}
+
+impl CliArgs {
+    /// The kube client, with the correct install namespace.
+    pub async fn client(&self) -> anyhow::Result<kube::Client> {
+        let mut config = kube_proxy::config_from_kubeconfig(self.kubeconfig.clone()).await?;
+        // If taking namespace from context, we already know self.namespace has been set
+        // from the context.
+        config.default_namespace = self.namespace.clone();
+        Ok(kube::Client::try_from(config)?)
+    }
+    /// Get the [`core_v1::PersistentVolume`] api client for the client namespace.
+    pub async fn pv_api(&self) -> anyhow::Result<kube::Api<core_v1::PersistentVolume>> {
+        Ok(kube::Api::all(self.client().await?))
+    }
 }
 
 impl Deref for CliArgs {
@@ -80,8 +98,34 @@ pub enum Operations {
     /// `Upgrade` the deployment.
     Upgrade(UpgradeArgs),
     /// `Delete` the upgrade resources.
+    Delete(DeleteArgs),
+}
+
+/// Delete resources.
+#[derive(Debug, clap::Args)]
+pub struct DeleteArgs {
+    /// Ignore error if resource is not found.
+    #[clap(long, short, global = true)]
+    ignore_not_found: bool,
+
+    /// Automatically confirm and assume yes for all prompts.
+    #[clap(long, short, global = true)]
+    pub yes: bool,
+
     #[clap(subcommand)]
-    Delete(DeleteResources),
+    resource: DeleteResources,
+}
+
+/// The type of resources which support the delete operation.
+#[derive(clap::Subcommand, Debug)]
+pub enum DeleteResources {
+    /// Delete upgrade resources
+    Upgrade(DeleteUpgradeArgs),
+    /// Deletes the specified volume resource.
+    Volume {
+        /// The id of the volume to delete.
+        id: VolumeId,
+    },
 }
 
 #[async_trait::async_trait(?Send)]
@@ -122,10 +166,36 @@ impl ExecuteOperation for Operations {
                 .await?;
                 resources.execute(&cli_args.namespace).await?
             }
-            Operations::Delete(resource) => match resource {
-                // todo: use generic execute trait
-                DeleteResources::Upgrade(res) => res.delete(&cli_args.namespace).await?,
-            },
+            Operations::Delete(args) => {
+                match &args.resource {
+                    // todo: use generic execute trait
+                    DeleteResources::Upgrade(res) => res.delete(&cli_args.namespace).await?,
+                    DeleteResources::Volume { id } => {
+                        // 1. ensure PV is not present
+                        let pv_name = format!("pvc-{id}");
+                        let client = cli_args.pv_api().await?;
+                        let pv = client.get_opt(&pv_name).await.map_err(|error| {
+                            anyhow::anyhow!(
+                                "Failed to fetch PV {pv_name} from K8s api-server: {error}"
+                            )
+                        })?;
+                        if pv.is_some() {
+                            return Err(Error::Generic(anyhow::anyhow!(
+                                "The volume is still being referenced by PV {pv_name}"
+                            )));
+                        }
+
+                        // 2. delete volume
+                        plugin::resources::DeleteArgs {
+                            ignore_not_found: args.ignore_not_found,
+                            yes: args.yes,
+                            resource: plugin::resources::DeleteResources::Volume { id: *id },
+                        }
+                        .execute(cli_args)
+                        .await?
+                    }
+                }
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
    feat(helm-chart): add dangerous retained vol GC
    
    Completes the previous task of disabling the orphan volume GC by
    adding a helm knob but making sure it's clear this is a dangerous
    option to enable!
    
---

    feat(kubectl-plugin): add delete volume subcommand
    
    When a PV set to retain is deleted, there's no simple way of deleting
    the associated mayastor volume.. till now.
    Also check the PV is deleted, before allowing the delete through.
