### PR TITLE
chore(deps): update the version of localpv-provisioner dependency chart to 4.3.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -49,7 +49,7 @@ dependencies:
     repository: https://nats-io.github.io/k8s/helm/charts/
     condition: eventing.enabled
   - name: localpv-provisioner
-    version: 4.2.0
+    version: 4.3.0
     repository: https://openebs.github.io/dynamic-localpv-provisioner
     condition: localpv-provisioner.enabled
 annotations:

--- a/chart/README.md
+++ b/chart/README.md
@@ -60,7 +60,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | https://grafana.github.io/helm-charts | loki | 6.29.0 |
 | https://jaegertracing.github.io/helm-charts | jaeger-operator | 2.50.1 |
 | https://nats-io.github.io/k8s/helm/charts/ | nats | 0.19.14 |
-| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 4.2.0 |
+| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 4.3.0 |
 
 ## Values
 

--- a/chart/images.txt
+++ b/chart/images.txt
@@ -1,8 +1,8 @@
 docker.io/bitnami/etcd:3.5.6-debian-11-r10
 docker.io/grafana/alloy:v1.8.1
 docker.io/grafana/loki:3.4.2
-docker.io/openebs/alpine-bash:4.1.0
-docker.io/openebs/alpine-sh:4.1.0
+docker.io/openebs/alpine-bash:4.2.0
+docker.io/openebs/alpine-sh:4.2.0
 docker.io/openebs/mayastor-agent-core:develop
 docker.io/openebs/mayastor-agent-ha-cluster:develop
 docker.io/openebs/mayastor-agent-ha-node:develop
@@ -19,8 +19,8 @@ nats:2.9.17-alpine
 natsio/nats-box:0.13.8
 natsio/nats-server-config-reloader:0.10.1
 natsio/prometheus-nats-exporter:0.11.0
-openebs/linux-utils:4.1.0
-openebs/provisioner-localpv:4.2.0
+openebs/linux-utils:4.2.0
+openebs/provisioner-localpv:4.3.0
 quay.io/minio/mc:RELEASE.2024-11-21T17-21-54Z
 quay.io/minio/minio:RELEASE.2024-12-18T13-15-44Z
 quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -67,7 +67,7 @@ base:
     enabled: true
     image:
       name: alpine-sh
-      tag: 4.1.0
+      tag: 4.2.0
       pullPolicy: IfNotPresent
     containers:
       - name: agent-core-grpc-probe
@@ -547,7 +547,7 @@ etcd:
     image:
       registry: docker.io
       repository: openebs/alpine-bash
-      tag: 4.1.0
+      tag: 4.2.0
       pullSecrets: []
   # extra debug information on logs
   debug: false


### PR DESCRIPTION
Changes:
- update localpv-provisioner dependency chart to 4.3.0
- update alpine-sh to 4.2.0
- update alpine-bash to 4.2.0