### PR TITLE
fix(upgrade-job): handle empty String continue token during paginated listing

### DIFF
--- a/call-home/src/bin/callhome/collector/k8s_client.rs
+++ b/call-home/src/bin/callhome/collector/k8s_client.rs
@@ -33,8 +33,10 @@ impl K8sClient {
             nodes_count += node_list.items.len();
 
             match node_list.metadata.continue_ {
-                Some(ref token) => list_params = list_params.continue_token(token),
-                None => break,
+                Some(ref token) if !token.is_empty() => {
+                    list_params = list_params.continue_token(token)
+                }
+                _ => break,
             }
         }
 

--- a/k8s/supportability/src/collect/k8s_resources/client.rs
+++ b/k8s/supportability/src/collect/k8s_resources/client.rs
@@ -198,8 +198,10 @@ impl ClientSet {
             let mut result = pods_api.list(&list_params).await?;
             pods.append(&mut result.items);
             match result.metadata.continue_ {
-                None => break,
-                Some(token) => list_params = list_params.continue_token(token.as_str()),
+                Some(ref token) if !token.is_empty() => {
+                    list_params = list_params.continue_token(token)
+                }
+                _ => break,
             };
         }
         Ok(pods)
@@ -352,8 +354,8 @@ impl ClientSet {
                     .collect(),
             );
             match vscs.metadata.continue_ {
-                Some(token) if !token.is_empty() => {
-                    list_params = list_params.continue_token(token.as_str())
+                Some(ref token) if !token.is_empty() => {
+                    list_params = list_params.continue_token(token)
                 }
                 _ => break,
             };
@@ -380,8 +382,8 @@ impl ClientSet {
             let mut result = events_api.list(&list_params).await?;
             events.append(&mut result.items);
             match result.metadata.continue_ {
-                Some(token) if !token.is_empty() => {
-                    list_params = list_params.continue_token(token.as_str())
+                Some(ref token) if !token.is_empty() => {
+                    list_params = list_params.continue_token(token)
                 }
                 _ => break,
             };

--- a/k8s/upgrade/src/common/kube/client.rs
+++ b/k8s/upgrade/src/common/kube/client.rs
@@ -323,10 +323,10 @@ where
         resources.extend(resource_list);
 
         match maybe_token {
-            Some(ref token) => {
+            Some(ref token) if !token.is_empty() => {
                 list_params = list_params.continue_token(token);
             }
-            None => break,
+            _ => break,
         }
     }
 
@@ -355,10 +355,10 @@ where
         resources.extend(resource_list);
 
         match maybe_token {
-            Some(ref token) => {
+            Some(ref token) if !token.is_empty() => {
                 list_params = list_params.continue_token(token);
             }
-            None => break,
+            _ => break,
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I've hit an issue during my testing with the kube client. It'd appear that sometimes, the continue_token is a `Some("".to_string())` and not a `None`, when the list is empty.