### PR TITLE
Cherry-pick PR 795 to release/2.10

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -24,10 +24,10 @@ jobs:
           - os: oracle-vm-8cpu-32gb-x86-64
             target: linux-musl
             arch: aarch64
-          - os: macos-14
+          - os: macos-15
             target: apple-darwin
             arch: aarch64
-          - os: macos-13
+          - os: macos-15-intel
             target: apple-darwin
             arch: x86_64
           - os: oracle-vm-8cpu-32gb-x86-64


### PR DESCRIPTION
Cherry pick PR : https://github.com/openebs/mayastor-extensions/pull/795 to release/2.10 branch.