### PR TITLE
Update cargo deps and submodule deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
  "regex",
  "ring",
  "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-webpki 0.102.8",
  "serde",
  "serde_json",
@@ -436,7 +436,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "itoa",
  "matchit",
@@ -462,7 +462,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -603,8 +603,8 @@ dependencies = [
  "heck",
  "humantime",
  "jsonpath_lib",
- "k8s-openapi 0.20.0",
- "kube 0.87.2",
+ "k8s-openapi",
+ "kube",
  "mime",
  "once_cell",
  "openapi",
@@ -741,15 +741,6 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "cookie"
@@ -938,7 +929,7 @@ version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
- "convert_case 0.4.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1502,17 +1493,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -1530,15 +1510,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -1560,29 +1534,6 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
@@ -1592,7 +1543,7 @@ dependencies = [
  "futures-util",
  "h2 0.4.6",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1607,7 +1558,7 @@ name = "hyper-body"
 version = "0.1.0"
 dependencies = [
  "http-body-util",
- "hyper 1.5.0",
+ "hyper",
  "tower 0.5.1",
 ]
 
@@ -1621,8 +1572,8 @@ dependencies = [
  "futures-util",
  "headers",
  "http 1.1.0",
- "hyper 1.5.0",
- "hyper-rustls 0.27.3",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
  "rustls-native-certs 0.7.3",
@@ -1633,29 +1584,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.31",
- "log",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.5.0",
+ "hyper",
  "hyper-util",
  "log",
  "rustls 0.23.19",
@@ -1668,23 +1603,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.31",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.5.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1699,7 +1622,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1717,8 +1640,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
- "hyper 1.5.0",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1999,36 +1922,12 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9ad60d674508f3ca8f380a928cfe7b096bc729c4e2dbfe3852bc45da3ab30b"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "json-patch"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
 dependencies = [
  "jsonptr",
  "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "jsonpath-rust"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06cc127b7c3d270be504572364f9569761a180b981919dd0d87693a7f5fb7829"
-dependencies = [
- "pest",
- "pest_derive",
- "regex",
  "serde_json",
  "thiserror",
 ]
@@ -2072,20 +1971,6 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3606fd16aca7989db2f84bb25684d0270c6d6fa1dbcd0025af7b4130523a6"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "chrono",
- "serde",
- "serde-value",
- "serde_json",
-]
-
-[[package]]
-name = "k8s-openapi"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19501afb943ae5806548bc3ebd7f3374153ca057a38f480ef30adfde5ef09755"
@@ -2101,24 +1986,11 @@ dependencies = [
 name = "k8s-operators"
 version = "1.0.0"
 dependencies = [
- "k8s-openapi 0.22.0",
- "kube 0.94.2",
+ "k8s-openapi",
+ "kube",
  "schemars",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "kube"
-version = "0.87.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3499c8d60c763246c7a213f51caac1e9033f46026904cb89bc8951ae8601f26e"
-dependencies = [
- "k8s-openapi 0.20.0",
- "kube-client 0.87.2",
- "kube-core 0.87.2",
- "kube-derive 0.87.2",
- "kube-runtime 0.87.2",
 ]
 
 [[package]]
@@ -2127,47 +1999,11 @@ version = "0.94.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ace78a62b361077505f2950bd48aa3e46596fb15350c9c993de15ddfa3cac5"
 dependencies = [
- "k8s-openapi 0.22.0",
- "kube-client 0.94.2",
- "kube-core 0.94.2",
- "kube-derive 0.94.2",
- "kube-runtime 0.94.2",
-]
-
-[[package]]
-name = "kube-client"
-version = "0.87.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033450dfa0762130565890dadf2f8835faedf749376ca13345bcd8ecd6b5f29f"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "chrono",
- "either",
- "futures",
- "home",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.31",
- "hyper-rustls 0.24.2",
- "hyper-timeout 0.4.1",
- "jsonpath-rust 0.3.5",
- "k8s-openapi 0.20.0",
- "kube-core 0.87.2",
- "pem",
- "pin-project",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "secrecy",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror",
- "tokio",
- "tokio-util",
- "tower 0.4.13",
- "tower-http 0.4.4",
- "tracing",
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+ "kube-derive",
+ "kube-runtime",
 ]
 
 [[package]]
@@ -2183,20 +2019,20 @@ dependencies = [
  "futures",
  "home",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper",
  "hyper-http-proxy",
- "hyper-rustls 0.27.3",
- "hyper-timeout 0.5.2",
+ "hyper-rustls",
+ "hyper-timeout",
  "hyper-util",
- "jsonpath-rust 0.5.1",
- "k8s-openapi 0.22.0",
- "kube-core 0.94.2",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
  "pem",
  "rand",
  "rustls 0.23.19",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
@@ -2212,24 +2048,6 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.87.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bba93d054786eba7994d03ce522f368ef7d48c88a1826faa28478d85fb63ae"
-dependencies = [
- "chrono",
- "form_urlencoded",
- "http 0.2.12",
- "json-patch 1.4.0",
- "k8s-openapi 0.20.0",
- "once_cell",
- "schemars",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "kube-core"
 version = "0.94.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50c095f051dada37740d883b6d47ad0430e95082140718073b773c8a70f231c"
@@ -2237,26 +2055,13 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "http 1.1.0",
- "json-patch 2.0.0",
- "k8s-openapi 0.22.0",
+ "json-patch",
+ "k8s-openapi",
  "schemars",
  "serde",
  "serde-value",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "kube-derive"
-version = "0.87.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e98dd5e5767c7b894c1f0e41fd628b145f808e981feb8b08ed66455d47f1a4"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -2278,10 +2083,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
- "hyper 1.5.0",
+ "hyper",
  "hyper-body",
- "k8s-openapi 0.22.0",
- "kube 0.94.2",
+ "k8s-openapi",
+ "kube",
  "serde_json",
  "shutdown",
  "thiserror",
@@ -2297,10 +2102,10 @@ name = "kube-proxy"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "hyper 1.5.0",
+ "hyper",
  "hyper-body",
  "hyper-util",
- "kube 0.94.2",
+ "kube",
  "kube-forward",
  "openapi",
  "thiserror",
@@ -2308,32 +2113,6 @@ dependencies = [
  "tower 0.5.1",
  "url",
  "utils",
-]
-
-[[package]]
-name = "kube-runtime"
-version = "0.87.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8893eb18fbf6bb6c80ef6ee7dd11ec32b1dc3c034c988ac1b3a84d46a230ae"
-dependencies = [
- "ahash",
- "async-trait",
- "backoff",
- "derivative",
- "futures",
- "hashbrown 0.14.5",
- "json-patch 1.4.0",
- "k8s-openapi 0.20.0",
- "kube-client 0.87.2",
- "parking_lot 0.12.3",
- "pin-project",
- "serde",
- "serde_json",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -2350,10 +2129,10 @@ dependencies = [
  "derivative",
  "futures",
  "hashbrown 0.14.5",
- "json-patch 2.0.0",
+ "json-patch",
  "jsonptr",
- "k8s-openapi 0.22.0",
- "kube-client 0.94.2",
+ "k8s-openapi",
+ "kube-client",
  "parking_lot 0.12.3",
  "pin-project",
  "serde",
@@ -2371,10 +2150,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
- "console-logger",
  "constants",
- "humantime",
- "kube 0.94.2",
+ "kube",
  "kube-forward",
  "kube-proxy",
  "openapi",
@@ -2414,12 +2191,6 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.7",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2646,22 +2417,22 @@ dependencies = [
  "async-trait",
  "dyn-clonable",
  "futures",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper",
  "hyper-body",
- "hyper-rustls 0.27.3",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "k8s-openapi 0.22.0",
- "kube 0.94.2",
+ "k8s-openapi",
+ "kube",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "pin-project",
  "rustls 0.23.19",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3012,8 +2783,8 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 name = "platform"
 version = "0.1.0"
 dependencies = [
- "k8s-openapi 0.22.0",
- "kube 0.94.2",
+ "k8s-openapi",
+ "kube",
  "tokio",
  "tracing",
 ]
@@ -3322,10 +3093,10 @@ dependencies = [
  "futures-util",
  "h2 0.4.6",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.5.0",
- "hyper-rustls 0.27.3",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -3336,7 +3107,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3378,7 +3149,7 @@ dependencies = [
  "futures",
  "getrandom",
  "http 1.1.0",
- "hyper 1.5.0",
+ "hyper",
  "parking_lot 0.11.2",
  "reqwest",
  "reqwest-middleware",
@@ -3511,24 +3282,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -3541,19 +3300,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -3999,12 +3749,12 @@ dependencies = [
  "http 1.1.0",
  "http-body-util",
  "humantime",
- "hyper 1.5.0",
+ "hyper",
  "hyper-body",
  "hyper-util",
- "k8s-openapi 0.22.0",
+ "k8s-openapi",
  "k8s-operators",
- "kube 0.94.2",
+ "kube",
  "kube-proxy",
  "lazy_static",
  "once_cell",
@@ -4012,17 +3762,14 @@ dependencies = [
  "platform",
  "pstor",
  "rest-plugin",
- "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
  "tar",
- "tokio",
  "tower 0.5.1",
  "urlencoding",
  "utils",
  "uuid",
- "yaml-rust",
 ]
 
 [[package]]
@@ -4219,16 +3966,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4331,10 +4068,10 @@ dependencies = [
  "bytes",
  "h2 0.4.6",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.5.0",
- "hyper-timeout 0.5.2",
+ "hyper",
+ "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
@@ -4401,27 +4138,6 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
-dependencies = [
- "base64 0.21.7",
- "bitflags 2.6.0",
- "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
- "mime",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
@@ -4430,7 +4146,7 @@ dependencies = [
  "bitflags 2.6.0",
  "bytes",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -4449,7 +4165,7 @@ dependencies = [
  "bitflags 2.6.0",
  "bytes",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "mime",
  "pin-project-lite",
  "tower-layer",
@@ -4623,12 +4339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4650,19 +4360,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 name = "upgrade"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64 0.22.1",
  "clap",
  "console-logger",
  "constants",
- "convert_case 0.6.0",
  "flate2",
- "http 1.1.0",
  "humantime",
- "hyper 1.5.0",
- "k8s-openapi 0.20.0",
- "kube 0.87.2",
+ "k8s-openapi",
+ "kube",
  "kube-proxy",
  "maplit",
  "openapi",
@@ -4674,7 +4380,6 @@ dependencies = [
  "snafu",
  "tempfile",
  "tokio",
- "tower 0.5.1",
  "tracing",
  "url",
  "utils",
@@ -5076,15 +4781,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/call-home/Cargo.toml
+++ b/call-home/Cargo.toml
@@ -20,8 +20,8 @@ path = "src/bin/stats/main.rs"
 [dependencies]
 constants = { path = "../constants" }
 openapi = { path = "../dependencies/control-plane/openapi" }
-kube = { version = "0.87.0", features = ["runtime", "derive"] }
-k8s-openapi = { version = "0.20.0", features = ["v1_22"] }
+kube = { version = "0.94.2", features = ["runtime", "derive"] }
+k8s-openapi = { version = "0.22.0", features = ["v1_24"] }
 futures = "0.3.31"
 tokio = { version = "1.41.0", features = ["full"] }
 clap = { version = "4.5.20", features = ["cargo", "derive", "string"] }

--- a/k8s/plugin/Cargo.toml
+++ b/k8s/plugin/Cargo.toml
@@ -21,7 +21,6 @@ openapi = { path = "../../dependencies/control-plane/openapi", default-features 
 utils = { path = "../../dependencies/control-plane/utils/utils-lib" }
 constants = { path = "../../constants" }
 rest-plugin = { path = "../../dependencies/control-plane/control-plane/plugin", default-features = false }
-console-logger = { path = "../../console-logger" }
 supportability = { path = "../supportability" }
 upgrade = { path = "../upgrade" }
 kube = { version = "0.94.2", features = ["derive", "runtime"] }
@@ -30,6 +29,5 @@ kube-forward = { path = "../../dependencies/control-plane/k8s/forward" }
 tokio = { version = "1.41.0" }
 anyhow = "1.0.92"
 clap = { version = "4.5.20", features = ["color", "derive"] }
-humantime = "2.1.0"
 async-trait = "0.1.83"
 shutdown = { path = "../../dependencies/control-plane/utils/shutdown" }

--- a/k8s/supportability/Cargo.toml
+++ b/k8s/supportability/Cargo.toml
@@ -16,10 +16,8 @@ tls = ["openapi/tower-client-tls"]
 
 [dependencies]
 futures = "0.3"
-tokio = { version = "1.41.0", features = ["full"] }
 k8s-openapi = { version = "0.22.0", features = ["v1_24"] }
 kube = { version = "0.94.2", features = ["derive"] }
-yaml-rust = { version = "0.4" }
 clap = { version = "4.5.20", features = ["color", "derive"] }
 anyhow = "1.0.92"
 humantime = "2.1.0"
@@ -35,7 +33,6 @@ flate2 = { version = "1.0.34" }
 chrono = "0.4.38"
 urlencoding = "2.1.3"
 downcast-rs = "1.2.1"
-schemars = "0.8.21"
 http = "1.1.0"
 hyper = { version = "1.5.0", features = ["client", "http1", "http2"] }
 hyper-util = "0.1.10"

--- a/k8s/upgrade/Cargo.toml
+++ b/k8s/upgrade/Cargo.toml
@@ -17,16 +17,11 @@ utils = { path = "../../dependencies/control-plane/utils/utils-lib" }
 constants = { path = "../../constants" }
 kube-proxy = { path = "../../dependencies/control-plane/k8s/proxy" }
 console-logger = { path = "../../console-logger" }
-convert_case = "0.6.0"
-kube = { version = "0.87.0", default-features = true, features = ["derive", "runtime"] }
-anyhow = "1.0.92"
+kube = { version = "0.94.2", default-features = true, features = ["derive", "runtime"] }
 clap = { version = "4.5.20", features = ["derive", "env", "string", "color"] }
 humantime = "2.1.0"
 maplit = "1.0.2"
-k8s-openapi = { version = "0.20.0", features = ["v1_22"] }
-tower = { version = "0.5.1", features = ["timeout", "util"] }
-hyper = { version = "1.5.0", features = ["client", "http1", "http2"] }
-http = "1.1.0"
+k8s-openapi = { version = "0.22.0", features = ["v1_24"] }
 async-trait = "0.1.83"
 serde = "1.0.214"
 serde_json = "1.0.132"


### PR DESCRIPTION
Changes:
- Update cargo deps to versions to those in the 'develop' branch. This is so that the code in openebs/openebs may compile correctly. Currently two different versions of kube-rs/kube and/or Arnavion/k8s-openapi doesn't compile correctly.
- Update submodule dependency