### PR TITLE
build(nix-shell): remove linux specific utils from aarch-darwin

### DIFF
--- a/scripts/k8s/shell.nix
+++ b/scripts/k8s/shell.nix
@@ -12,14 +12,13 @@ pkgs.mkShell {
     kubectl
     kind
     jq
-    nvme-cli
-  ] ++ pkgs.lib.optional (inPureNixShell) [
+  ] ++ pkgs.lib.optional (inPureNixShell && pkgs.system != "aarch64-darwin") [
     kmod
     procps
     docker
     util-linux
     sudo
-  ];
+  ] ++ pkgs.lib.optional (pkgs.system != "aarch64-darwin") nvme-cli;
 
   SUDO = "sudo";
   shellHook = ''


### PR DESCRIPTION
Allows us to run the nix-shell on darwin, simply in a way to build the plugin and any non-linux dependent binaries.
The nvme-cli and kmod was used for testing on kind clusters, which is assuming that the host is linux.
