### PR TITLE
refactor(plugin/support): add wrapper for kubeconfig path and opts

### DIFF
--- a/k8s/plugin/src/main.rs
+++ b/k8s/plugin/src/main.rs
@@ -40,17 +40,15 @@ impl CliArgs {
         let path = args.kube_config_path.clone();
         args.args.kubeconfig = path.clone();
         if let Operations::Dump(ref mut dump_args) = args.operations {
-            dump_args.args.set_kube_config_path(path);
+            dump_args
+                .args
+                .set_kube_config(path.clone(), args.context.clone());
         }
         args.args.context = args.context.clone();
         args.args.namespace = if let Some(namespace) = &args.namespace {
             namespace.to_string()
         } else if args.namespace_from_context {
-            let client = kube_proxy::client_from_kubeconfig(
-                args.kube_config_path.clone(),
-                args.context.clone(),
-            )
-            .await?;
+            let client = kube_proxy::client_from_kubeconfig(path, args.context.clone()).await?;
             client.default_namespace().to_string()
         } else {
             constants::DEFAULT_PLUGIN_NAMESPACE.to_string()

--- a/k8s/plugin/src/resources/mod.rs
+++ b/k8s/plugin/src/resources/mod.rs
@@ -182,6 +182,7 @@ impl ExecuteOperation for Operations {
                 preflight_validations::preflight_check(
                     &cli_args.namespace,
                     cli_args.kubeconfig.clone(),
+                    cli_args.context.clone(),
                     cli_args.timeout,
                     resources,
                 )

--- a/k8s/supportability/src/collect/common.rs
+++ b/k8s/supportability/src/collect/common.rs
@@ -15,8 +15,8 @@ pub struct DumpConfig {
     etcd_uri: Option<String>,
     /// Period states to collect logs from specified duration
     since: humantime::Duration,
-    /// Path to kubeconfig file, which requires to interact with Kube-Apiserver
-    kube_config_path: Option<std::path::PathBuf>,
+    /// The kubeconfig options
+    kubeconfig: crate::KubeConfigArgs,
     /// Specifies the timeout value to interact with other systems
     timeout: humantime::Duration,
     /// Specfies the output format, i.e tar, stdout.
@@ -37,7 +37,7 @@ impl DumpConfig {
     /// * `loki_uri` - Optional address of the Loki service endpoint.
     /// * `etcd_uri` - Optional address of the etcd service endpoint.
     /// * `since` - Duration from which to collect logs.
-    /// * `kube_config_path` - Optional path to the kubeconfig file.
+    /// * `kubeconfig` - kubeconfig file and options.
     /// * `timeout` - Timeout duration for interacting with external systems.
     /// * `output_format` - Output format (e.g., tar, stdout).
     /// * `tenant_id` - Tenant ID used while querying.
@@ -49,7 +49,7 @@ impl DumpConfig {
         loki_uri: Option<String>,
         etcd_uri: Option<String>,
         since: humantime::Duration,
-        kube_config_path: Option<std::path::PathBuf>,
+        kubeconfig: crate::KubeConfigArgs,
         timeout: humantime::Duration,
         output_format: OutputFormat,
         tenant_id: String,
@@ -61,7 +61,7 @@ impl DumpConfig {
             loki_uri,
             etcd_uri,
             since,
-            kube_config_path,
+            kubeconfig,
             timeout,
             output_format,
             tenant_id,
@@ -94,9 +94,19 @@ impl DumpConfig {
         &self.since
     }
 
+    /// Returns a reference to the [`crate::KubeConfigArgs`].
+    pub fn kubeconfig(&self) -> &crate::KubeConfigArgs {
+        &self.kubeconfig
+    }
+
     /// Returns the optional path to the kubeconfig file used to interact with the Kube-Apiserver.
     pub fn kube_config_path(&self) -> Option<&std::path::PathBuf> {
-        self.kube_config_path.as_ref()
+        self.kubeconfig.path.as_ref()
+    }
+
+    /// Returns the optional context to the kubeconfig file used to interact with the Kube-Apiserver.
+    pub fn kube_config_opts(&self) -> &kube::config::KubeConfigOptions {
+        &self.kubeconfig.opts
     }
 
     /// Returns the timeout duration used to interact with external systems.

--- a/k8s/supportability/src/collect/k8s_resources/client.rs
+++ b/k8s/supportability/src/collect/k8s_resources/client.rs
@@ -82,16 +82,16 @@ pub struct ClientSet {
 impl ClientSet {
     /// Create a new ClientSet, from the config file if provided, otherwise with default.
     pub(crate) async fn new(
-        kube_config_path: Option<std::path::PathBuf>,
+        kubeconfig: crate::KubeConfigArgs,
         namespace: String,
     ) -> Result<Self, K8sResourceError> {
-        let config = match kube_config_path {
+        let config = match kubeconfig.path {
             Some(config_path) => {
                 let kube_config = kube::config::Kubeconfig::read_from(&config_path)
                     .map_err(|e| -> K8sResourceError { e.into() })?;
-                kube::Config::from_custom_kubeconfig(kube_config, &Default::default()).await?
+                kube::Config::from_custom_kubeconfig(kube_config, &kubeconfig.opts).await?
             }
-            None => kube::Config::infer().await?,
+            None => kube::Config::from_kubeconfig(&kubeconfig.opts).await?,
         };
         let client = Client::try_from(config)?;
         Ok(Self { client, namespace })

--- a/k8s/supportability/src/collect/k8s_resources/k8s_resource_dump.rs
+++ b/k8s/supportability/src/collect/k8s_resources/k8s_resource_dump.rs
@@ -97,10 +97,10 @@ impl EntityName for StatefulSet {
 impl K8sResourceDumperClient {
     /// get a new k8s resource dumper client
     pub(crate) async fn new(
-        kube_config_path: Option<std::path::PathBuf>,
+        kubeconfig_args: crate::KubeConfigArgs,
         namespace: String,
     ) -> Result<Self, K8sResourceDumperError> {
-        let k8s_client = ClientSet::new(kube_config_path, namespace).await?;
+        let k8s_client = ClientSet::new(kubeconfig_args, namespace).await?;
         Ok(Self { k8s_client })
     }
 

--- a/k8s/supportability/src/collect/logs/loki.rs
+++ b/k8s/supportability/src/collect/logs/loki.rs
@@ -140,7 +140,7 @@ impl LokiClient {
     /// Instantiate new instance of Http Loki client
     pub(crate) async fn new(
         uri: Option<String>,
-        kube_config_path: Option<std::path::PathBuf>,
+        kubeconfig_args: crate::KubeConfigArgs,
         namespace: String,
         since: humantime::Duration,
         timeout: humantime::Duration,
@@ -149,7 +149,8 @@ impl LokiClient {
         let (uri, client) = match uri {
             None => {
                 let (uri, svc) = match kube_proxy::ConfigBuilder::default_loki()
-                    .with_kube_config(kube_config_path)
+                    .with_kube_config(kubeconfig_args.path.clone())
+                    .with_context(kubeconfig_args.opts.context.clone())
                     .with_target_mod(|t| t.with_namespace(namespace))
                     .build()
                     .await

--- a/k8s/supportability/src/collect/logs/mod.rs
+++ b/k8s/supportability/src/collect/logs/mod.rs
@@ -84,18 +84,18 @@ impl LogCollection {
     /// param 'timeout' --> Specifies the timeout while interacting with Loki Service
     /// param 'tenant_id' --> Specifies the tenant_id while interacting with Loki Service
     pub(crate) async fn new_logger(
-        kube_config_path: Option<std::path::PathBuf>,
+        kubeconfig_args: crate::KubeConfigArgs,
         namespace: String,
         loki_uri: Option<String>,
         since: humantime::Duration,
         timeout: humantime::Duration,
         tenant_id: String,
     ) -> Result<Box<dyn Logger>, LogError> {
-        let client_set = ClientSet::new(kube_config_path.clone(), namespace.clone()).await?;
+        let client_set = ClientSet::new(kubeconfig_args.clone(), namespace.clone()).await?;
         Ok(Box::new(Self {
             loki_client: loki::LokiClient::new(
                 loki_uri,
-                kube_config_path,
+                kubeconfig_args,
                 namespace,
                 since,
                 timeout,

--- a/k8s/supportability/src/collect/persistent_store/etcd.rs
+++ b/k8s/supportability/src/collect/persistent_store/etcd.rs
@@ -16,11 +16,11 @@ impl EtcdStore {
     /// The provided namespace will be used to search for etcd service, if the
     /// etcd point is not provided
     pub(crate) async fn new(
-        kube_config_path: Option<std::path::PathBuf>,
+        kubeconfig: crate::KubeConfigArgs,
         etcd_endpoint: Option<String>,
         namespace: String,
     ) -> Result<Self, EtcdError> {
-        let client_set = ClientSet::new(kube_config_path.clone(), namespace.clone()).await?;
+        let client_set = ClientSet::new(kubeconfig.clone(), namespace.clone()).await?;
         let platform_info =
             platform::k8s::K8s::from_custom(client_set.kube_client(), client_set.namespace())
                 .await
@@ -33,7 +33,8 @@ impl EtcdStore {
             endpoint
         } else {
             let uri = kube_proxy::ConfigBuilder::default_etcd()
-                .with_kube_config(kube_config_path)
+                .with_kube_config(kubeconfig.path)
+                .with_context(kubeconfig.opts.context)
                 .with_target_mod(|t| t.with_namespace(namespace))
                 .build()
                 .await

--- a/k8s/supportability/src/collect/resource_dump.rs
+++ b/k8s/supportability/src/collect/resource_dump.rs
@@ -71,7 +71,7 @@ impl ResourceDumper {
         };
 
         let etcd_dumper = match EtcdStore::new(
-            config.kube_config_path().cloned(),
+            config.kubeconfig().clone(),
             config.etcd_uri().cloned(),
             config.namespace().to_string(),
         )

--- a/k8s/supportability/src/collect/system_dump.rs
+++ b/k8s/supportability/src/collect/system_dump.rs
@@ -71,7 +71,7 @@ impl SystemDumper {
         };
 
         let logger = match LogCollection::new_logger(
-            config.kube_config_path().cloned(),
+            config.kubeconfig().clone(),
             config.namespace().to_string(),
             config.loki_uri().cloned(),
             *config.since(),
@@ -90,7 +90,7 @@ impl SystemDumper {
         };
 
         let k8s_resource_dumper = match K8sResourceDumperClient::new(
-            config.kube_config_path().cloned(),
+            config.kubeconfig().clone(),
             config.namespace().to_string(),
         )
         .await
@@ -105,7 +105,7 @@ impl SystemDumper {
         };
 
         let etcd_dumper = match EtcdStore::new(
-            config.kube_config_path().cloned(),
+            config.kubeconfig().clone(),
             config.etcd_uri().cloned(),
             config.namespace().to_string(),
         )
@@ -120,6 +120,7 @@ impl SystemDumper {
 
         let rest_client = match kube_proxy::ConfigBuilder::default_api_rest()
             .with_kube_config(config.kube_config_path().cloned())
+            .with_context(config.kube_config_opts().context.clone())
             .with_timeout(Some((*config.timeout()).into()))
             .with_target_mod(|t| t.with_namespace(config.namespace()))
             .build()

--- a/k8s/supportability/src/lib.rs
+++ b/k8s/supportability/src/lib.rs
@@ -43,7 +43,7 @@ pub struct SupportArgs {
 
     /// Path to kubeconfig file.
     #[clap(skip)]
-    kubeconfig: Option<PathBuf>,
+    kubeconfig: KubeConfigArgs,
 
     /// The tenant id to be used to query loki logs.
     #[clap(global = true, long, default_value = "openebs")]
@@ -55,13 +55,20 @@ pub struct SupportArgs {
 }
 
 impl SupportArgs {
-    /// Sets the path to the kubeconfig file used to interact with the Kube-Apiserver.
+    /// Sets the kubeconfig file and context name, used to interact with the Kube-Apiserver.
     ///
     /// # Arguments
     ///
     /// * `path` - An optional `PathBuf` representing the kubeconfig path.
-    pub fn set_kube_config_path(&mut self, path: Option<std::path::PathBuf>) {
-        self.kubeconfig = path;
+    /// * `context` - An optional context in the kubeconfig file.
+    pub fn set_kube_config(&mut self, path: Option<std::path::PathBuf>, context: Option<String>) {
+        self.kubeconfig = crate::KubeConfigArgs {
+            path,
+            opts: kube::config::KubeConfigOptions {
+                context,
+                ..Default::default()
+            },
+        };
     }
 }
 
@@ -103,7 +110,7 @@ pub(crate) const ARCHIVE_PREFIX: &str = "mayastor";
 
 async fn execute_resource_dump(
     cli_args: SupportArgs,
-    kube_config_path: Option<PathBuf>,
+    kubeconfig: crate::KubeConfigArgs,
     resource: Resource,
 ) -> Result<(), Error> {
     let mut config = DumpConfig::new(
@@ -112,7 +119,7 @@ async fn execute_resource_dump(
         cli_args.loki_endpoint,
         cli_args.etcd_endpoint,
         cli_args.since,
-        kube_config_path,
+        kubeconfig,
         cli_args.timeout,
         OutputFormat::Tar,
         cli_args.tenant_id,
@@ -178,4 +185,21 @@ async fn execute_resource_dump(
     }
     println!("Completed collection of dump !!");
     Ok(())
+}
+
+/// Kubeconfig arguments.
+#[derive(Default, Clone)]
+pub struct KubeConfigArgs {
+    /// The path to the kubeconfig file, otherwise it's inferred.
+    path: Option<PathBuf>,
+    /// Options used when loading the kubeconfig file.
+    opts: kube::config::KubeConfigOptions,
+}
+
+impl std::fmt::Debug for KubeConfigArgs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KubeConfigOpts")
+            .field("kubeconfig", &self.path)
+            .finish()
+    }
 }

--- a/k8s/upgrade/src/plugin/preflight_validations.rs
+++ b/k8s/upgrade/src/plugin/preflight_validations.rs
@@ -22,13 +22,15 @@ use utils::version_info;
 pub async fn preflight_check(
     namespace: &str,
     kube_config_path: Option<PathBuf>,
+    context: Option<String>,
     timeout: humantime::Duration,
     resources: &UpgradeArgs,
 ) -> error::Result<()> {
     console_logger::info(user_prompt::UPGRADE_WARNING, "");
     // Initialise the REST client.
     let config = kube_proxy::ConfigBuilder::default_api_rest()
-        .with_kube_config(kube_config_path.clone())
+        .with_kube_config(kube_config_path)
+        .with_context(context)
         .with_timeout(*timeout)
         .with_target_mod(|t| t.with_namespace(namespace))
         .build()


### PR DESCRIPTION
We're now parsing the context name, but this was not passed to the support bundle.
Rather than passing more arguments, create a new type which includes the path and the options.
