### PR TITLE
Kubectl Plugin: Snapshot Deletion

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -54,10 +54,6 @@ dependencies:
     condition: localpv-provisioner.enabled
 annotations:
   helm.sh/images: |
-    - name: etcd
-      image: docker.io/bitnamilegacy/etcd:3.6.4-debian-12-r0
-    - name: kubectl
-      image: docker.io/bitnamilegacy/kubectl:1.25.15
     - name: alloy
       image: docker.io/grafana/alloy:v1.8.1
     - name: loki
@@ -66,6 +62,10 @@ annotations:
       image: docker.io/openebs/alpine-bash:4.2.0
     - name: alpine-sh
       image: docker.io/openebs/alpine-sh:4.2.0
+    - name: etcd
+      image: docker.io/openebs/etcd:3.6.4-debian-12-r0
+    - name: kubectl
+      image: docker.io/openebs/kubectl:1.25.15
     - name: mayastor-agent-core
       image: docker.io/openebs/mayastor-agent-core:develop
     - name: mayastor-agent-ha-cluster

--- a/chart/README.md
+++ b/chart/README.md
@@ -236,7 +236,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | preUpgradeHook.&ZeroWidthSpace;enabled | Enable/Disable mayastor pre-upgrade hook | `true` |
 | preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;pullPolicy | The imagePullPolicy for the container | `"IfNotPresent"` |
 | preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;registry | The container image registry URL for the hook job | `"docker.io"` |
-| preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;repo | The container repository for the hook job | `"bitnamilegacy/kubectl"` |
+| preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;repo | The container repository for the hook job | `"openebs/kubectl"` |
 | preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | The container image tag for the hook job | `"1.25.15"` |
 | preUpgradeHook.&ZeroWidthSpace;imagePullSecrets | Optional array of imagePullSecrets containing private registry credentials # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ | `[]` |
 | preUpgradeHook.&ZeroWidthSpace;tolerations | Node tolerations for server scheduling to nodes with taints # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # | `[]` |

--- a/chart/images.txt
+++ b/chart/images.txt
@@ -1,9 +1,9 @@
-docker.io/bitnamilegacy/etcd:3.6.4-debian-12-r0
-docker.io/bitnamilegacy/kubectl:1.25.15
 docker.io/grafana/alloy:v1.8.1
 docker.io/grafana/loki:3.4.2
 docker.io/openebs/alpine-bash:4.2.0
 docker.io/openebs/alpine-sh:4.2.0
+docker.io/openebs/etcd:3.6.4-debian-12-r0
+docker.io/openebs/kubectl:1.25.15
 docker.io/openebs/mayastor-agent-core:develop
 docker.io/openebs/mayastor-agent-ha-cluster:develop
 docker.io/openebs/mayastor-agent-ha-node:develop

--- a/chart/shell.nix
+++ b/chart/shell.nix
@@ -2,7 +2,7 @@
     overlays = [ (_: _: { inherit (import ../nix/sources.nix); }) (import ../nix/overlay.nix { }) ];
   }
 }:
