### PR TITLE
build: use shared workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,15 +594,12 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "anyhow",
- "bytes",
  "chrono",
  "clap",
  "constants",
  "events-api",
- "futures",
  "heck",
  "humantime",
- "jsonpath_lib",
  "k8s-openapi",
  "kube",
  "mime",
@@ -616,7 +613,6 @@ dependencies = [
  "reqwest-retry",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha256",
  "snafu",
  "tempfile",
@@ -1152,7 +1148,6 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "once_cell",
  "prost",
  "prost-extend",
  "serde",
@@ -1537,12 +1532,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.1.0",
  "http-body",
  "pin-project-lite",
@@ -1998,17 +1993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonpath_lib"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
-dependencies = [
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "jsonptr"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,7 +2065,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "tower 0.4.13",
- "tower-http 0.5.2",
+ "tower-http",
  "tracing",
 ]
 
@@ -2305,18 +2289,13 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 name = "metrics-exporter"
 version = "0.1.0"
 dependencies = [
- "actix-service",
  "actix-web",
  "clap",
- "humantime",
  "mime",
  "once_cell",
  "prometheus",
  "rpc",
  "serde",
- "serde_json",
- "strum",
- "strum_macros",
  "tokio",
  "tonic",
  "tracing",
@@ -2496,7 +2475,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower 0.5.1",
- "tower-http 0.6.1",
+ "tower-http",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -3814,7 +3793,6 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
- "constants",
  "downcast-rs",
  "flate2",
  "futures",
@@ -3827,7 +3805,6 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "kube-proxy",
- "lazy_static",
  "once_cell",
  "openapi",
  "parse-size",
@@ -4229,24 +4206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-http"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
-dependencies = [
- "base64 0.22.1",
- "bitflags 2.6.0",
- "bytes",
- "http 1.1.0",
- "http-body",
- "mime",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4445,7 +4404,6 @@ dependencies = [
  "console-logger",
  "constants",
  "flate2",
- "futures",
  "humantime",
  "k8s-openapi",
  "kube",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,67 @@ members = [
 
 exclude = ["./dependencies/control-plane"]
 resolver = "1"
+
+[workspace.dependencies]
+# k8s
+kube = { version = "0.94.2", features = ["runtime", "derive"] }
+k8s-openapi = { version = "0.22.0", features = ["v1_24"] }
+schemars = { version = "0.8.21" }
+
+# async
+tokio = { version = "1.41.0", features = ["full"] }
+tokio-retry = "0.3"
+futures = "0.3"
+async-trait = "0.1.83"
+
+# tracing
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "std"] }
+
+# ser/deser
+serde = { version = "1.0.214", features = ["derive"] }
+serde_json = "1.0.132"
+serde_yaml = "0.9.34"
+
+# errors
+snafu = "0.8.5"
+anyhow = "1.0.92"
+
+# misc
+uuid = { version = "1.11.0", features = ["serde", "v4"] }
+clap = { version = "4.5.20", features = ["cargo", "derive", "env", "string", "color"] }
+nu-ansi-term = "0.50.1"
+sha256 = "1.5.0"
+chrono = "0.4.38"
+rand = "0.8.5"
+tempfile = "3.13.0"
+humantime = "2.1.0"
+once_cell = "1.20.2"
+maplit = "1.0.2"
+semver = { version = "1.0.23", features = ["serde"] }
+regex = "1.11.1"
+base64 = "0.22.1"
+flate2 = "1.0.34"
+tar = "0.4"
+parse-size = "1.1.0"
+downcast-rs = "1.2.1"
+
+# http
+tonic = "0.12.3"
+reqwest = "0.12.9"
+reqwest-middleware = "0.3.3"
+reqwest-retry = "0.6.1"
+url = "2.5.4"
+hyper = { version = "1.5.0", features = ["client", "http1", "http2"] }
+hyper-util = "0.1.10"
+tower = { version = "0.5.1", features = ["timeout", "util"] }
+http = "1.1.0"
+urlencoding = "2.1.3"
+http-body-util = "0.1.2"
+
+# exporter
+actix-web = { version = "4.9.0", features = ["rustls-0_21"] }
+prometheus = "0.13.4"
+mime = "0.3.17"
+prometheus-parse = "0.2.5"
+heck = "0.5.0"

--- a/call-home/Cargo.toml
+++ b/call-home/Cargo.toml
@@ -20,39 +20,38 @@ path = "src/bin/stats/main.rs"
 [dependencies]
 constants = { path = "../constants" }
 openapi = { path = "../dependencies/control-plane/openapi" }
-kube = { version = "0.94.2", features = ["runtime", "derive"] }
-k8s-openapi = { version = "0.22.0", features = ["v1_24"] }
-futures = "0.3.31"
-tokio = { version = "1.41.0", features = ["full"] }
-clap = { version = "4.5.20", features = ["cargo", "derive", "string"] }
-serde_json = "1.0.132"
-serde_yaml = "0.9.34"
-serde = { version = "1.0.214", features = ["derive"] }
-sha256 = "1.5.0"
-jsonpath_lib = "0.3.0"
-url = "2.5.4"
-snafu = "0.8.5"
-anyhow = "1.0.92"
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "std"] }
-reqwest = "0.12.9"
-reqwest-middleware = "0.3.3"
-reqwest-retry = "0.6.1"
-chrono = "0.4.38"
-rand = "0.8.5"
-tempfile = "3.13.0"
-humantime = "2.1.0"
-once_cell = "1.20.2"
-bytes = "1.8.0"
 utils = { path = "../dependencies/control-plane/utils/utils-lib" }
 events-api = { path = "../dependencies/control-plane/utils/dependencies/apis/events" }
-tokio-retry = "0.3"
+
+
+kube = { workspace = true, features = ["runtime", "derive"] }
+k8s-openapi = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+clap = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
+sha256 = { workspace = true }
+url = { workspace = true }
+snafu = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "std"] }
+reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
+reqwest-retry = { workspace = true }
+chrono = { workspace = true }
+rand = { workspace = true }
+tempfile = { workspace = true }
+humantime = { workspace = true }
+once_cell = { workspace = true }
+
+tokio-retry = { workspace = true }
 
 # exporter
