### PR TITLE
revert: disable loki-stack during helm install ci

### DIFF
--- a/scripts/helm/install.sh
+++ b/scripts/helm/install.sh
@@ -176,9 +176,7 @@ else
        --set="obs.callhome.enabled=true,obs.callhome.sendReport=false,localpv-provisioner.analytics.enabled=false" \
        --set="eventing.enabled=true,nats.cluster.enabled=false,nats.cluster.replicas=1" \
        --set="loki.loki.commonConfig.replication_factor=2,loki.singleBinary.replicas=2,loki.minio.replicas=2" \
-       --set="loki-stack.enabled=false" \
        $HELM_DRY_RUN $WAIT_ARG $PULL_POLICY_ARG $DEP_UPDATE_ARG $VERSION_ARG ${HELM_ARGS:-}
-       # TODO: `--set="loki-stack.enabled=false"` remove this once the upgrade operator supports step upgrade to remove old loki-stack.
   set +x
 fi
 


### PR DESCRIPTION
A workaround was introduced in PR 663 for testing core upgrade on the CI. This workaround is to disable loki-stack so that the stateful set from the loki chart doesn't cause conflicts with the statefulset from the loki-stack chart. This is not needed any more, a fix has been merged in PR 673