### PR TITLE
fix(chart): wait for etcd upgrade rollout before exiting

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -241,6 +241,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;repo | The container repository for the hook job | `"openebs/kubectl"` |
 | preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | The container image tag for the hook job | `"1.25.15"` |
 | preUpgradeHook.&ZeroWidthSpace;imagePullSecrets | Optional array of imagePullSecrets containing private registry credentials # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ | `[]` |
+| preUpgradeHook.&ZeroWidthSpace;rolloutTimeout | Set how long we should wait for the Etcd cluster to finish rolling out before giving up. | `"600s"` |
 | preUpgradeHook.&ZeroWidthSpace;tolerations | Node tolerations for server scheduling to nodes with taints # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # | `[]` |
 | priorityClassName | Pod scheduling priority. Setting this value will apply to all components except the external Chart dependencies. If any component has `priorityClassName` set, then this value would be overridden for that component. For external components like etcd, jaeger or loki, PriorityClass can only be set at component level. | `""` |
 | storageClass.&ZeroWidthSpace;allowVolumeExpansion | Enable volume expansion for the default StorageClass. | `true` |

--- a/chart/label-etcd-for-helm-release.sh
+++ b/chart/label-etcd-for-helm-release.sh
@@ -127,13 +127,15 @@ print_help() {
     cat <<EOF
 Usage: $0 [OPTIONS] <helm_release_name>
 
-  <helm_release_name>          (required) The release name of the helm
-                               release whose Etcd
+  <helm_release_name>            (required) The release name of the helm
+                                 release which deploys the Etcd.
 
 Options:
-  -h, --help                   Display this text.
-  -n, --namespace <namespace>  Set the kubernetes namespace of the Etcd
-                               cluster. (default: )
+  -h, --help                     Display this text.
+  -n, --namespace <namespace>    Set the kubernetes namespace of the Etcd
+                                 cluster. (default: )
+  --rollout-timeout <duration>   Timeout for waiting on StatefulSet rollout
+                                 to complete. (default: ${ROLLOUT_TIMEOUT})
 
 Examples:
   $0 -n mayastor openebs-mayastor
@@ -162,6 +164,18 @@ parse_args() {
         ;;
       *)
         NAMESPACE=${arg#*=}
+        ;;
+      esac
+      ;;
+    --rollout-timeout*)
+      case "$arg" in
+      --rollout-timeout)
+        test $# -lt 2 && log_fatal "missing value for the optional argument '$arg'."
+        ROLLOUT_TIMEOUT=$2
+        shift
+        ;;
+      *)
+        ROLLOUT_TIMEOUT=${arg#*=}
         ;;
       esac
       ;;
@@ -254,6 +268,7 @@ NAMESPACE=
 # Mandatory input.
 RELEASE_NAME=
 EXISTING_ETCD_STS=
+ROLLOUT_TIMEOUT="600s"
 
 parse_args "$@"
 
@@ -318,5 +333,9 @@ kubectl_ns label --overwrite po -l "$etcd_selector" app.kubernetes.io/component=
 kubectl_ns delete sts -l "$etcd_selector" --cascade=orphan --ignore-not-found
 # Create the StatefulSet with the new label. This is idempotent because we exit early if we find no StatefulSet.
 echo "$modified_etcd_yaml" | "$KUBECTL" create -f -
+
+# Wait for the StatefulSet rollout to complete before exiting.
+# This ensures the etcd cluster is stable before the Bitnami preUpgradeJob runs.
+kubectl_ns rollout status statefulset/"$sts_name" --timeout="$ROLLOUT_TIMEOUT"
 
 set +o errexit +o xtrace

--- a/chart/templates/pre-upgrade-hook.yaml
+++ b/chart/templates/pre-upgrade-hook.yaml
@@ -130,7 +130,7 @@ spec:
             - "sh"
             - "-c"
           args:
-            - "/scripts/label-etcd-for-helm-release.sh {{ .Release.Name }} -n {{ .Release.Namespace }}"
+            - "/scripts/label-etcd-for-helm-release.sh {{ .Release.Name }} -n {{ .Release.Namespace }} --rollout-timeout {{ .Values.preUpgradeHook.rolloutTimeout }}"
           volumeMounts:
             - name: scripts
               mountPath: /scripts

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -737,7 +737,7 @@ alloy:
       create: true
       content: |
         {{- $releaseName := .Release.Name | replace "-" "_" -}}
-        
+
         livedebugging {
           enabled = {{ .Values.logging_config.debugging }}
         }
@@ -973,6 +973,8 @@ localpv-provisioner:
 preUpgradeHook:
   # -- Enable/Disable mayastor pre-upgrade hook
   enabled: true
+  # -- Set how long we should wait for the Etcd cluster to finish rolling out before giving up.
+  rolloutTimeout: "600s"
   # -- Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##


### PR DESCRIPTION
It's hard to reason about https://github.com/openebs/openebs/issues/4150. One possible way to end up in a state like this may be that there are 2 rollouts of the etcd happening -- First rollout happens when the 8.6.0 etcd is deleted with orphaned pods and recreated with new labels. The bitnami preUpgradeJob runs against this new rollout Pods. Now, while this rollout is still in-progress the bitnami job may exit quickly and helm may apply the 12.x etcd chart, triggering another rollout on a cluster which is potentially unhealthy. Maybe the bitnami preUpgradeJob's changes couldn't propagate to the entire cluster as the rollout was partially done. And then the second rollout happens from helm's apply. The reasoning is that between the successful Bitnami preUpgradeJob completion and the 8.6.0 Etcd cluster rebalancing itself and reaching a healthy state, the helm 12.x rollout tears it apart.

If the preUpgradeJob's write operations are able to succeed, this means, the cluster has quorum. Else the job will fail and be retried, until it succeeds (tested scenario). If the cluster has quorum, this would mean it has data availability. But compromised survivability, and the new helm rollout may start killing Pods and destabilize the cluster.

There's also another possibility, less likely. The initial rollout was so slow that the etcd preUpgradeJob was able to spawn and finish against the 8.6.0 cluster. And while the rollout was happening, the next rollout was also issued, and the cluster was on the brink of quorum, and the eventually lost consistency.

Anyway, these are assumptions, and it might be a good idea for us to wait for the first rollout to complete completely.