-actix-web = { version = "4.9.0", features = ["rustls-0_21"] }
-prometheus = "0.13.4"
-mime = "0.3.17"
+actix-web = { workspace = true }
+prometheus = { workspace = true }
+mime = { workspace = true }
 
 # parse prometheus output
-prometheus-parse = "0.2.5"
-heck = "0.5.0"
+prometheus-parse = { workspace = true }
+heck = { workspace = true }

--- a/console-logger/Cargo.toml
+++ b/console-logger/Cargo.toml
@@ -10,4 +10,4 @@ name = "console_logger"
 path = "./src/console.rs"
 
 [dependencies]
-nu-ansi-term = "0.50.1"
+nu-ansi-term = { workspace = true }

--- a/constants/Cargo.toml
+++ b/constants/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-utils = {path = "../dependencies/control-plane/utils/utils-lib" }
-heck = "0.5.0"
+utils = { path = "../dependencies/control-plane/utils/utils-lib" }
+heck = { workspace = true }

--- a/k8s/plugin/Cargo.toml
+++ b/k8s/plugin/Cargo.toml
@@ -23,12 +23,13 @@ constants = { path = "../../constants" }
 rest-plugin = { path = "../../dependencies/control-plane/control-plane/plugin", default-features = false }
 supportability = { path = "../supportability" }
 upgrade = { path = "../upgrade" }
-kube = { version = "0.94.2", features = ["derive", "runtime"] }
-k8s-openapi = "0.22.0"
+shutdown = { path = "../../dependencies/control-plane/utils/shutdown" }
+
+kube = { workspace = true, features = ["derive", "runtime"] }
+k8s-openapi = { workspace = true }
 kube-proxy = { path = "../../dependencies/control-plane/k8s/proxy" }
 kube-forward = { path = "../../dependencies/control-plane/k8s/forward" }
-tokio = { version = "1.41.0" }
-anyhow = "1.0.92"
-clap = { version = "4.5.20", features = ["color", "derive"] }
-async-trait = "0.1.83"
-shutdown = { path = "../../dependencies/control-plane/utils/shutdown" }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+async-trait = { workspace = true }

--- a/k8s/supportability/Cargo.toml
+++ b/k8s/supportability/Cargo.toml
@@ -16,30 +16,6 @@ rls = ["openapi/tower-client-rls"]
 tls = ["openapi/tower-client-tls"]
 
 [dependencies]
-futures = "0.3"
-k8s-openapi = { version = "0.22.0", features = ["v1_24"] }
-kube = { version = "0.94.2", features = ["derive"] }
-schemars = { version = "0.8.21" }
-clap = { version = "4.5.20", features = ["color", "derive"] }
-anyhow = "1.0.92"
-humantime = "2.1.0"
-async-trait = "0.1.83"
-serde = "1.0.214"
-serde_json = "1.0.132"
-serde_yaml = "0.9.34"
-lazy_static = "1.5.0"
-uuid = { version = "1.11.0", features = ["serde", "v4"] }
-once_cell = "1.20.2"
-tar = "0.4"
-flate2 = { version = "1.0.34" }
-chrono = "0.4.38"
-urlencoding = "2.1.3"
-downcast-rs = "1.2.1"
-http = "1.1.0"
-hyper = { version = "1.5.0", features = ["client", "http1", "http2"] }
-hyper-util = "0.1.10"
-tower = { version = "0.5.1", features = ["timeout", "util"] }
-parse-size = "1.1.0"
 pstor = { path = "../../dependencies/control-plane/utils/pstor" }
 platform = { path = "../../dependencies/control-plane/utils/dependencies/platform" }
 openapi = { path = "../../dependencies/control-plane/openapi", default-features = false, features = ["tower-client", "tower-trace"] }
