### PR TITLE
chore: add tenant id header to loki query

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -593,6 +593,10 @@ loki:
       # -- VolumeBindingMode of minio's localpv hostpath storage class.
       volumeBindingMode: WaitForFirstConsumer
   loki:
+    serviceLabels:
+      app: loki
+    podLabels:
+      app: loki
     schemaConfig:
       configs:
         - from: 2024-04-01

--- a/k8s/supportability/src/collect/common.rs
+++ b/k8s/supportability/src/collect/common.rs
@@ -25,6 +25,8 @@ pub(crate) struct DumpConfig {
     /// Topologer implements functionality to build topological information of system
     pub(crate) topologer: Option<Box<dyn Topologer>>,
     pub(crate) output_format: OutputFormat,
+    /// Tenant ID that needs to be passed while querying.
+    pub(crate) tenant_id: String,
 }
 
 /// The output format.

--- a/k8s/supportability/src/collect/constants.rs
+++ b/k8s/supportability/src/collect/constants.rs
@@ -37,6 +37,9 @@ pub(crate) const MAYASTOR_SERVICE: &str = "io-engine";
 /// Defines the name of mayastor-io container(dataplane container)
 pub(crate) const DATA_PLANE_CONTAINER_NAME: &str = "io-engine";
 
+/// Loki Tenant ID header key.
+pub(crate) const X_SCOPE_ORGID: &str = "X-Scope-OrgID";
+
 /// Defines the logging label(key-value pair) on services.
 pub(crate) fn logging_label_selector() -> String {
     format!("{}=true", ::constants::loki_logging_key())

--- a/k8s/supportability/src/collect/logs/loki.rs
+++ b/k8s/supportability/src/collect/logs/loki.rs
@@ -1,3 +1,4 @@
+use crate::collect::constants::X_SCOPE_ORGID;
 use crate::{collect::utils::write_to_log_file, log};
 use chrono::Utc;
 use hyper::body::Buf;
@@ -130,6 +131,8 @@ pub(crate) struct LokiClient {
     direction: LogDirection,
     /// maximum number of entries to return on one http call
     limit: u64,
+    /// Tenant id to be used for querying.
+    tenant_id: String,
 }
 
 impl LokiClient {
@@ -140,6 +143,7 @@ impl LokiClient {
         namespace: String,
         since: humantime::Duration,
         timeout: humantime::Duration,
+        tenant_id: String,
     ) -> Option<Self> {
         let (uri, client) = match uri {
             None => {
@@ -188,6 +192,7 @@ impl LokiClient {
             logs_endpoint: ENDPOINT.to_string(),
             direction: LogDirection::Forward,
             limit: 3000,
+            tenant_id,
         })
     }
 
@@ -317,6 +322,7 @@ impl<'a> LokiPoll<'a> {
         let request = http::Request::builder()
             .method("GET")
             .uri(&request_str)
+            .header(X_SCOPE_ORGID, self.client.tenant_id.clone())
             .body(hyper_body::Body::empty())?;
 
         let response = self.client().ready().await?.call(request).await?;

--- a/k8s/supportability/src/collect/logs/mod.rs
+++ b/k8s/supportability/src/collect/logs/mod.rs
@@ -92,12 +92,14 @@ impl LogCollection {
     /// param 'loki_uri' --> Defines the address of loki instance
     /// param 'since'  --> Defines period from which logs needs to collect
     /// param 'timeout' --> Specifies the timeout while interacting with Loki Service
+    /// param 'tenant_id' --> Specifies the tenant_id while interacting with Loki Service
     pub(crate) async fn new_logger(
         kube_config_path: Option<std::path::PathBuf>,
         namespace: String,
         loki_uri: Option<String>,
         since: humantime::Duration,
         timeout: humantime::Duration,
+        tenant_id: String,
     ) -> Result<Box<dyn Logger>, LogError> {
         let client_set = ClientSet::new(kube_config_path.clone(), namespace.clone()).await?;
         Ok(Box::new(Self {
@@ -107,6 +109,7 @@ impl LogCollection {
                 namespace,
                 since,
                 timeout,
+                tenant_id,
             )
             .await,
             k8s_logger_client: K8sLoggerClient::new(client_set),

--- a/k8s/supportability/src/collect/resource_dump.rs
+++ b/k8s/supportability/src/collect/resource_dump.rs
@@ -84,6 +84,7 @@ impl ResourceDumper {
             config.loki_uri,
             config.since,
             config.timeout,
+            config.tenant_id,
         )
         .await
         {

--- a/k8s/supportability/src/collect/system_dump.rs
+++ b/k8s/supportability/src/collect/system_dump.rs
@@ -71,6 +71,7 @@ impl SystemDumper {
             config.loki_uri,
             config.since,
             config.timeout,
+            config.tenant_id,
         )
         .await
         {

--- a/k8s/supportability/src/lib.rs
+++ b/k8s/supportability/src/lib.rs
@@ -48,6 +48,10 @@ pub struct SupportArgs {
     /// Path to kubeconfig file.
     #[clap(skip)]
     pub kubeconfig: Option<PathBuf>,
+
+    /// The tenant id to be used to query loki logs.
+    #[clap(global = true, long, default_value = "openebs")]
+    tenant_id: String,
 }
 
 /// Supportability - collects state & log information of services and dumps it to a tar file.
@@ -115,6 +119,7 @@ async fn execute_resource_dump(
         timeout: cli_args.timeout,
         topologer: None,
         output_format: OutputFormat::Tar,
+        tenant_id: cli_args.tenant_id,
     };
     let mut errors = Vec::new();
     match resource {


### PR DESCRIPTION
- Newer loki deployments need tenant id to be sent while querying.
- This adds the tenant id header to the supportability.
- Adds app: loki labels to pods and svc.