-pkgs.mkShell {
+pkgs.mkShellNoCC {
   name = "helm-scripts-shell";
   buildInputs = with pkgs; [
     coreutils

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -30,7 +30,7 @@ image:
   # -- ImagePullPolicy for our images
   pullPolicy: Always
   # -- docker-secrets required to pull images if the container registry from image.registry is protected
-  pullSecrets: []
+  pullSecrets: [ ]
 # -- Node labels for pod assignment
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 # Note that if multi-arch images support 'kubernetes.io/arch: amd64'
@@ -54,7 +54,7 @@ earlyEvictionTolerations:
 # -- Tolerations to be applied to all components except external Chart dependencies.
 # If any component has tolerations set, then it would override this value.
 # For external components like etcd, jaeger and loki, tolerations can only be set at component level.
-tolerations: []
+tolerations: [ ]
 base:
   # -- Request timeout for rest & core agents
   default_req_timeout: 5s
@@ -75,19 +75,19 @@ base:
       pullPolicy: IfNotPresent
     containers:
       - name: agent-core-grpc-probe
-        command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-agent-core 50051; do date; echo "Waiting for agent-core-grpc services..."; sleep 1; done;']
+        command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-agent-core 50051; do date; echo "Waiting for agent-core-grpc services..."; sleep 1; done;' ]
       - name: etcd-probe
-        command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-etcd {{ .Values.etcd.service.ports.client }}; do date; echo "Waiting for etcd..."; sleep 1; done;']
+        command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-etcd {{ .Values.etcd.service.ports.client }}; do date; echo "Waiting for etcd..."; sleep 1; done;' ]
   initHaNodeContainers:
     enabled: true
     containers:
       - name: agent-cluster-grpc-probe
-        command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-agent-core 50052; do date; echo "Waiting for agent-cluster-grpc services..."; sleep 1; done;']
+        command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-agent-core 50052; do date; echo "Waiting for agent-cluster-grpc services..."; sleep 1; done;' ]
   initCoreContainers:
     enabled: true
     containers:
       - name: etcd-probe
-        command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-etcd {{ .Values.etcd.service.ports.client }}; do date; echo "Waiting for etcd..."; sleep 1; done;']
+        command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-etcd {{ .Values.etcd.service.ports.client }}; do date; echo "Waiting for etcd..."; sleep 1; done;' ]
   metrics:
     # -- Enable the metrics exporter
     enabled: true
@@ -104,18 +104,18 @@ base:
       port: 6831
       initContainer:
         - name: jaeger-probe
-          command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 -u {{.Values.base.jaeger.agent.name}} {{.Values.base.jaeger.agent.port}}; do date; echo "Waiting for jaeger..."; sleep 1; done;']
+          command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 -u {{.Values.base.jaeger.agent.name}} {{.Values.base.jaeger.agent.port}}; do date; echo "Waiting for jaeger..."; sleep 1; done;' ]
     collector:
       name: jaeger-collector
       port: 4317
       initContainer:
         - name: jaeger-probe
-          command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 -u {{.Values.base.jaeger.collector.name}} {{.Values.base.jaeger.collector.port}}; do date; echo "Waiting for jaeger..."; sleep 1; done;']
+          command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 -u {{.Values.base.jaeger.collector.name}} {{.Values.base.jaeger.collector.port}}; do date; echo "Waiting for jaeger..."; sleep 1; done;' ]
   initRestContainer:
     enabled: true
     initContainer:
       - name: api-rest-probe
-        command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-api-rest 8081; do date; echo "Waiting for REST API endpoint to become available"; sleep 1; done;']
+        command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-api-rest 8081; do date; echo "Waiting for REST API endpoint to become available"; sleep 1; done;' ]
 operators:
   pool:
     # -- Log level for diskpool operator service
@@ -132,7 +132,7 @@ operators:
         # -- Memory requests for diskpool operator
         memory: "16Mi"
     # -- Set tolerations, overrides global
-    tolerations: []
+    tolerations: [ ]
     # -- Set PriorityClass, overrides global
     priorityClassName: ""
 jaeger-operator:
@@ -148,7 +148,7 @@ jaeger-operator:
   rbac:
     # Create a clusterRole for Jaeger
     clusterRole: true
-  tolerations: []
+  tolerations: [ ]
   priorityClassName: ""
 agents:
   core:
@@ -206,7 +206,7 @@ agents:
         # -- Memory requests for core agents
         memory: "32Mi"
     # -- Set tolerations, overrides global
-    tolerations: []
+    tolerations: [ ]
     # -- Set PriorityClass, overrides global.
     # If both local and global are not set, the final deployment manifest has a mayastor custom critical priority class assigned to the pod by default.
     # Refer the `templates/_helpers.tpl` and `templates/mayastor/agents/core/agent-core-deployment.yaml` for more details.
@@ -241,7 +241,7 @@ agents:
           # -- Memory requests for ha node agent
           memory: "64Mi"
       # -- Set tolerations, overrides global
-      tolerations: []
+      tolerations: [ ]
       # -- Set PriorityClass, overrides global
       priorityClassName: ""
       # -- Container port for the ha-node service
@@ -313,7 +313,7 @@ apis:
         # NodePort associated with https port
         https: 30010
     # -- Set tolerations, overrides global
-    tolerations: []
+    tolerations: [ ]
     # -- Set PriorityClass, overrides global.
     # If both local and global are not set, the final deployment manifest has a mayastor custom critical priority class assigned to the pod by default.
     # Refer the `templates/_helpers.tpl` and `templates/mayastor/apis/rest/api-rest-deployment.yaml` for more details.
@@ -355,7 +355,7 @@ csi:
         # -- Memory requests for csi controller
         memory: "64Mi"
     # -- Set tolerations, overrides global
-    tolerations: []
+    tolerations: [ ]
     # -- Set PriorityClass, overrides global
     priorityClassName: ""
     # -- Prevent modifying the volume mode when creating a PVC from an existing VolumeSnapshot
@@ -403,14 +403,14 @@ csi:
     restClient:
       enabled: true
     # -- Set tolerations, overrides global
-    tolerations: []
+    tolerations: [ ]
     # -- Set PriorityClass, overrides global
     priorityClassName: ""
     initContainers:
       enabled: false
       containers:
         - name: nvme-tcp-probe
-          command: ['sh', '-c', 'trap "exit 1" TERM; until [ -d /sys/module/nvme_tcp ]; do [ -z "$WARNED" ] && echo "nvme_tcp module not loaded..."; WARNED=1; sleep 60; done;']
+          command: [ 'sh', '-c', 'trap "exit 1" TERM; until [ -d /sys/module/nvme_tcp ]; do [ -z "$WARNED" ] && echo "nvme_tcp module not loaded..."; WARNED=1; sleep 60; done;' ]
     # -- Container port for the csi-node service
     port: 10199
 io_engine:
@@ -461,7 +461,7 @@ io_engine:
   cpuCount: "2"
   # -- If not empty, overrides the cpuCount and explicitly sets the list of cores.
   # Example: --set='io_engine.coreList={30,31}'
-  coreList: []
+  coreList: [ ]
   # -- Node selectors to designate storage nodes for diskpool creation
   # Note that if multi-arch images support 'kubernetes.io/arch: amd64'
   # should be removed.
@@ -488,7 +488,7 @@ io_engine:
       # -- Hugepage memory in 1GiB chunks
       hugepages1Gi:
   # -- Set tolerations, overrides global
-  tolerations: []
+  tolerations: [ ]
   # -- Set PriorityClass, overrides global
   priorityClassName: ""
   # -- Runtime class to use. Defaults to cluster standard
@@ -575,10 +575,10 @@ etcd:
       registry: docker.io
       repository: openebs/alpine-bash
       tag: 4.2.0
-      pullSecrets: []
+      pullSecrets: [ ]
   image:
     registry: docker.io
-    repository: bitnamilegacy/etcd
+    repository: openebs/etcd
     # extra debug information on logs
     debug: false
   # -- Pod anti-affinity preset
@@ -586,7 +586,7 @@ etcd:
   podAntiAffinityPreset: "hard"
   ## -- nodeSelector [object] Node labels for pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-  nodeSelector: {}
+  nodeSelector: { }
   # etcd service parameters defines how the etcd service is exposed
   service:
     # K8s service type
@@ -601,7 +601,7 @@ etcd:
       # Port from where etcd endpoints are accessible from outside cluster
       client: 31379
       peer: ""
-  tolerations: []
+  tolerations: [ ]
   priorityClassName: ""
   preUpgradeJob:
     annotations:
@@ -906,7 +906,7 @@ obs:
         # -- Memory requests for callhome
         memory: "16Mi"
     # -- Set tolerations, overrides global
-    tolerations: []
+    tolerations: [ ]
     # -- Set PriorityClass, overrides global
     priorityClassName: ""
   # Eventing component enabled/disabled based on obs.callhome.enabled value
@@ -959,10 +959,10 @@ preUpgradeHook:
   # -- Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
-  tolerations: []
+  tolerations: [ ]
   # -- Optional array of imagePullSecrets containing private registry credentials
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-  imagePullSecrets: []
+  imagePullSecrets: [ ]
   # - name: secretName
   # Labels to be added to the Job Pod.
   podLabels:
@@ -975,7 +975,7 @@ preUpgradeHook:
     # -- The container image registry URL for the hook job
     registry: docker.io
     # -- The container repository for the hook job
-    repo: bitnamilegacy/kubectl
+    repo: openebs/kubectl
     # -- The container image tag for the hook job
     tag: "1.25.15"
     # -- The imagePullPolicy for the container

--- a/k8s/plugin/src/resources/mod.rs
+++ b/k8s/plugin/src/resources/mod.rs
@@ -1,8 +1,9 @@
 use anyhow::anyhow;
 use clap::Parser;
 use k8s_openapi::api::core::v1 as core_v1;
+use kube::api::GroupVersionKind;
 use openapi::tower::client::Url;
-use plugin::resources::VolumeId;
+use plugin::resources::{snapshot, VolumeId};
 use plugin::{
     resources::{
         CordonResources, DrainResources, GetResources, LabelResources, ScaleResources,
@@ -50,6 +51,20 @@ impl CliArgs {
     /// Get the [`core_v1::PersistentVolume`] api client for the client namespace.
     pub async fn pv_api(&self) -> anyhow::Result<kube::Api<core_v1::PersistentVolume>> {
         Ok(kube::Api::all(self.client().await?))
+    }
+    fn snap_content(&self) -> kube::api::ApiResource {
+        kube::api::ApiResource::from_gvk(&GroupVersionKind {
+            group: "snapshot.storage.k8s.io".into(),
+            version: "v1".into(),
+            kind: "VolumeSnapshotContent".into(),
+        })
+    }
+    /// Get the cluster-scoped `VolumeSnapshotContent` [`kube::api::DynamicObject`] api client.
+    pub async fn snap_content_api(&self) -> anyhow::Result<kube::Api<kube::api::DynamicObject>> {
+        Ok(kube::Api::all_with(
+            self.client().await?,
+            &self.snap_content(),
+        ))
     }
 }
 
@@ -126,6 +141,8 @@ pub enum DeleteResources {
         /// The id of the volume to delete.
         id: VolumeId,
     },
+    /// Deletes the specified volume snapshot resource.
+    VolumeSnapshot(snapshot::DelVolumeSnapshotArgs),
 }
 
 #[async_trait::async_trait(?Send)]
@@ -190,6 +207,32 @@ impl ExecuteOperation for Operations {
                             ignore_not_found: args.ignore_not_found,
                             yes: args.yes,
                             resource: plugin::resources::DeleteResources::Volume { id: *id },
+                        }
+                        .execute(cli_args)
+                        .await?
+                    }
+                    DeleteResources::VolumeSnapshot(snap_args) => {
+                        // 1. ensure the K8s VolumeSnapshotContent CR is not present.
+                        let vsc_name = format!("snapcontent-{}", snap_args.snapshot);
+                        let client = cli_args.snap_content_api().await?;
+                        let vsc = client.get_opt(&vsc_name).await.map_err(|error| {
+                            anyhow::anyhow!(
+                                "Failed to fetch VSC {vsc_name} from K8s api-server: {error}"
+                            )
+                        })?;
+                        if vsc.is_some() {
+                            return Err(Error::Generic(anyhow::anyhow!(
+                                "The volume snapshot is still being referenced by VSC {vsc_name}"
+                            )));
+                        }
+
+                        // 2. go ahead and try to delete the mayastor volume snapshot
+                        plugin::resources::DeleteArgs {
+                            ignore_not_found: args.ignore_not_found,
+                            yes: args.yes,
+                            resource: plugin::resources::DeleteResources::VolumeSnapshot(
+                                snap_args.clone(),
+                            ),
                         }
                         .execute(cli_args)
                         .await?

--- a/scripts/k8s/shell.nix
+++ b/scripts/k8s/shell.nix
@@ -5,7 +5,7 @@
 let
   inPureNixShell = builtins.getEnv "IN_NIX_SHELL" == "pure";
 in
-pkgs.mkShell {
+pkgs.mkShellNoCC {
   name = "k8s-cluster-shell";
   buildInputs = with pkgs; [
     kubernetes-helm-wrapped

--- a/shell.nix
+++ b/shell.nix
@@ -40,7 +40,7 @@ let
     utillinux
   ] ++ pkgs.lib.optional (usePreCommit) pre-commit;
 in
-pkgs.mkShell {
+pkgs.mkShellNoCC {
   name = "extensions-shell";
   buildInputs = buildInputs ++ pkgs.lib.optional (!norust) rust
     ++ k8sShellAttrs.buildInputs ++ helmShellAttrs.buildInputs ++ bddShellAttrs.buildInputs
@@ -54,7 +54,7 @@ pkgs.mkShell {
   # copy the rust toolchain to a writable directory, see: https://github.com/rust-lang/cargo/issues/10096
   # the whole toolchain is copied to allow the src to be retrievable through "rustc --print sysroot"
   RUST_TOOLCHAIN = ".rust-toolchain/${rust.version}";
-  RUST_TOOLCHAIN_NIX = "${rust}";
+  RUST_TOOLCHAIN_NIX = pkgs.lib.optional (!norust) "${rust}";
 
   shellHook = ''
     ./scripts/nix/git-submodule-init.sh
@@ -72,5 +72,7 @@ pkgs.mkShell {
 
     rust_version="${rust.version}" rustup_channel="${lib.strings.concatMapStringsSep "-" (x: x) (lib.lists.drop 1 (lib.strings.splitString "-" rust.version))}" \
     dev_rustup="${toString (devrustup)}" devrustup_moth="${devrustup_moth}" . "$CTRL_SRC"/scripts/rust/env-setup.sh
+    unset CC
+    unset AR
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -14,6 +14,11 @@ let
   channel = import ./nix/lib/rust.nix { inherit pkgs; };
   rust_chan = channel.default_src;
   rust = rust_chan.${rust-profile};
+  usePreCommit = builtins.getEnv "IN_NIX_SHELL" == "impure" && builtins.getEnv "CI" != "1";
+  pre-commit = pkgs.runCommand "pre-commit" { } ''
+    mkdir -p $out/bin
+    cp ${pkgs.pre-commit}/bin/pre-commit $out/bin/pre-commit
+  '';
   k8sShellAttrs = import ./scripts/k8s/shell.nix { inherit pkgs; };
   helmShellAttrs = import ./chart/shell.nix { inherit pkgs; };
   bddShellAttrs = import ./tests/bdd/shell.nix { inherit pkgs; };
@@ -32,9 +37,8 @@ let
     paperclip
     openssl
     pkg-config
-    pre-commit
     utillinux
-  ];
+  ] ++ pkgs.lib.optional (usePreCommit) pre-commit;
 in
 pkgs.mkShell {
   name = "extensions-shell";
@@ -54,7 +58,7 @@ pkgs.mkShell {
 
   shellHook = ''
     ./scripts/nix/git-submodule-init.sh
-    if [ "$CI" != "1" ] && [ "$IN_NIX_SHELL" == "impure" ]; then
+    if [ "${toString usePreCommit}" = "1" ]; then
       echo
       pre-commit install
       pre-commit install --hook commit-msg


### PR DESCRIPTION
    chore: use stdenv with no CC in the nix-shell
    
    This reduces the derivation size when not using internal rust and also
    can prevent ring rebuilds due to CC env var mismatch.

---

    fix: move bitnami images to openebs
    
    The bitnami docker repo is going to be migrated on the 25Nov, so
    let's just move these to our dockerhub since that one is not going anywhere.
    We should consider doing this for other dependencies.

---

    chore: add pre-commit trampoline
    
    Allows us to erase the the references which pre-commit now seems
    to leave around and which interfere with nix-shell and venv.
    
----

    feat: add snapshot delete subcommand
    
    Similar to the volume, it first ensures that the volumesnapshotcontent is
    not present! If it is, then it bails out with an error.