@@ -47,5 +23,32 @@ kube-proxy = { path = "../../dependencies/control-plane/k8s/proxy" }
 rest-plugin = { path = "../../dependencies/control-plane/control-plane/plugin", default-features = false }
 utils = { path = "../../dependencies/control-plane/utils/utils-lib" }
 hyper-body = { path = "../../dependencies/control-plane/utils/hyper-body" }
-constants = { path = "../../constants" }
-http-body-util = "0.1.2"
+
+futures = { workspace = true }
+async-trait = { workspace = true }
+
+kube = { workspace = true, features = ["derive"] }
+k8s-openapi = { workspace = true }
+schemars = { workspace = true }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+
+anyhow = { workspace = true }
+clap = { workspace = true }
+humantime = { workspace = true }
+uuid = { workspace = true }
+once_cell = { workspace = true }
+tar = { workspace = true }
+flate2 = { workspace = true }
+chrono = { workspace = true }
+downcast-rs = { workspace = true }
+parse-size = { workspace = true }
+
+hyper = { workspace = true, features = ["client", "http1", "http2"] }
+hyper-util = { workspace = true }
+tower = { workspace = true, features = ["timeout", "util"] }
+http = { workspace = true }
+urlencoding = { workspace = true }
+http-body-util = { workspace = true }

--- a/k8s/upgrade/Cargo.toml
+++ b/k8s/upgrade/Cargo.toml
@@ -17,23 +17,22 @@ utils = { path = "../../dependencies/control-plane/utils/utils-lib" }
 constants = { path = "../../constants" }
 kube-proxy = { path = "../../dependencies/control-plane/k8s/proxy" }
 console-logger = { path = "../../console-logger" }
-kube = { version = "0.94.2", default-features = true, features = ["derive", "runtime"] }
-clap = { version = "4.5.20", features = ["derive", "env", "string", "color"] }
-humantime = "2.1.0"
-maplit = "1.0.2"
-k8s-openapi = { version = "0.22.0", features = ["v1_24"] }
-async-trait = "0.1.83"
-serde = "1.0.214"
-serde_json = "1.0.132"
-snafu = "0.8.5"
-serde_yaml = "0.9.34"
-semver = { version = "1.0.23", features = ["serde"] }
-url = "2.5.4"
-regex = "1.11.1"
-tokio = { version = "1.41.0", features = ["full"] }
-tempfile = "3.13.0"
-# Tracing
-tracing = "0.1.40"
-base64 = "0.22.1"
-flate2 = "1.0.34"
-futures = "0.3.31"
+
+kube = { workspace = true, features = ["derive", "runtime"] }
+k8s-openapi = { workspace = true }
+clap = { workspace = true, features = ["derive", "env", "string", "color"] }
+tokio = { workspace = true, features = ["full"] }
+async-trait = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+humantime = { workspace = true }
+maplit = { workspace = true }
+serde = { workspace = true }
+url = { workspace = true }
+semver = { workspace = true, features = ["serde"] }
+regex = { workspace = true }
+snafu = { workspace = true }
+tempfile = { workspace = true }
+base64 = { workspace = true }
+flate2 = { workspace = true }
+tracing = { workspace = true }

--- a/metrics-exporter/Cargo.toml
+++ b/metrics-exporter/Cargo.toml
@@ -11,19 +11,15 @@ path = "src/bin/io_engine/main.rs"
 
 
 [dependencies]
-actix-web = { version = "4.9.0", features = ["rustls-0_21"] }
-actix-service = "2.0.2"
-tokio = { version = "1.41.0", features = ["full"] }
-once_cell = "1.20.2"
-clap = { version = "4.5.20", features = ["color", "derive", "string"] }
-prometheus = "0.13.4"
-tonic = "0.12.3"
-humantime = "2.1.0"
-serde_json = "1.0.132"
-serde = "1.0.214"
-mime = "0.3.17"
 rpc = { path = "../dependencies/control-plane/rpc" }
 utils = { path = "../dependencies/control-plane/utils/utils-lib" }
-strum = "0.26.3"
-strum_macros = "0.26.4"
-tracing = "0.1.40"
+
+actix-web = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+once_cell = { workspace = true }
+clap = { workspace = true, features = ["color", "derive", "string"] }
+prometheus = { workspace = true }
+tonic = { workspace = true }
+serde = { workspace = true }
+mime = { workspace = true }
+tracing = { workspace = true }

--- a/nix/pkgs/extensions/cargo-project.nix
+++ b/nix/pkgs/extensions/cargo-project.nix
@@ -64,6 +64,7 @@ let
     "call-home"
     "upgrade"
     "constants"
+    "dependencies/control-plane/Cargo.toml"
     "dependencies/control-plane/openapi/Cargo.toml"
     "dependencies/control-plane/openapi/build.rs"
     "dependencies/control-plane/openapi/src/lib.rs"


### PR DESCRIPTION
This will make crate upgrades easier to maintain.
