### PR TITLE
ci: don't docker login without the secrets

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -8,6 +8,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   CI: 1
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
 jobs:
   helm-chart-test:
@@ -50,6 +51,7 @@ jobs:
         run: nix-shell ./scripts/helm/shell.nix --run "./scripts/helm/images.sh generate --dependency-update --exit-code"
       - name: Login to Docker Hub
         uses: docker/login-action@v3
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
When an external contrib raises a PR from fork, the secrets will not be available on PR actions.
In this case we can skip the docker login.
This may however go into pull rate limits...
Anyhow this action also runs on bors, so it's probably fine.