### PR TITLE
fix: etcd jwt permission issue for openshift

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -176,6 +176,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | etcd.&ZeroWidthSpace;podAntiAffinityPreset | Pod anti-affinity preset Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity | `"hard"` |
 | etcd.&ZeroWidthSpace;removeMemberOnContainerTermination | Use a PreStop hook to remove the etcd members from the etcd cluster on container termination Ignored if lifecycleHooks is set or replicaCount=1 | `false` |
 | etcd.&ZeroWidthSpace;replicaCount | Number of replicas of etcd | `3` |
+| global.&ZeroWidthSpace;compatibility.&ZeroWidthSpace;openshift.&ZeroWidthSpace;adaptSecurityContext | Adapt the securityContext sections of the ETCD STS to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation) | `"disable"` |
 | image.&ZeroWidthSpace;pullPolicy | ImagePullPolicy for our images | `"Always"` |
 | image.&ZeroWidthSpace;pullSecrets | docker-secrets required to pull images if the container registry from image.registry is protected | `[]` |
 | image.&ZeroWidthSpace;registry | Image registry to pull our product images | `"docker.io"` |

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -9,6 +9,10 @@ crds:
 global:
   security:
     allowInsecureImages: true
+  compatibility:
+    openshift:
+      # -- Adapt the securityContext sections of the ETCD STS to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
+      adaptSecurityContext: disable
 
 image:
   # -- Image registry to pull our product images


### PR DESCRIPTION
This PR fixes etcd jwt permission issues during fresh installs and upgrades of mayastor on openshift cluster

Disables automatic security context adaptation:

global.compatibility.openshift.adaptSecurityContext=disable
This preserves:
runAsUser
runAsGroup
fsGroup

Allowing:
UID 1001 to access mounted secrets
ETCD to start successfully

Only Helm Chart Changes introduced, no code changes.
Updated Documentation