### PR TITLE
build: integrate with new release.sh vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,6 +4520,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "regex",
  "strum",
  "strum_macros",
  "tracing",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,15 +13,15 @@ fi
 
 IMAGES="metrics.exporter.io-engine obs.callhome stats.aggregator upgrade.job"
 HELM_DEPS_IMAGES="upgrade.job"
+HELM_CHART_DIR="$(dirname "$0")/../chart"
 BUILD_BINARIES="kubectl-plugin"
 PROJECT="extensions"
 . "$SOURCE_REL"
 
 # Sadly helm ignore does not work on symlinks: https://github.com/helm/helm/issues/13284
 # So we must cleanup to ensure the upgrade image is built correctly
-CHART_DIR="$(dirname "$0")/../chart"
-if [ -L "$CHART_DIR"/kubectl-plugin ]; then
-  rm "$CHART_DIR"/kubectl-plugin
+if [ -L "$HELM_CHART_DIR"/kubectl-plugin ]; then
+  rm "$HELM_CHART_DIR"/kubectl-plugin
 fi
 
 common_run $@


### PR DESCRIPTION
Changes:
- Update mayastor-control-plane git submodule dependency
- Use the new HELM_CHART_DIR variable in release.sh