### PR TITLE
Etcd upgrade script tweaks

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -231,7 +231,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | operators.&ZeroWidthSpace;pool.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;cpu | Cpu requests for diskpool operator | `"50m"` |
 | operators.&ZeroWidthSpace;pool.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;memory | Memory requests for diskpool operator | `"16Mi"` |
 | operators.&ZeroWidthSpace;pool.&ZeroWidthSpace;tolerations | Set tolerations, overrides global | `[]` |
-| preUpgradeHook.&ZeroWidthSpace;annotations | This helps in debugging by leaving the Job/Pod instances lying around | <pre>{<br>"helm.sh/hook-delete-policy":"hook-succeeded"<br>}</pre> |
+| preUpgradeHook.&ZeroWidthSpace;enabled | Enable/Disable mayastor pre-upgrade hook | `true` |
 | preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;pullPolicy | The imagePullPolicy for the container | `"IfNotPresent"` |
 | preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;registry | The container image registry URL for the hook job | `"docker.io"` |
 | preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;repo | The container repository for the hook job | `"bitnamilegacy/kubectl"` |

--- a/chart/label-etcd-for-helm-release.sh
+++ b/chart/label-etcd-for-helm-release.sh
@@ -215,6 +215,15 @@ kubectl_ns() {
   fi
 }
 
+# Count the no. of newlines in a string.
+# Arguments:
+#   $1 -- The string to count newlines from
+# Returns:
+#   Count of newlines in the string
+line_count() {
+  [ -n "$1" ] && printf "%s\n" "$1" | wc -l | sed 's/^[[:space:]]*//' || echo 0
+}
+
 # Prints the Yaml to an Etcd StatefulSet
 # Arguments:
 #   $1 -- Kubernetes label selector for the Etcd StatefulSet
@@ -227,7 +236,7 @@ get_etcd_sts_yaml_or_die() {
 -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')" || exit $?
 
   # Make sure that there's just one such StatefulSet.
-  name_count=$(printf "%s" "$sts_name" | grep -c "^")
+  name_count=$(line_count "$sts_name")
   if [ "$name_count" -eq 0 ]; then
     log_with_ns "Nothing to do: no such StatefulSet"
     exit 0

--- a/chart/templates/pre-upgrade-hook.yaml
+++ b/chart/templates/pre-upgrade-hook.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.preUpgradeHook.enabled }}
 {{- if .Release.IsUpgrade }}
 {{- if include "etcd_is_8.6.0" . }}
 apiVersion: v1
@@ -136,5 +137,6 @@ spec:
       {{- if .Values.preUpgradeHook.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.preUpgradeHook.imagePullSecrets | nindent 8 }}
       {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -596,7 +596,7 @@ etcd:
   priorityClassName: ""
   preUpgradeJob:
     annotations:
-      "helm.sh/hook-delete-policy": "hook-succeeded"
+      "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
 loki:
   enabled: true
   # NOTE: For all possible storage options for loki, check https://github.com/openebs/mayastor-extensions/blob/HEAD/chart/loki-storage.md
@@ -945,6 +945,8 @@ localpv-provisioner:
   analytics:
     enabled: true
 preUpgradeHook:
+  # -- Enable/Disable mayastor pre-upgrade hook
+  enabled: true
   # -- Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
@@ -957,9 +959,9 @@ preUpgradeHook:
   podLabels:
     openebs.io/logging: "true"
   # Extra annotations to be added to all the hook resources.
-  # -- This helps in debugging by leaving the Job/Pod instances lying around
+  # This helps in debugging by leaving the Job/Pod instances lying around
   annotations:
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
   image:
     # -- The container image registry URL for the hook job
     registry: docker.io

--- a/k8s/upgrade/src/plugin/objects.rs
+++ b/k8s/upgrade/src/plugin/objects.rs
@@ -189,7 +189,7 @@ pub(crate) fn upgrade_job_cluster_role(
             PolicyRule {
                 api_groups: Some(vec!["batch"].into_vec()),
                 resources: Some(vec!["jobs"].into_vec()),
-                verbs: vec!["create", "list", "delete", "get", "patch"].into_vec(),
+                verbs: vec!["create", "list", "delete", "get", "patch", "watch"].into_vec(),
                 ..Default::default()
             },
             PolicyRule {


### PR DESCRIPTION
`grep` fails with a non-zero exit code when the line count is 0, this triggers the `set -o errexit` to fail the script. Using `wc -l` instead