### PR TITLE
feat(upgrade): normalize k8s name

### DIFF
--- a/k8s/upgrade/src/plugin/constants.rs
+++ b/k8s/upgrade/src/plugin/constants.rs
@@ -1,3 +1,4 @@
+use crate::plugin::objects::normalize_k8s_name;
 use utils::version_info;
 
 /// This is used to create labels for the upgrade job.
@@ -60,7 +61,7 @@ pub(crate) fn upgrade_event_selector(release_name: &str, component_name: &str) -
     let kind = "involvedObject.kind=Job";
     let name_key = "involvedObject.name";
     let tag = upgrade_obj_suffix();
-    let name_value = format!("{release_name}-{component_name}-{tag}");
+    let name_value = normalize_k8s_name(format!("{release_name}-{component_name}-{tag}"));
     format!("{kind},{name_key}={name_value}")
 }
 

--- a/k8s/upgrade/src/plugin/objects.rs
+++ b/k8s/upgrade/src/plugin/objects.rs
@@ -23,6 +23,26 @@ use kube::core::ObjectMeta;
 use maplit::btreemap;
 use openapi::apis::IntoVec;
 
+/// Trims kubernetes names to 63 characters.
+pub(crate) fn normalize_k8s_name(mut input: String) -> String {
+    const MAX: usize = 63;
+
+    // 3. trim to 63 bytes at char boundary
+    if input.len() > MAX {
+        let mut cut = MAX;
+        while !input.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        input.truncate(cut);
+    }
+
+    while input.ends_with('-') {
+        input.pop();
+    }
+
+    input
+}
+
 /// Defines the upgrade job service account.
 pub(crate) fn upgrade_job_service_account(
     namespace: Option<String>,
@@ -31,7 +51,7 @@ pub(crate) fn upgrade_job_service_account(
     ServiceAccount {
         metadata: ObjectMeta {
             labels: Some(upgrade_labels!()),
-            name: Some(service_account_name),
+            name: Some(normalize_k8s_name(service_account_name)),
             namespace,
             ..Default::default()
         },
@@ -47,7 +67,7 @@ pub(crate) fn upgrade_job_cluster_role(
     ClusterRole {
         metadata: ObjectMeta {
             labels: Some(upgrade_labels!()),
-            name: Some(cluster_role_name),
+            name: Some(normalize_k8s_name(cluster_role_name)),
             namespace,
             ..Default::default()
         },
@@ -250,21 +270,27 @@ pub(crate) fn upgrade_job_cluster_role_binding(
     ClusterRoleBinding {
         metadata: ObjectMeta {
             labels: Some(upgrade_labels!()),
-            name: Some(upgrade_name_concat(
+            name: Some(normalize_k8s_name(upgrade_name_concat(
                 &release_name,
                 UPGRADE_JOB_CLUSTERROLEBINDING_NAME_SUFFIX,
-            )),
+            ))),
             namespace: namespace.clone(),
             ..Default::default()
         },
         role_ref: RoleRef {
             api_group: "rbac.authorization.k8s.io".to_string(),
             kind: "ClusterRole".to_string(),
-            name: upgrade_name_concat(&release_name, UPGRADE_JOB_CLUSTERROLE_NAME_SUFFIX),
+            name: normalize_k8s_name(upgrade_name_concat(
+                &release_name,
+                UPGRADE_JOB_CLUSTERROLE_NAME_SUFFIX,
+            )),
         },
         subjects: Some(vec![Subject {
             kind: "ServiceAccount".to_string(),
-            name: upgrade_name_concat(&release_name, UPGRADE_JOB_SERVICEACCOUNT_NAME_SUFFIX),
+            name: normalize_k8s_name(upgrade_name_concat(
+                &release_name,
+                UPGRADE_JOB_SERVICEACCOUNT_NAME_SUFFIX,
+            )),
             namespace,
             ..Default::default()
         }]),
@@ -279,10 +305,10 @@ pub(crate) fn upgrade_configmap(
     ConfigMap {
         metadata: ObjectMeta {
             labels: Some(upgrade_labels!()),
-            name: Some(upgrade_name_concat(
+            name: Some(normalize_k8s_name(upgrade_name_concat(
                 &release_name,
                 UPGRADE_CONFIG_MAP_NAME_SUFFIX,
-            )),
+            ))),
             namespace: Some(namespace.to_string()),
             ..Default::default()
         },
@@ -322,7 +348,10 @@ pub(crate) fn upgrade_job(
     Job {
         metadata: ObjectMeta {
             labels: Some(upgrade_labels!()),
-            name: Some(upgrade_name_concat(&release_name, UPGRADE_JOB_NAME_SUFFIX)),
+            name: Some(normalize_k8s_name(upgrade_name_concat(
+                &release_name,
+                UPGRADE_JOB_NAME_SUFFIX,
+            ))),
             namespace: Some(namespace.to_string()),
             ..Default::default()
         },
@@ -388,17 +417,17 @@ pub(crate) fn upgrade_job(
                         }]),
                         ..Default::default()
                     }],
-                    service_account_name: Some(upgrade_name_concat(
+                    service_account_name: Some(normalize_k8s_name(upgrade_name_concat(
                         &release_name,
                         UPGRADE_JOB_SERVICEACCOUNT_NAME_SUFFIX,
-                    )),
+                    ))),
                     volumes: Some(vec![Volume {
                         name: UPGRADE_CONFIG_MAP.to_string(),
                         config_map: Some(ConfigMapVolumeSource {
-                            name: Some(upgrade_name_concat(
+                            name: Some(normalize_k8s_name(upgrade_name_concat(
                                 &release_name,
                                 UPGRADE_CONFIG_MAP_NAME_SUFFIX,
-                            )),
+                            ))),
                             ..Default::default()
                         }),
                         ..Default::default()

--- a/k8s/upgrade/src/plugin/upgrade.rs
+++ b/k8s/upgrade/src/plugin/upgrade.rs
@@ -8,6 +8,7 @@ use crate::plugin::{
         UPGRADE_JOB_NAME_SUFFIX, UPGRADE_JOB_SERVICEACCOUNT_NAME_SUFFIX,
     },
     error, objects,
+    objects::normalize_k8s_name,
     user_prompt::{
         upgrade_dry_run_summary, CONTROL_PLANE_PODS_LIST, DATA_PLANE_PODS_LIST,
         DATA_PLANE_PODS_LIST_SKIP_RESTART, DELETE_INCOMPLETE_JOB, HELM_UPGRADE_VALIDATION_ERROR,
@@ -362,7 +363,7 @@ impl UpgradeEventClient {
     }
 }
 
-/// Print the upgrade iutput to console.
+/// Print the upgrade output to console.
 pub async fn log_upgrade_result(event: &Event) -> error::Result<()> {
     _ = match event.message.clone() {
         Some(data) => {
@@ -408,8 +409,10 @@ impl UpgradeResources {
 
     /// Create/Delete ServiceAction.
     pub async fn service_account_actions(&self, ns: &str, action: Actions) -> error::Result<()> {
-        let service_account_name =
-            upgrade_name_concat(&self.release_name, UPGRADE_JOB_SERVICEACCOUNT_NAME_SUFFIX);
+        let service_account_name = normalize_k8s_name(upgrade_name_concat(
+            &self.release_name,
+            UPGRADE_JOB_SERVICEACCOUNT_NAME_SUFFIX,
+        ));
         if let Some(sa) = self
             .service_account
             .get_opt(&service_account_name)
@@ -469,8 +472,10 @@ impl UpgradeResources {
 
     /// Create/Delete cluster role
     pub async fn cluster_role_actions(&self, ns: &str, action: Actions) -> error::Result<()> {
-        let cluster_role_name =
-            upgrade_name_concat(&self.release_name, UPGRADE_JOB_CLUSTERROLE_NAME_SUFFIX);
+        let cluster_role_name = normalize_k8s_name(upgrade_name_concat(
+            &self.release_name,
+            UPGRADE_JOB_CLUSTERROLE_NAME_SUFFIX,
+        ));
 
         if let Some(cr) = self
             .cluster_role
@@ -531,10 +536,10 @@ impl UpgradeResources {
         ns: &str,
         action: Actions,
     ) -> error::Result<()> {
-        let cluster_role_binding_name = upgrade_name_concat(
+        let cluster_role_binding_name = normalize_k8s_name(upgrade_name_concat(
             &self.release_name,
             UPGRADE_JOB_CLUSTERROLEBINDING_NAME_SUFFIX,
-        );
+        ));
         if let Some(crb) = self
             .cluster_role_binding
             .get_opt(&cluster_role_binding_name)
@@ -603,7 +608,10 @@ impl UpgradeResources {
         action: Actions,
         args: &UpgradeArgs,
     ) -> error::Result<HashMap<String, String>> {
-        let cm_name = upgrade_name_concat(&self.release_name, UPGRADE_CONFIG_MAP_NAME_SUFFIX);
+        let cm_name = normalize_k8s_name(upgrade_name_concat(
+            &self.release_name,
+            UPGRADE_CONFIG_MAP_NAME_SUFFIX,
+        ));
         let data = create_config_map_data(args).await?;
         let cm = self
             .config_map
@@ -680,7 +688,10 @@ impl UpgradeResources {
         args: &UpgradeArgs,
         set_file_map: Option<HashMap<String, String>>,
     ) -> error::Result<()> {
-        let job_name = upgrade_name_concat(&self.release_name, UPGRADE_JOB_NAME_SUFFIX);
+        let job_name = normalize_k8s_name(upgrade_name_concat(
+            &self.release_name,
+            UPGRADE_JOB_NAME_SUFFIX,
+        ));
         if let Some(job) = self
             .job
             .get_opt(&job_name)
@@ -863,7 +874,10 @@ pub(crate) async fn get_release_name(ns: &str) -> error::Result<String> {
 /// Return true if upgrade job is completed
 pub(crate) async fn is_upgrade_job_completed(ns: &str) -> error::Result<bool> {
     let uo = UpgradeResources::new(ns).await?;
-    let job_name = upgrade_name_concat(&uo.release_name, UPGRADE_JOB_NAME_SUFFIX);
+    let job_name = normalize_k8s_name(upgrade_name_concat(
+        &uo.release_name,
+        UPGRADE_JOB_NAME_SUFFIX,
+    ));
     let option_job = uo
         .job
         .get_opt(&job_name)


### PR DESCRIPTION
This change trims kubernetes names to at-max 63 characters long.