### PR TITLE
fix: add knob for volume health

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -81,6 +81,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;cpu | Cpu requests for core agents | `"500m"` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;memory | Memory requests for core agents | `"32Mi"` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;tolerations | Set tolerations, overrides global | `[]` |
+| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;volumeHealth | Enable extended volume health information, which helps generate the volume status more accurately. This is disabled by default on pre 2.9 to keep existing behaviour. | `nil` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;cluster.&ZeroWidthSpace;logLevel | Log level for the ha cluster service | `"info"` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;cluster.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for ha cluster agent | `"100m"` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;cluster.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;memory | Memory limits for ha cluster agent | `"64Mi"` |

--- a/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
+++ b/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
@@ -69,6 +69,8 @@ spec:
             - "--max-rebuilds={{ .Values.agents.core.rebuild.maxConcurrent }}"{{ end }}
             {{- if eq ((.Values.agents.core.rebuild).partial).enabled false }}
             - "--disable-partial-rebuild"{{ end }}
+            {{- if not (default false .Values.agents.core.volumeHealth) }}
+            - "--no-volume-health"{{ end }}
           ports:
             - containerPort: 50051
           env:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -197,6 +197,9 @@ agents:
         waitPeriod: ""
     # The maximum number of concurrent create volume requests.
     maxCreateVolume: 10
+    # -- Enable extended volume health information, which helps generate the volume status more accurately.
+    # This is disabled by default on pre 2.9 to keep existing behaviour.
+    volumeHealth:
 
     resources:
       limits:


### PR DESCRIPTION
Volume health information was missing from the public api, leading into showing incorrect status for volumes.
In case this affects any existing scripts/tests, we add a knob to disable this information.
This is disabled on pre-2.9 by default to keep existing behavior.
