### PR TITLE
feat(k8s-plugin): add support for kubeconfig context switching

### DIFF
--- a/k8s/plugin/src/main.rs
+++ b/k8s/plugin/src/main.rs
@@ -18,6 +18,10 @@ struct CliArgs {
     #[clap(global = true, long, short = 'n')]
     namespace: Option<String>,
 
+    /// Kubernetes context to use.
+    #[clap(global = true, long)]
+    context: Option<String>,
+
     #[clap(flatten)]
     args: resources::CliArgs,
 
@@ -38,10 +42,15 @@ impl CliArgs {
         if let Operations::Dump(ref mut dump_args) = args.operations {
             dump_args.args.set_kube_config_path(path);
         }
+        args.args.context = args.context.clone();
         args.args.namespace = if let Some(namespace) = &args.namespace {
             namespace.to_string()
         } else if args.namespace_from_context {
-            let client = kube_proxy::client_from_kubeconfig(args.kube_config_path.clone()).await?;
+            let client = kube_proxy::client_from_kubeconfig(
+                args.kube_config_path.clone(),
+                args.context.clone(),
+            )
+            .await?;
             client.default_namespace().to_string()
         } else {
             constants::DEFAULT_PLUGIN_NAMESPACE.to_string()

--- a/k8s/plugin/src/resources/mod.rs
+++ b/k8s/plugin/src/resources/mod.rs
@@ -35,6 +35,10 @@ pub struct CliArgs {
     #[clap(skip)]
     pub namespace: String,
 
+    /// Kubernetes context in the kubeconfig file.
+    #[clap(skip)]
+    pub context: Option<String>,
+
     #[clap(flatten)]
     pub cli_args: plugin::CliArgs,
 }
@@ -42,7 +46,8 @@ pub struct CliArgs {
 impl CliArgs {
     /// The kube client, with the correct install namespace.
     pub async fn client(&self) -> anyhow::Result<kube::Client> {
-        let mut config = kube_proxy::config_from_kubeconfig(self.kubeconfig.clone()).await?;
+        let opts = kube_proxy::kubeconfig_options_from_context(self.context.clone());
+        let mut config = kube_proxy::config_from_kubeconfig(self.kubeconfig.clone(), opts).await?;
         // If taking namespace from context, we already know self.namespace has been set
         // from the context.
         config.default_namespace = self.namespace.clone();
@@ -294,6 +299,7 @@ pub async fn init_rest(cli_args: &CliArgs) -> Result<(), Error> {
         None => {
             let config = kube_proxy::ConfigBuilder::default_api_rest()
                 .with_kube_config(cli_args.kubeconfig.clone())
+                .with_context(cli_args.context.clone())
                 .with_timeout(*cli_args.timeout)
                 .with_target_mod(|t| t.with_namespace(&cli_args.namespace))
                 .build()


### PR DESCRIPTION
Providing a new argument to choose between different kubeconfig contexts. 

<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
The idea behind is that user can be storing multiple clusters or environments in a single kubeconfig file and just switching context when wants to use specific one.

However, currently mayastor plugin doesn't support such change and it's always executed against `current-context`, which is inconvinient.

This PR is trying to add option/argument to allow user to specify a different context (as with kubectl) instead of the default one (`current-context`).

Depends on https://github.com/openebs/mayastor-control-plane/pull/1018

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is useful in case of single kubeconfig file with multiple contexts (e.g. clusters).


## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> No

<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested against several kind servers all in a single kubeconfig.
Tested with both provided and not provided context (e.g. use current one).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.