### PR TITLE
chore: fix typos in etcd upgrade components

### DIFF
--- a/chart/label-etcd-for-helm-release.sh
+++ b/chart/label-etcd-for-helm-release.sh
@@ -254,7 +254,7 @@ parse_args "$@"
 etcd_selector="app.kubernetes.io/name=etcd,\
 app.kubernetes.io/instance=${RELEASE_NAME},\
 helm.sh/chart=etcd-8.6.0,\
-app.kubernetes.io/component!=etcd"\
+app.kubernetes.io/component!=etcd"
 
 # This step needs to happen in the outer scope of this script, so that it's able to exit when it fails.
 # This will exit 0 if there is no StatefulSet of 8.6.0 and w/o the label. This makes the create step idempotent.

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -358,7 +358,7 @@ Get the Events Jetstream Replica Count
 {{/*
 Returns matched if the Etcd StatefulSet is of v8.6.0
 Usage:
-  {{- if include "is_etcd_8.6.0" . }}
+  {{- if include "etcd_is_8.6.0" . }}
     Do something
   {{- end }}
 */}}


### PR DESCRIPTION
Changes:
- Remove trailing line break in the label-etcd-for-helm-release.sh script
- Fix name in usage documentation for etcd_is_8.6.0 helpers templating function