### PR TITLE
Huge pages

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -188,10 +188,12 @@ This removes all the Kubernetes components associated with the chart and deletes
 | io_engine.&ZeroWidthSpace;priorityClassName | Set PriorityClass, overrides global | `""` |
 | io_engine.&ZeroWidthSpace;pstorRetries | Number of retries for pstor persistence before the volume target self shutdowns | `300` |
 | io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for the io-engine | `""` |
-| io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;hugepages2Mi | Hugepage size available on the nodes | `"2Gi"` |
+| io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;hugepages1Gi | Hugepage memory in 1GiB chunks | `nil` |
+| io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;hugepages2Mi | Hugepage memory in 2MiB chunks | `"2Gi"` |
 | io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;memory | Memory limits for the io-engine | `"1Gi"` |
 | io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;cpu | Cpu requests for the io-engine | `""` |
-| io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;hugepages2Mi | Hugepage size available on the nodes | `"2Gi"` |
+| io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;hugepages1Gi | Hugepage memory in 1GiB chunks | `nil` |
+| io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;hugepages2Mi | Hugepage memory in 2MiB chunks | `"2Gi"` |
 | io_engine.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;memory | Memory requests for the io-engine | `"1Gi"` |
 | io_engine.&ZeroWidthSpace;runtimeClassName | Runtime class to use. Defaults to cluster standard | `""` |
 | io_engine.&ZeroWidthSpace;target.&ZeroWidthSpace;nvmf.&ZeroWidthSpace;iface | NVMF target interface (ip, mac, name or subnet) If RDMA is enabled, please set iface to an RDMA capable netdev name from host network. Example, if an rdma device mlx5_0 is available on a netdev eth0 on RNIC, as can be seen from `rdma link` command output, then this field should be set to eth0. | `""` |

--- a/chart/templates/mayastor/csi/csi-controller-deployment.yaml
+++ b/chart/templates/mayastor/csi/csi-controller-deployment.yaml
@@ -38,6 +38,37 @@ spec:
       tolerations: {{ $tolerations }}
       {{- end }}
       containers:
