### PR TITLE
fix: Use normalized etcdUrl in default etcd-probe init containers

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -77,7 +77,7 @@ base:
       - name: agent-core-grpc-probe
         command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-agent-core 50051; do date; echo "Waiting for agent-core-grpc services..."; sleep 1; done;' ]
       - name: etcd-probe
-        command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-etcd {{ .Values.etcd.service.ports.client }}; do date; echo "Waiting for etcd..."; sleep 1; done;' ]
+        command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ include "etcdUrl" . }} {{ .Values.etcd.service.ports.client }}; do date; echo "Waiting for etcd..."; sleep 1; done;' ]
   initHaNodeContainers:
     enabled: true
     containers:
@@ -87,7 +87,7 @@ base:
     enabled: true
     containers:
       - name: etcd-probe
-        command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-etcd {{ .Values.etcd.service.ports.client }}; do date; echo "Waiting for etcd..."; sleep 1; done;' ]
+        command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ include "etcdUrl" . }} {{ .Values.etcd.service.ports.client }}; do date; echo "Waiting for etcd..."; sleep 1; done;' ]
   metrics:
     # -- Enable the metrics exporter
     enabled: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
This change uses the existing `{{ include "etcdUrl" . }}` helper instead of a hardcoded `{{ .Release.Name }}-etcd` value for `etcd-probe` init containers in the default `values.yaml`, enabling a more seamless usage of the `etcd.externalUrl` value when brining your own `etcd` service to an installation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This solves the problem where providing an `etcd.externalUrl` also requires explicitly setting `base.initContainers.containers[1/etcd-probe].command` and `base.initCoreContainers.containers[0/etcd-probe].command`
<!--- If it fixes an open issue, please link to the issue here. -->


## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
`No`, this does not fix a regression.
<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my own `microk8s` deployment, using the `https://openebs.github.io/openebs/openebs@4.3.2` helm chart.

Usage/style of the existing `{{ include "etcdUrl" . }}` helper was observed in `chart/templates/mayastor/agents/core/agent-core-deployment.yaml`, in the `--store` arg for the `agent-core` and `agent-ha-cluster` containers.

No other instances of a hardcoded `{{ .Release.Name }}-etcd` value were found in the codebase.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.