### PR TITLE
fix: move bitnami images to openebs

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -54,8 +54,6 @@ dependencies:
     condition: localpv-provisioner.enabled
 annotations:
   helm.sh/images: |
-    - name: etcd
-      image: docker.io/bitnami/etcd:3.5.6-debian-11-r10
     - name: alloy
       image: docker.io/grafana/alloy:v1.8.1
     - name: loki
@@ -64,6 +62,8 @@ annotations:
       image: docker.io/openebs/alpine-bash:4.2.0
     - name: alpine-sh
       image: docker.io/openebs/alpine-sh:4.2.0
+    - name: etcd
+      image: docker.io/openebs/etcd:3.5.6-debian-11-r10
     - name: mayastor-agent-core
       image: docker.io/openebs/mayastor-agent-core:release-2.9
     - name: mayastor-agent-ha-cluster

--- a/chart/images.txt
+++ b/chart/images.txt
@@ -1,8 +1,8 @@
-docker.io/bitnami/etcd:3.5.6-debian-11-r10
 docker.io/grafana/alloy:v1.8.1
 docker.io/grafana/loki:3.4.2
 docker.io/openebs/alpine-bash:4.2.0
 docker.io/openebs/alpine-sh:4.2.0
+docker.io/openebs/etcd:3.5.6-debian-11-r10
 docker.io/openebs/mayastor-agent-core:release-2.9
 docker.io/openebs/mayastor-agent-ha-cluster:release-2.9
 docker.io/openebs/mayastor-agent-ha-node:release-2.9

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -549,8 +549,11 @@ etcd:
       repository: openebs/alpine-bash
       tag: 4.2.0
       pullSecrets: []
-  # extra debug information on logs
-  debug: false
+  image:
+    registry: docker.io
+    repository: openebs/etcd
+    # extra debug information on logs
+    debug: false
   # -- Pod anti-affinity preset
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   podAntiAffinityPreset: "hard"


### PR DESCRIPTION
The bitnami docker repo is going to be migrated on the 25Nov, so 
let's just move these to our dockerhub since that one is not going anywhere.
We should consider doing this for other dependencies.
