### PR TITLE
ci: update to macos 15 as 13 is deprecated

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -24,10 +24,10 @@ jobs:
           - os: oracle-vm-8cpu-32gb-x86-64
             target: linux-musl
             arch: aarch64
-          - os: macos-14
+          - os: macos-15
             target: apple-darwin
             arch: aarch64
-          - os: macos-13
+          - os: macos-15-intel
             target: apple-darwin
             arch: x86_64
           - os: oracle-vm-8cpu-32gb-x86-64


### PR DESCRIPTION
This PR is to deprecate MacOS 13 add MacOS 15 instead based on the following thread : https://github.com/actions/runner-images/issues/13046

Tested : https://github.com/openebs/mayastor-extensions/actions/runs/20042096815/job/57478526427