+        - name: csi-controller
+          resources:
+            limits:
+              cpu: {{ .Values.csi.controller.resources.limits.cpu | quote }}
+              memory: {{ .Values.csi.controller.resources.limits.memory | quote }}
+            requests:
+              cpu: {{ .Values.csi.controller.resources.requests.cpu | quote }}
+              memory: {{ .Values.csi.controller.resources.requests.memory | quote }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-csi-controller:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--csi-socket=/var/lib/csi/sockets/pluginproxy/csi.sock"
+            - "--rest-endpoint=http://{{ .Release.Name }}-api-rest:8081"{{ if .Values.base.jaeger.enabled }}
+            - "--jaeger={{ include "jaeger_url" . }}"{{ end }}
+            {{- range $key, $val := .Values.csi.node.topology.segments }}
+            - "--node-selector={{ $key }}={{ $val }}"
+            {{- end }}
+            - "--ansi-colors={{ .Values.base.logging.color }}"
+            - "--fmt-style={{ include "logFormat" . }}"
+            - "--create-volume-limit={{ .Values.csi.controller.maxCreateVolume }}"
+            - "--enable-orphan-vol-gc={{- .Values.csi.controller.enableDangerousRetainGC | default false }}"
+          env:
+            - name: RUST_LOG
+              value: {{ .Values.csi.controller.logLevel }}
+            {{- if default .Values.base.logging.silenceLevel .Values.csi.controller.logSilenceLevel }}
+            - name: RUST_LOG_SILENCE
+              value: {{ default .Values.base.logging.silenceLevel .Values.csi.controller.logSilenceLevel }}
+            {{- end }}
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
           image: "{{ .Values.csi.image.registry }}/{{ .Values.csi.image.repo }}/csi-provisioner:{{ .Values.csi.image.provisionerTag }}"
           args:
@@ -103,37 +134,6 @@ spec:
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           image: "{{ .Values.csi.image.registry }}/{{ .Values.csi.image.repo }}/csi-resizer:{{ .Values.csi.image.resizerTag }}"
           imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-        - name: csi-controller
-          resources:
-            limits:
-              cpu: {{ .Values.csi.controller.resources.limits.cpu | quote }}
-              memory: {{ .Values.csi.controller.resources.limits.memory | quote }}
-            requests:
-              cpu: {{ .Values.csi.controller.resources.requests.cpu | quote }}
-              memory: {{ .Values.csi.controller.resources.requests.memory | quote }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-csi-controller:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-            - "--csi-socket=/var/lib/csi/sockets/pluginproxy/csi.sock"
-            - "--rest-endpoint=http://{{ .Release.Name }}-api-rest:8081"{{ if .Values.base.jaeger.enabled }}
-            - "--jaeger={{ include "jaeger_url" . }}"{{ end }}
-            {{- range $key, $val := .Values.csi.node.topology.segments }}
-            - "--node-selector={{ $key }}={{ $val }}"
-            {{- end }}
-            - "--ansi-colors={{ .Values.base.logging.color }}"
-            - "--fmt-style={{ include "logFormat" . }}"
-            - "--create-volume-limit={{ .Values.csi.controller.maxCreateVolume }}"
-            - "--enable-orphan-vol-gc={{- .Values.csi.controller.enableDangerousRetainGC | default false }}"
-          env:
-            - name: RUST_LOG
-              value: {{ .Values.csi.controller.logLevel }}
-            {{- if default .Values.base.logging.silenceLevel .Values.csi.controller.logSilenceLevel }}
-            - name: RUST_LOG_SILENCE
-              value: {{ default .Values.base.logging.silenceLevel .Values.csi.controller.logSilenceLevel }}
-            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -110,15 +110,21 @@ spec:
           mountPath: /var/local/{{ .Release.Name }}/io-engine/
         - name: hugepages-2mi
           mountPath: /dev/hugepages-2mi
+        {{- if .Values.io_engine.resources.requests.hugepages1Gi }}
+        - name: hugepages-1gi
+          mountPath: /dev/hugepages-1gi
+        {{- end }}
         resources:
           limits:
             cpu: {{ .Values.io_engine.resources.limits.cpu | default (include "coreCount" .) | quote }}
             memory: {{ .Values.io_engine.resources.limits.memory | quote }}
             hugepages-2Mi: {{ .Values.io_engine.resources.limits.hugepages2Mi | quote }}
+            hugepages-1Gi: {{ .Values.io_engine.resources.requests.hugepages1Gi | quote }}
           requests:
             cpu: {{ .Values.io_engine.resources.requests.cpu | default (include "coreCount" .) | quote }}
             memory: {{ .Values.io_engine.resources.requests.memory | quote }}
             hugepages-2Mi: {{ .Values.io_engine.resources.requests.hugepages2Mi | quote }}
+            hugepages-1Gi: {{ .Values.io_engine.resources.requests.hugepages1Gi | quote }}
         ports:
         - containerPort: 10124
           protocol: TCP
@@ -161,6 +167,11 @@ spec:
       - name: hugepages-2mi
         emptyDir:
           medium: HugePages-2Mi
+      {{- if .Values.io_engine.resources.requests.hugepages1Gi }}
+      - name: hugepages-1gi
+        emptyDir:
+          medium: HugePages-1Gi
+      {{- end }}
       - name: configlocation
         hostPath:
           path: /var/local/{{ .Release.Name }}/io-engine/

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -108,8 +108,8 @@ spec:
           mountPath: /dev/shm
         - name: configlocation
           mountPath: /var/local/{{ .Release.Name }}/io-engine/
-        - name: hugepage
-          mountPath: /dev/hugepages
+        - name: hugepages-2mi
+          mountPath: /dev/hugepages-2mi
         resources:
           limits:
             cpu: {{ .Values.io_engine.resources.limits.cpu | default (include "coreCount" .) | quote }}
@@ -158,9 +158,9 @@ spec:
         emptyDir:
           medium: Memory
           sizeLimit: "1Gi"
-      - name: hugepage
+      - name: hugepages-2mi
         emptyDir:
-          medium: HugePages
+          medium: HugePages-2Mi
       - name: configlocation
         hostPath:
           path: /var/local/{{ .Release.Name }}/io-engine/

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -41,28 +41,6 @@ spec:
       initContainers:
         {{- include "base_init_containers" . }}
       containers:
-      {{- if .Values.base.metrics.enabled }}
-      - name: metrics-exporter-io-engine
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-metrics-exporter-io-engine:{{ default .Values.image.tag .Values.image.repoTags.extensions }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        env:
-        - name: MY_NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        ports:
-          - containerPort: {{ default 9502 .Values.base.metrics.port }}
-            protocol: TCP
-            name: metrics
-        args:
-          - "--metrics-endpoint=[::]:{{ default 9502 .Values.base.metrics.port }}"
-          - "--fmt-style={{ include "logFormat" . }}"
-          - "--ansi-colors={{ .Values.base.logging.color }}"
-      {{- end }}
       - name: io-engine
         image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-io-engine:{{ default .Values.image.tag .Values.image.repoTags.dataPlane }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -145,6 +123,28 @@ spec:
         - containerPort: 10124
           protocol: TCP
           name: io-engine
+      {{- if .Values.base.metrics.enabled }}
+      - name: metrics-exporter-io-engine
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-metrics-exporter-io-engine:{{ default .Values.image.tag .Values.image.repoTags.extensions }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        ports:
+          - containerPort: {{ default 9502 .Values.base.metrics.port }}
+            protocol: TCP
+            name: metrics
+        args:
+          - "--metrics-endpoint=[::]:{{ default 9502 .Values.base.metrics.port }}"
+          - "--fmt-style={{ include "logFormat" . }}"
+          - "--ansi-colors={{ .Values.base.logging.color }}"
+      {{- end }}
       volumes:
       - name: device
         hostPath:

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
       priorityClassName: {{ $pcName }}
       {{- end }}
       {{- if .Values.runtimeClassName }}
-      runetimeClassName: {{ .Values.runtimeClassName | quote }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
       {{- end }}
       {{- if $tolerations := include "tolerations" (dict "template" . "localTolerations" .Values.io_engine.tolerations) }}
       tolerations: {{ $tolerations }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -461,15 +461,19 @@ io_engine:
       cpu: ""
       # -- Memory limits for the io-engine
       memory: "1Gi"
-      # -- Hugepage size available on the nodes
+      # -- Hugepage memory in 2MiB chunks
       hugepages2Mi: "2Gi"
+      # -- Hugepage memory in 1GiB chunks
+      hugepages1Gi:
     requests:
       # -- Cpu requests for the io-engine
       cpu: ""
       # -- Memory requests for the io-engine
       memory: "1Gi"
-      # -- Hugepage size available on the nodes
+      # -- Hugepage memory in 2MiB chunks
       hugepages2Mi: "2Gi"
+      # -- Hugepage memory in 1GiB chunks
+      hugepages1Gi:
   # -- Set tolerations, overrides global
   tolerations: []
   # -- Set PriorityClass, overrides global


### PR DESCRIPTION
    feat(chart): support 1GiB hugepages
    
    By default we still use the 2MiB hugepages, but now one can add
    requests of 1GiB pages, and can even disable 2MiB pages.
    
---

    fix(chart): specify 2mi hugepages explicitly
    
    This resolves issues when multiple sizes are mounted and this leads into
    flocking issues by dpdk.
    
---

    refactor(chart): reorder containers in pods
    
    Put the "main" container first, making it the default when
    running logs for example.
    This is useful because sometimes users forget to add the -c
    even when we ask them to, and also reduces typing anyhow.
    
---

    fix(chart): typo on io-engine for runtimeClassName
