### PR TITLE
Fix - use correct grpc port in metrics exporter

### DIFF
--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -126,7 +126,7 @@ spec:
             hugepages-2Mi: {{ .Values.io_engine.resources.requests.hugepages2Mi | quote }}
             hugepages-1Gi: {{ .Values.io_engine.resources.requests.hugepages1Gi | quote }}
         ports:
-        - containerPort: 10124
+        - containerPort: {{ default 10124 .Values.io_engine.port }}
           protocol: TCP
           name: io-engine
       {{- if .Values.base.metrics.enabled }}
@@ -148,6 +148,7 @@ spec:
             name: metrics
         args:
           - "--metrics-endpoint=[::]:{{ default 9502 .Values.base.metrics.port }}"
+          - "--grpc-port={{ default 10124 .Values.io_engine.port }}"
           - "--fmt-style={{ include "logFormat" . }}"
           - "--ansi-colors={{ .Values.base.logging.color }}"
       {{- end }}

--- a/metrics-exporter/src/bin/io_engine/client/grpc_client.rs
+++ b/metrics-exporter/src/bin/io_engine/client/grpc_client.rs
@@ -105,14 +105,14 @@ impl GrpcClient {
 }
 
 /// Initialize mayastor grpc client.
-pub(crate) async fn init_client() -> Result<GrpcClient, ExporterError> {
+pub(crate) async fn init_client(grpc_port: u16) -> Result<GrpcClient, ExporterError> {
     let timeout = Timeouts::new(Duration::from_secs(1), Duration::from_secs(5));
     let pod_ip = get_pod_ip()?;
     let _ = get_node_name()?;
 
     let endpoint = Uri::builder()
         .scheme("https")
-        .authority(SocketAddr::new(pod_ip, 10124).to_string())
+        .authority(SocketAddr::new(pod_ip, grpc_port).to_string())
         .path_and_query("")
         .build()
         .map_err(|error| ExporterError::InvalidURI(error.to_string()))?;

--- a/metrics-exporter/src/bin/io_engine/main.rs
+++ b/metrics-exporter/src/bin/io_engine/main.rs
@@ -49,6 +49,10 @@ pub(crate) struct Cli {
     #[clap(long, short, default_value = "[::]:9502")]
     metrics_endpoint: SocketAddr,
 
+    /// Port for the io-engine gRPC server running on the same pod.
+    #[clap(long, default_value_t = 10124)]
+    grpc_port: u16,
+
     /// Formatting style to be used while logging.
     #[clap(default_value = FmtStyle::Pretty.as_ref(), short, long)]
     fmt_style: FmtStyle,
@@ -85,7 +89,7 @@ async fn main() -> Result<(), ExporterError> {
         .init("metrics-exporter-io_engine");
 
     initialize_cache().await;
-    let client = init_client().await?;
+    let client = init_client(args.grpc_port).await?;
     // Initialize io engine gRPC client.
     GRPC_CLIENT
         .set(client)

--- a/scripts/k8s/images.sh
+++ b/scripts/k8s/images.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]:-"$0"}")")"
+ROOT_DIR="$SCRIPT_DIR/../.."
+
+source "$ROOT_DIR"/scripts/utils/log.sh
+
+set -euo pipefail
+
+TAG=
+IMAGE_BUILD="false"
+IMAGE_SKIP="false"
+BIN_BUILD="false"
+IMAGE_LOAD="false"
+CHART_DIR="$ROOT_DIR/chart"
+BUILD_OUT="${KIND_OUT:-$ROOT_DIR/out}"
+HELM=helm
+
+# Print usage options for this script.
+print_help() {
+  cat <<EOF
+Usage: $(basename "${0}") [OPTIONS]
+
+Options:
+  -h, --help              Display this text.
+  --build-out     [path]  Path where the build output goes to. (Default: $BUILD_OUT)
+  --build-all             Builds the mayastor images and binary plugin.
+  --build-bin             Builds the mayastor binary plugin.
+  --build-img             Builds the mayastor images.
+  --load                  Loads the images into the kind cluster.
+
+Examples:
+  $(basename "${0}") --build
+EOF
+}
+
+cleanup() {
+  if [ -f "${BUILD_OUT:-}" ]; then
+    rm -rf "${BUILD_OUT:-}"
+  fi
+}
+
+image_tag() {
+  $HELM show values "$CHART_DIR" --kubeconfig "$CHART_DIR/fake" | yq '.image.tag'
+}
+
+# Parse args.
+while test $# -gt 0; do
+  arg="$1"
+  case "$arg" in
+  --tag)
+    shift
+    TAG="$1"
+    ;;
+  --build-all)
+    IMAGE_BUILD="true"
+    BIN_BUILD="true"
+    ;;
+  --build-bin)
+    BIN_BUILD="true"
+    ;;
+  --build-img)
+    IMAGE_BUILD="true"
+    ;;
+  --build-out)
+    shift
+    BUILD_OUT="$1"
+    ;;
+  --load)
+    IMAGE_LOAD="true"
+    ;;
+  -h* | --help*)
+    print_help
+    exit 0
+    ;;
+  *)
+    print_help
+    log_fatal "unexpected argument '$arg'" 1
+    ;;
+  esac
+  shift
+done
+
+if [ "$IMAGE_LOAD" = "true" ] && [ "$BIN_BUILD" = "true" ] && [ "$IMAGE_BUILD" = "false" ]; then
+  log_fatal "Cannot load the bin plugin only!"
+fi
+
+trap cleanup EXIT
+
+if [ "$IMAGE_LOAD" = "true" ]; then
+  if [ "$(kubectl config current-context)" != "kind-kind" ]; then
+    log_fatal "Only Supported on Kind Clusters!"
+  fi
+fi
+
+if [ -z "$TAG" ]; then
+  TAG="$(image_tag)"
+fi
+
+if [ -z "$BUILD_OUT" ]; then
+  if [ -n "$IMAGE_BUILD" ] && [ -n "$IMAGE_BUILD" ]; then
+    BUILD_OUT=$(mktemp -d /tmp/mayastor-images-XXXXXX)
+  else
+    log_fatal "Build Output Dir is required when using only --build-* or --load"
+  fi
+fi
+
+if [ "$IMAGE_BUILD" = "true" ] || [ "$BIN_BUILD" = "true" ]; then
+  SKIP=""
+  if [ "$IMAGE_BUILD" = "false" ]; then
+    SKIP="--skip-images"
+  elif [ "$BIN_BUILD" = "false" ]; then
+    SKIP="--skip-bins"
+  fi
+  RUSTFLAGS="-C debuginfo=0 -C strip=debuginfo" "$ROOT_DIR"/scripts/release.sh --tag "$TAG" --build-binary-out "$BUILD_OUT" --no-static-linking --skip-publish --debug "$SKIP"
+fi
+
+if [ "$IMAGE_LOAD" = "true" ]; then
+  "$ROOT_DIR"/scripts/k8s/load-images-to-kind.sh --tag "$TAG" --trim-debug-suffix
+fi


### PR DESCRIPTION
    chore: add easy container image builder
    
    Build quick images and load them into the kind cluster
    
---

    fix(io-engine/metrics-exporter): use correct io-engine grpc port number

