### PR TITLE
feat: enable etcd metrics by default in the chart

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -167,6 +167,8 @@ This removes all the Kubernetes components associated with the chart and deletes
 | etcd.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;basePath | Host path where local etcd data is stored in. | `"/var/local/{{ .Release.Name }}/localpv-hostpath/etcd"` |
 | etcd.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;reclaimPolicy | ReclaimPolicy of etcd's localpv hostpath storage class. | `"Delete"` |
 | etcd.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;volumeBindingMode | VolumeBindingMode of etcd's localpv hostpath storage class. | `"WaitForFirstConsumer"` |
+| etcd.&ZeroWidthSpace;metrics.&ZeroWidthSpace;enabled | Expose etcd metrics. | `true` |
+| etcd.&ZeroWidthSpace;metrics.&ZeroWidthSpace;useSeparateEndpoint | Use a separate endpoint for exposing metrics, override the default port (9090) by setting containerPorts.metrics. | `true` |
 | etcd.&ZeroWidthSpace;persistence.&ZeroWidthSpace;enabled | If true, use a Persistent Volume Claim. If false, use emptyDir. | `true` |
 | etcd.&ZeroWidthSpace;persistence.&ZeroWidthSpace;size | Volume size | `"2Gi"` |
 | etcd.&ZeroWidthSpace;persistence.&ZeroWidthSpace;storageClass | Will define which storageClass to use in etcd's StatefulSets. Options: <p> - `"manual"` - Will provision a hostpath PV on the same node. <br> - `""` (empty) - Will use the default StorageClass on the cluster. </p> | `"mayastor-etcd-localpv"` |

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -503,6 +503,11 @@ etcd:
   # -- (string) Url of the external etcd cluster. Note, etcd.enable must be set to false.
   externalUrl: ""
   # Configuration for etcd's localpv hostpath storage class.
+  metrics:
+    # -- Expose etcd metrics.
+    enabled: true
+    # -- Use a separate endpoint for exposing metrics, override the default port (9090) by setting containerPorts.metrics.
+    useSeparateEndpoint: true
   localpvScConfig:
     enabled: true
     # Name of etcd's localpv hostpath storage class.


### PR DESCRIPTION
Description
This change enables etcd metrics by default in the chart. Metrics are exposed on a dedicated endpoint, with the option to override the default port (9090) using containerPorts.metrics.

Provides better visibility into etcd performance, health, and resource usage.
 
Simplifies monitoring setup for operators and developers, reducing manual configuration.
 
Regression
No This change does not fix a regression. It introduces a new default behavior to enhance observability.
 
How Has This Been Tested?
Deployed the updated chart in a Kubernetes cluster.
 
Verified that etcd metrics are exposed on the default port (9090).
 
Confirmed that metrics can be scraped successfully by Prometheus after deploying a servicemonitor manually.
 
 
Types of changes
- [x] New feature (non-breaking change which adds functionality)

Checklist:
- [x] My code follows the code style of this project.
- [x] My change does requires a change to the documentation.
- [x] I have updated the documentation accordingly.