### PR TITLE
chore: update etcd to 12.0.14 and use bitnamilegacy images

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -56,6 +56,8 @@ annotations:
   helm.sh/images: |
     - name: etcd
       image: docker.io/bitnamilegacy/etcd:3.6.4-debian-12-r0
+    - name: kubectl
+      image: docker.io/bitnamilegacy/kubectl:1.25.15
     - name: alloy
       image: docker.io/grafana/alloy:v1.8.1
     - name: loki

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -30,7 +30,7 @@ dependencies:
     condition: crds.enabled
   - name: etcd
     repository: https://charts.bitnami.com/bitnami
-    version: 12.0.11
+    version: 12.0.14
     condition: etcd.enabled
   - name: jaeger-operator
     version: 2.50.1
@@ -55,7 +55,7 @@ dependencies:
 annotations:
   helm.sh/images: |
     - name: etcd
-      image: docker.io/bitnami/etcd:3.6.2-debian-12-r0
+      image: docker.io/bitnamilegacy/etcd:3.6.4-debian-12-r0
     - name: alloy
       image: docker.io/grafana/alloy:v1.8.1
     - name: loki

--- a/chart/README.md
+++ b/chart/README.md
@@ -55,7 +55,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | Repository | Name | Version |
 |------------|------|---------|
 |  | crds | 0.0.0 |
-| https://charts.bitnami.com/bitnami | etcd | 12.0.11 |
+| https://charts.bitnami.com/bitnami | etcd | 12.0.14 |
 | https://grafana.github.io/helm-charts | alloy | 1.0.1 |
 | https://grafana.github.io/helm-charts | loki | 6.29.0 |
 | https://jaegertracing.github.io/helm-charts | jaeger-operator | 2.50.1 |
@@ -234,7 +234,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | preUpgradeHook.&ZeroWidthSpace;annotations | This helps in debugging by leaving the Job/Pod instances lying around | <pre>{<br>"helm.sh/hook-delete-policy":"hook-succeeded"<br>}</pre> |
 | preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;pullPolicy | The imagePullPolicy for the container | `"IfNotPresent"` |
 | preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;registry | The container image registry URL for the hook job | `"docker.io"` |
-| preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;repo | The container repository for the hook job | `"bitnami/kubectl"` |
+| preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;repo | The container repository for the hook job | `"bitnamilegacy/kubectl"` |
 | preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | The container image tag for the hook job | `"1.25.15"` |
 | preUpgradeHook.&ZeroWidthSpace;imagePullSecrets | Optional array of imagePullSecrets containing private registry credentials # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ | `[]` |
 | preUpgradeHook.&ZeroWidthSpace;tolerations | Node tolerations for server scheduling to nodes with taints # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # | `[]` |

--- a/chart/images.txt
+++ b/chart/images.txt
@@ -1,4 +1,4 @@
-docker.io/bitnami/etcd:3.6.2-debian-12-r0
+docker.io/bitnamilegacy/etcd:3.6.4-debian-12-r0
 docker.io/grafana/alloy:v1.8.1
 docker.io/grafana/loki:3.4.2
 docker.io/openebs/alpine-bash:4.2.0

--- a/chart/images.txt
+++ b/chart/images.txt
@@ -1,4 +1,5 @@
 docker.io/bitnamilegacy/etcd:3.6.4-debian-12-r0
+docker.io/bitnamilegacy/kubectl:1.25.15
 docker.io/grafana/alloy:v1.8.1
 docker.io/grafana/loki:3.4.2
 docker.io/openebs/alpine-bash:4.2.0

--- a/chart/label-etcd-for-helm-release.sh
+++ b/chart/label-etcd-for-helm-release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-# This script was introduced in v2.10.0, to upgrade the 'etcd' dependency helm chart from 8.6.0 to 12.0.11.
+# This script was introduced in v2.10.0, to upgrade the 'etcd' dependency helm chart from 8.6.0 to 12.0.14.
 # The etcd chart, in v8.6.0, used to have a podAntiAffinity section which looked like this, when used with
 #   the 'hard' podAntiAffinityPreset..
 #

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -568,6 +568,8 @@ etcd:
       tag: 4.2.0
       pullSecrets: []
   image:
+    registry: docker.io
+    repository: bitnamilegacy/etcd
     # extra debug information on logs
     debug: false
   # -- Pod anti-affinity preset
@@ -962,7 +964,7 @@ preUpgradeHook:
     # -- The container image registry URL for the hook job
     registry: docker.io
     # -- The container repository for the hook job
-    repo: bitnami/kubectl
+    repo: bitnamilegacy/kubectl
     # -- The container image tag for the hook job
     tag: "1.25.15"
     # -- The imagePullPolicy for the container

