### PR TITLE
fix: move bitnami images to openebs

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -559,9 +559,11 @@ etcd:
       repository: openebs/alpine-bash
       tag: 4.1.0
       pullSecrets: []
-  # extra debug information on logs
-  debug: false
-
+  image:
+    registry: docker.io
+    repository: openebs/etcd
+    # extra debug information on logs
+    debug: false
   # -- Pod anti-affinity preset
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   podAntiAffinityPreset: "hard"

--- a/k8s/upgrade/src/common/constants.rs
+++ b/k8s/upgrade/src/common/constants.rs
@@ -60,3 +60,6 @@ pub(crate) const TWO_DOT_SEVEN_DOT_TWO: &str = "2.7.2";
 
 /// Version value for 2.7.3.
 pub(crate) const TWO_DOT_SEVEN_DOT_THREE: &str = "2.7.3";
+
+/// Version value for 2.7.8.
+pub(crate) const TWO_DOT_SEVEN_DOT_EIGHT: &str = "2.7.8";

--- a/k8s/upgrade/src/helm/chart.rs
+++ b/k8s/upgrade/src/helm/chart.rs
@@ -71,6 +71,8 @@ pub(crate) struct CoreValues {
     agents: Agents,
     /// This contains values for all the base components.
     base: Base,
+    /// This contains values for all of the Etcd components,
+    etcd: Etcd,
     /// This is the yaml object which contains values for the container image registry, repository,
     /// tag, etc.
     image: Image,
@@ -324,6 +326,36 @@ impl CoreValues {
     /// updated image tag.
     pub(crate) fn jaeger_operator_image_tag(&self) -> &str {
         self.jaeger_operator.image_tag()
+    }
+
+    /// Returns the value of .etcd.debug (as seen on etcd chart v8.6.0).
+    pub(crate) fn etcd_deprecated_debug_logs(&self) -> Option<bool> {
+        self.etcd.deprecated_debug_logs()
+    }
+
+    /// Returns the image repository of the etcd container.
+    pub(crate) fn etcd_image_repo(&self) -> &str {
+        self.etcd.image_repository()
+    }
+}
+
+/// This is used to deserialize the yaml object etcd.
+#[derive(Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+struct Etcd {
+    image: GenericImage,
+    #[serde(rename(deserialize = "debug"))]
+    deprecated_debug: Option<bool>,
+}
+
+impl Etcd {
+    /// Returns the value of .etcd.autoCompactionRetention.
+    fn deprecated_debug_logs(&self) -> Option<bool> {
+        self.deprecated_debug
+    }
+
+    fn image_repository(&self) -> &str {
+        self.image.repository()
     }
 }
 
@@ -1177,12 +1209,18 @@ impl LocalpvProvisionerLocalpv {
 struct GenericImage {
     #[serde(default)]
     tag: String,
+    #[serde(default)]
+    repository: String,
 }
 
 impl GenericImage {
-    /// This is getter for the various container image tags in the localpv-provisioner helm chart.
+    /// This is getter for various container image tags.
     fn tag(&self) -> &str {
         self.tag.as_str()
+    }
+    /// This is a getter for the various container image repositories.
+    fn repository(&self) -> &str {
+        self.repository.as_str()
     }
 }
 

--- a/k8s/upgrade/src/helm/values.rs
+++ b/k8s/upgrade/src/helm/values.rs
@@ -2,7 +2,8 @@ use crate::{
     common::{
         constants::{
             KUBE_API_PAGE_SIZE, TWO_DOT_FIVE, TWO_DOT_FOUR, TWO_DOT_ONE, TWO_DOT_O_RC_ONE,
-            TWO_DOT_SEVEN_DOT_THREE, TWO_DOT_SEVEN_DOT_TWO, TWO_DOT_SIX, TWO_DOT_THREE,
+            TWO_DOT_SEVEN_DOT_EIGHT, TWO_DOT_SEVEN_DOT_THREE, TWO_DOT_SEVEN_DOT_TWO, TWO_DOT_SIX,
+            TWO_DOT_THREE,
         },
         error::{
             DeserializePromtailExtraConfig, ListCrds, Result, SemverParse,
@@ -522,6 +523,24 @@ where
         )?;
     }
 
+    // Special-case values for 2.7.8
+    let two_dot_seven_dot_eight = Version::parse(TWO_DOT_SEVEN_DOT_EIGHT).context(SemverParse {
+        version_string: TWO_DOT_SEVEN_DOT_EIGHT.to_string(),
+    })?;
+    if source_version.ge(&two_dot_o_rc_zero) && source_version.lt(&two_dot_seven_dot_eight) {
+        if let Some(debug_logs) = source_values.etcd_deprecated_debug_logs() {
+            yq.delete_object(
+                YamlKey::try_from(".etcd.debug")?,
+                upgrade_values_file.path(),
+            )?;
+            yq.set_literal_value(
+                YamlKey::try_from(".etcd.image.debug")?,
+                debug_logs,
+                upgrade_values_file.path(),
+            )?;
+        }
+    }
+
     // Default options.
     // Image tag is set because the high_priority file is the user's source options file.
     // The target's image tag needs to be set for PRODUCT upgrade.
@@ -572,7 +591,11 @@ where
         target_values.localpv_helper_image_tag(),
         upgrade_values_file.path(),
     )?;
-
+    yq.set_literal_value(
+        YamlKey::try_from(".etcd.image.repository")?,
+        target_values.etcd_image_repo(),
+        upgrade_values_file.path(),
+    )?;
     // Disable CRD installation in case they already exist using helm values.
     safe_crd_install(upgrade_values_file.path(), &yq).await?;
 


### PR DESCRIPTION
The bitnami docker repo was migrated on the 28Nov, so let's just move these to our dockerhub since that one is not going anywhere.
We should consider doing this for other dependencies.
