### PR TITLE
fix: Prerequisites hyperlink in helm chart's readme file

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -8,7 +8,7 @@ Mayastor Helm chart for Kubernetes
 
 ### Prerequisites
 
- - Make sure the [system requirement pre-requisites](https://mayastor.gitbook.io/introduction/quickstart/prerequisites) are met.
+ - Make sure the [system requirement pre-requisites](https://openebs.io/docs/quickstart-guide/prerequisites#replicated-pv-mayastor-prerequisites) are met.
  - Label the storage nodes same as the mayastor.nodeSelector in values.yaml
  - Create the namespace you want the chart to be installed, or pass the `--create-namespace` flag in the `helm install` command.
    ```sh

--- a/chart/README.md.tmpl
+++ b/chart/README.md.tmpl
@@ -7,7 +7,7 @@
 
 ### Prerequisites
 
- - Make sure the [system requirement pre-requisites](https://mayastor.gitbook.io/introduction/quickstart/prerequisites) are met.
+ - Make sure the [system requirement pre-requisites](https://openebs.io/docs/quickstart-guide/prerequisites#replicated-pv-mayastor-prerequisites) are met.
  - Label the storage nodes same as the mayastor.nodeSelector in values.yaml
  - Create the namespace you want the chart to be installed, or pass the `--create-namespace` flag in the `helm install` command.
    ```sh


### PR DESCRIPTION
This PR fixes the prerequisites hyperlink in helm chart's readme file.

Earlier it was pointing to the older gitbook website.