--- a/k8s/upgrade/src/helm/chart.rs
+++ b/k8s/upgrade/src/helm/chart.rs
@@ -117,6 +117,8 @@ pub(crate) struct CoreValues {
     /// This contains the sub-chart values for the hostpath provisioner's helm chart.
     #[serde(default, rename(deserialize = "localpv-provisioner"))]
     localpv_provisioner: LocalpvProvisioner,
+    #[serde(default, rename(deserialize = "preUpgradeHook"))]
+    pre_upgrade_hook: PreUpgradeHook,
 }
 
 impl TryFrom<&Path> for CoreValues {
@@ -414,12 +416,44 @@ impl CoreValues {
         self.etcd.image_tag()
     }
 
+    /// Returns the image repository of the etcd container.
+    pub(crate) fn etcd_image_repo(&self) -> &str {
+        self.etcd.image_repository()
+    }
+
     pub(crate) fn etcd_vol_permissions_image_tag(&self) -> &str {
         self.etcd.vol_permissions_image_tag()
     }
 
     pub(crate) fn etcd_vol_permissions_image_repo(&self) -> &str {
         self.etcd.vol_permissions_image_repo()
+    }
+
+    /// Returns the image tag of the etcd container.
+    pub(crate) fn pre_upgrade_hook_image_tag(&self) -> &str {
+        self.pre_upgrade_hook.image_tag()
+    }
+
+    /// Returns the image repository of the etcd container.
+    pub(crate) fn pre_upgrade_hook_image_repo(&self) -> &str {
+        self.pre_upgrade_hook.image_repository()
+    }
+}
+
+/// This is used to deserialize the yaml object preUpgradeHook.
+#[derive(Default, Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+struct PreUpgradeHook {
+    image: GenericImage,
+}
+
+impl PreUpgradeHook {
+    fn image_tag(&self) -> &str {
+        self.image.tag()
+    }
+
+    fn image_repository(&self) -> &str {
+        self.image.repository()
     }
 }
 
@@ -481,6 +515,10 @@ impl Etcd {
 
     fn image_tag(&self) -> &str {
         self.image.tag()
+    }
+
+    fn image_repository(&self) -> &str {
+        self.image.repository()
     }
 
     fn vol_permissions_image_tag(&self) -> &str {

--- a/k8s/upgrade/src/helm/values.rs
+++ b/k8s/upgrade/src/helm/values.rs
@@ -787,6 +787,11 @@ where
         upgrade_values_file.path(),
     )?;
     yq.set_quoted_string_value(
+        YamlKey::try_from(".etcd.image.repository")?,
+        target_values.etcd_image_repo(),
+        upgrade_values_file.path(),
+    )?;
+    yq.set_quoted_string_value(
         YamlKey::try_from(".etcd.image.tag")?,
         target_values.etcd_image_tag(),
         upgrade_values_file.path(),
@@ -794,6 +799,16 @@ where
     yq.set_quoted_string_value(
         YamlKey::try_from(".etcd.volumePermissions.image.tag")?,
         target_values.etcd_vol_permissions_image_tag(),
+        upgrade_values_file.path(),
+    )?;
+    yq.set_quoted_string_value(
+        YamlKey::try_from(".preUpgradeHook.image.repository")?,
+        target_values.pre_upgrade_hook_image_repo(),
+        upgrade_values_file.path(),
+    )?;
+    yq.set_quoted_string_value(
+        YamlKey::try_from(".preUpgradeHook.image.tag")?,
+        target_values.pre_upgrade_hook_image_tag(),
         upgrade_values_file.path(),
     )?;
     yq.set_quoted_string_value(

--- a/scripts/helm/images.sh
+++ b/scripts/helm/images.sh
@@ -164,6 +164,7 @@ case "$COMMAND" in
     # First let's get all images which are statically deployed by the chart. IOW, any images which are part of
     # a pod or pod-controller which gets deployed by the chart.
     $HELM template "$CHART_DIR" --set "$ENABLE_ANALYTICS" --kubeconfig "$CHART_DIR/fake" | grep -Po "^[ \t]*image: \K(.*:.*)$" | tr -d \" | LC_ALL=C sort | uniq > "$TEMPLATE_IMAGES"
+    $HELM template "$CHART_DIR" --set "$ENABLE_ANALYTICS" --kubeconfig "$CHART_DIR/fake" --is-upgrade | grep -Po "^[ \t]*image: \K(.*:.*)$" | tr -d \" | LC_ALL=C sort | uniq >> "$TEMPLATE_IMAGES"
 
     # Second, we handle images which are deployed on-demand by the product and its dependencies.
     # An example of this is the init pod's deployed by the localpv-provisioner in order to prepare the filesystem for


### PR DESCRIPTION
We're moving away from bitnami/etcd and bitnami/kubectl and instead moving bitnamilegacy/etcd and bitnamilegacy/kubectl due to reasons cited here: https://github.com/bitnami/charts/issues/35164