### PR TITLE
feat: allow specifying nodeSelector in the Helm chart for all components

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -74,6 +74,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;encryptedPoolsSoftScheduling | Prefer encrypted pools for volume replicas. If a volume wasn't provisioned with a encryption storageclass, we try to place the replicas of such volume on best-effort basis onto encrypted pools, if this global is set. This is effective subject to volume spec already modified via plugin to request encryption. | `false` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;logLevel | Log level for the core service | `"info"` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;minTimeouts | Enable minimal timeouts | `true` |
+| agents.&ZeroWidthSpace;core.&ZeroWidthSpace;nodeSelector | Set nodeSelector, overrides global | <pre>{<br><br>}</pre> |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;poolClusterSize | Default blobstore cluster size for diskpools, in bytes. This value is used as a default value of blobstore cluster size on diskpools. This is set to 4MiB internally by default, if nothing specified here. The value is also configurable via Diskpool CR, which takes precedence over this setting. This is an advanced configuration, please refer documentation to understand the usage and implications of this. | `""` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;priorityClassName | Set PriorityClass, overrides global. If both local and global are not set, the final deployment manifest has a mayastor custom critical priority class assigned to the pod by default. Refer the `templates/_helpers.tpl` and `templates/mayastor/agents/core/agent-core-deployment.yaml` for more details. | `""` |
 | agents.&ZeroWidthSpace;core.&ZeroWidthSpace;rebuild.&ZeroWidthSpace;maxConcurrent | The maximum number of system-wide rebuilds permitted at any given time. If set to an empty string, there are no limits. | `""` |
@@ -92,6 +93,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;cluster.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;cpu | Cpu requests for ha cluster agent | `"100m"` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;cluster.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;memory | Memory requests for ha cluster agent | `"16Mi"` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;node.&ZeroWidthSpace;logLevel | Log level for the ha node service | `"info"` |
+| agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;node.&ZeroWidthSpace;nodeSelector | Set nodeSelector, overrides global | <pre>{<br><br>}</pre> |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;node.&ZeroWidthSpace;port | Container port for the ha-node service | `50053` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;node.&ZeroWidthSpace;priorityClassName | Set PriorityClass, overrides global | `""` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;node.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for ha node agent | `"100m"` |
@@ -113,6 +115,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | apis.&ZeroWidthSpace;rest.&ZeroWidthSpace;healthProbes.&ZeroWidthSpace;readiness.&ZeroWidthSpace;periodSeconds | No. of seconds between readiness probe checks. | `20` |
 | apis.&ZeroWidthSpace;rest.&ZeroWidthSpace;healthProbes.&ZeroWidthSpace;readiness.&ZeroWidthSpace;timeoutSeconds | No. of seconds of timeout tolerance. | `5` |
 | apis.&ZeroWidthSpace;rest.&ZeroWidthSpace;logLevel | Log level for the rest service | `"info"` |
+| apis.&ZeroWidthSpace;rest.&ZeroWidthSpace;nodeSelector | Set nodeSelector, overrides global | <pre>{<br><br>}</pre> |
 | apis.&ZeroWidthSpace;rest.&ZeroWidthSpace;priorityClassName | Set PriorityClass, overrides global. If both local and global are not set, the final deployment manifest has a mayastor custom critical priority class assigned to the pod by default. Refer the `templates/_helpers.tpl` and `templates/mayastor/apis/rest/api-rest-deployment.yaml` for more details. | `""` |
 | apis.&ZeroWidthSpace;rest.&ZeroWidthSpace;replicaCount | Number of replicas of rest | `1` |
 | apis.&ZeroWidthSpace;rest.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for rest | `"100m"` |
@@ -131,6 +134,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | crds.&ZeroWidthSpace;csi.&ZeroWidthSpace;volumeSnapshots.&ZeroWidthSpace;enabled | Install Volume Snapshot CRDs | `true` |
 | crds.&ZeroWidthSpace;enabled | Disables the installation of all CRDs if set to false | `true` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;logLevel | Log level for the csi controller | `"info"` |
+| csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;nodeSelector | Set nodeSelector, overrides global | <pre>{<br><br>}</pre> |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;preventVolumeModeConversion | Prevent modifying the volume mode when creating a PVC from an existing VolumeSnapshot | `true` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;priorityClassName | Set PriorityClass, overrides global | `""` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for csi controller | `"32m"` |
@@ -148,6 +152,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;snapshotControllerTag | csi-snapshot-controller image release tag | `"v8.2.0"` |
 | csi.&ZeroWidthSpace;image.&ZeroWidthSpace;snapshotterTag | csi-snapshotter image release tag | `"v8.2.0"` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;kubeletDir | The kubeletDir directory for the csi-node plugin | `"/var/lib/kubelet"` |
+| csi.&ZeroWidthSpace;node.&ZeroWidthSpace;nodeSelector | Set nodeSelector, overrides global | <pre>{<br><br>}</pre> |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;nvme.&ZeroWidthSpace;ctrl_loss_tmo | The ctrl_loss_tmo (controller loss timeout) in seconds | `"1980"` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;nvme.&ZeroWidthSpace;tcpFallback | Fallback to nvme-tcp if nvme-rdma is enabled for Mayastor but rdma is not available on a particular csi-node | `true` |
 | csi.&ZeroWidthSpace;node.&ZeroWidthSpace;port | Container port for the csi-node service | `10199` |
@@ -222,6 +227,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | nodeSelector | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ Note that if multi-arch images support 'kubernetes.io/arch: amd64' should be removed and set 'nodeSelector' to empty '{}' as default value. | <pre>{<br>"kubernetes.io/arch":"amd64"<br>}</pre> |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;enabled | Enable callhome | `true` |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;logLevel | Log level for callhome | `"info"` |
+| obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;nodeSelector | Set nodeSelector, overrides global | <pre>{<br><br>}</pre> |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;priorityClassName | Set PriorityClass, overrides global | `""` |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for callhome | `"100m"` |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;memory | Memory limits for callhome | `"32Mi"` |
@@ -235,6 +241,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | obs.&ZeroWidthSpace;stats.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;memory | Memory requests for stats | `"16Mi"` |
 | obs.&ZeroWidthSpace;stats.&ZeroWidthSpace;service.&ZeroWidthSpace;type | Rest K8s service type | `"ClusterIP"` |
 | operators.&ZeroWidthSpace;pool.&ZeroWidthSpace;logLevel | Log level for diskpool operator service | `"info"` |
+| operators.&ZeroWidthSpace;pool.&ZeroWidthSpace;nodeSelector | Set nodeSelector, overrides global | <pre>{<br><br>}</pre> |
 | operators.&ZeroWidthSpace;pool.&ZeroWidthSpace;priorityClassName | Set PriorityClass, overrides global | `""` |
 | operators.&ZeroWidthSpace;pool.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;cpu | Cpu limits for diskpool operator | `"100m"` |
 | operators.&ZeroWidthSpace;pool.&ZeroWidthSpace;resources.&ZeroWidthSpace;limits.&ZeroWidthSpace;memory | Memory limits for diskpool operator | `"32Mi"` |

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -208,6 +208,19 @@ Usage:
 {{- end }}
 
 {{/*
+Creates the node selector based on the global and component wise node selectors
+Usage:
+{{ include "node_selector" (dict "template" . "localNodeSelector" .Values.path.to.local.nodeSelector) }}
+*/}}
+{{- define "node_selector" -}}
+{{- if .localNodeSelector }}
+    {{- toYaml .localNodeSelector | nindent 8 }}
+{{- else if .template.Values.nodeSelector }}
+    {{- toYaml .template.Values.nodeSelector | nindent 8 }}
+{{- end }}
+{{- end }}
+
+{{/*
 Generates the priority class name, with the given `template` and the `localPriorityClass`
 Usage:
 {{ include "priority_class" (dict "template" . "localPriorityClass" .Values.path.to.local.priorityClassName) }}

--- a/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
+++ b/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
@@ -28,8 +28,8 @@ spec:
       {{- if $pcName := include "priority_class_with_default" (dict "template" . "localPriorityClass" .Values.agents.core.priorityClassName) }}
       priorityClassName: {{ $pcName }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- if $nodeSelector := include "node_selector" (dict "template" . "localNodeSelector" .Values.agents.core.nodeSelector) }}
+      nodeSelector: {{ $nodeSelector }}
       {{- end }}
       {{- if $tolerations := include "_tolerations_with_early_eviction" (dict "template" . "localTolerations" .Values.agents.core.tolerations) }}
       tolerations: {{ $tolerations }}

--- a/chart/templates/mayastor/agents/ha/ha-node-daemonset.yaml
+++ b/chart/templates/mayastor/agents/ha/ha-node-daemonset.yaml
@@ -35,9 +35,7 @@ spec:
       priorityClassName: {{ $pcName }}
       {{- end }}
       nodeSelector:
-        {{- if .Values.nodeSelector }}
-        {{- toYaml .Values.nodeSelector | nindent 8 }}
-        {{- end }}
+        {{- include "node_selector" (dict "template" . "localNodeSelector" .Values.agents.ha.node.nodeSelector) }}
         {{- if .Values.csi.node.topology.nodeSelector }}
         {{- range $key, $val := .Values.csi.node.topology.segments }}
         {{ $key }}: {{ $val }}

--- a/chart/templates/mayastor/apis/api-rest-deployment.yaml
+++ b/chart/templates/mayastor/apis/api-rest-deployment.yaml
@@ -27,8 +27,8 @@ spec:
       {{- if $pcName := include "priority_class_with_default" (dict "template" . "localPriorityClass" .Values.apis.rest.priorityClassName) }}
       priorityClassName: {{ $pcName }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- if $nodeSelector := include "node_selector" (dict "template" . "localNodeSelector" .Values.apis.rest.nodeSelector) }}
+      nodeSelector: {{ $nodeSelector }}
       {{- end }}
       {{- if $tolerations := include "_tolerations_with_early_eviction" (dict "template" . "localTolerations" .Values.apis.rest.tolerations) }}
       tolerations: {{ $tolerations }}

--- a/chart/templates/mayastor/csi/csi-controller-deployment.yaml
+++ b/chart/templates/mayastor/csi/csi-controller-deployment.yaml
@@ -31,8 +31,8 @@ spec:
       {{- if $pcName := include "priority_class_with_default" (dict "template" . "localPriorityClass" .Values.csi.controller.priorityClassName) }}
       priorityClassName: {{ $pcName }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- if $nodeSelector := include "node_selector" (dict "template" . "localNodeSelector" .Values.csi.controller.nodeSelector) }}
+      nodeSelector: {{ $nodeSelector }}
       {{- end }}
       {{- if $tolerations := include "_tolerations_with_early_eviction" (dict "template" . "localTolerations" .Values.csi.controller.tolerations) }}
       tolerations: {{ $tolerations }}

--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -36,9 +36,7 @@ spec:
       priorityClassName: {{ $pcName }}
       {{- end }}
       nodeSelector:
-        {{- if .Values.nodeSelector }}
-        {{- toYaml .Values.nodeSelector | nindent 8 }}
-        {{- end }}
+        {{- include "node_selector" (dict "template" . "localNodeSelector" .Values.csi.node.nodeSelector) }}
         {{- if .Values.csi.node.topology.nodeSelector }}
         {{- range $key, $val := .Values.csi.node.topology.segments }}
         {{ $key }}: {{ $val }}

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -28,7 +28,9 @@ spec:
       hostNetwork: true
       # To resolve services in the namespace
       dnsPolicy: ClusterFirstWithHostNet
-      nodeSelector: {{- .Values.io_engine.nodeSelector | toYaml | nindent 8 }}
+      {{- if $nodeSelector := include "node_selector" (dict "template" . "localNodeSelector" .Values.io_engine.nodeSelector) }}
+      nodeSelector: {{ $nodeSelector }}
+      {{- end }}
       {{- if $pcName := include "priority_class_with_default" (dict "template" . "localPriorityClass" .Values.io_engine.priorityClassName) }}
       priorityClassName: {{ $pcName }}
       {{- end }}

--- a/chart/templates/mayastor/obs/obs-callhome-deployment.yaml
+++ b/chart/templates/mayastor/obs/obs-callhome-deployment.yaml
@@ -27,8 +27,8 @@ spec:
       {{- if $pcName := include "priority_class" (dict "template" . "localPriorityClass" .Values.obs.callhome.priorityClassName) }}
       priorityClassName: {{ $pcName }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- if $nodeSelector := include "node_selector" (dict "template" . "localNodeSelector" .Values.obs.callhome.nodeSelector) }}
+      nodeSelector: {{ $nodeSelector }}
       {{- end }}
       {{- if $tolerations := include "tolerations" (dict "template" . "localTolerations" .Values.obs.callhome.tolerations) }}
       tolerations: {{ $tolerations }}

--- a/chart/templates/mayastor/operators/operator-diskpool-deployment.yaml
+++ b/chart/templates/mayastor/operators/operator-diskpool-deployment.yaml
@@ -28,8 +28,8 @@ spec:
       {{- if $pcName := include "priority_class_with_default" (dict "template" . "localPriorityClass" .Values.operators.pool.priorityClassName) }}
       priorityClassName: {{ $pcName }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- if $nodeSelector := include "node_selector" (dict "template" . "localNodeSelector" .Values.operators.pool.nodeSelector) }}
+      nodeSelector: {{ $nodeSelector }}
       {{- end }}
       {{- if $tolerations := include "_tolerations_with_early_eviction" (dict "template" . "localTolerations" .Values.operators.pool.tolerations) }}
       tolerations: {{ $tolerations }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -133,6 +133,8 @@ operators:
         memory: "16Mi"
     # -- Set tolerations, overrides global
     tolerations: [ ]
+    # -- Set nodeSelector, overrides global
+    nodeSelector: {}
     # -- Set PriorityClass, overrides global
     priorityClassName: ""
 jaeger-operator:
@@ -207,6 +209,8 @@ agents:
         memory: "32Mi"
     # -- Set tolerations, overrides global
     tolerations: [ ]
+    # -- Set nodeSelector, overrides global
+    nodeSelector: {}
     # -- Set PriorityClass, overrides global.
     # If both local and global are not set, the final deployment manifest has a mayastor custom critical priority class assigned to the pod by default.
     # Refer the `templates/_helpers.tpl` and `templates/mayastor/agents/core/agent-core-deployment.yaml` for more details.
@@ -242,6 +246,8 @@ agents:
           memory: "64Mi"
       # -- Set tolerations, overrides global
       tolerations: [ ]
+      # -- Set nodeSelector, overrides global
+      nodeSelector: {}
       # -- Set PriorityClass, overrides global
       priorityClassName: ""
       # -- Container port for the ha-node service
@@ -314,6 +320,8 @@ apis:
         https: 30010
     # -- Set tolerations, overrides global
     tolerations: [ ]
+    # -- Set nodeSelector, overrides global
+    nodeSelector: {}
     # -- Set PriorityClass, overrides global.
     # If both local and global are not set, the final deployment manifest has a mayastor custom critical priority class assigned to the pod by default.
     # Refer the `templates/_helpers.tpl` and `templates/mayastor/apis/rest/api-rest-deployment.yaml` for more details.
@@ -356,6 +364,8 @@ csi:
         memory: "64Mi"
     # -- Set tolerations, overrides global
     tolerations: [ ]
+    # -- Set nodeSelector, overrides global
+    nodeSelector: {}
     # -- Set PriorityClass, overrides global
     priorityClassName: ""
     # -- Prevent modifying the volume mode when creating a PVC from an existing VolumeSnapshot
@@ -404,6 +414,8 @@ csi:
       enabled: true
     # -- Set tolerations, overrides global
     tolerations: [ ]
+    # -- Set nodeSelector, overrides global
+    nodeSelector: {}
     # -- Set PriorityClass, overrides global
     priorityClassName: ""
     initContainers:
@@ -950,6 +962,8 @@ obs:
         memory: "16Mi"
     # -- Set tolerations, overrides global
     tolerations: [ ]
+    # -- Set nodeSelector, overrides global
+    nodeSelector: {}
     # -- Set PriorityClass, overrides global
     priorityClassName: ""
   # Eventing component enabled/disabled based on obs.callhome.enabled value


### PR DESCRIPTION
## Description

Add per-component `nodeSelector` support to all Deployments, StatefulSets, and DaemonSets in the Helm chart, matching the existing `tolerations` pattern: a component-level value takes precedence, with the global `nodeSelector` as fallback.

Changes:
- New `node_selector` helper template in `_helpers.tpl` (mirrors the existing `tolerations` helper)
- Added `nodeSelector: {}` to 7 component sections in `values.yaml` (`agents.core`, `agents.ha.node`, `apis.rest`, `csi.controller`, `csi.node`, `obs.callhome`, `operators.pool`)
- Updated all 8 workload templates to use the new helper
- The `io-engine` DaemonSet (which already had its own `nodeSelector`) now also falls back to the global value
- Regenerated `chart/README.md` via `helm-docs`

## Motivation and Context

Previously, `tolerations` supported per-component overrides with a global fallback, but `nodeSelector` only existed at the global level for most components. This made it impossible to schedule individual components on different nodes (e.g., placing the control plane on dedicated nodes while keeping the data plane on storage nodes) without resorting to post-render patching.

## Regression

No

## How Has This Been Tested?

- `helm template` with default values renders identically to before (all components inherit global `nodeSelector`)
- `helm template --set agents.core.nodeSelector.custom/node=storage` correctly applies the override only to `agent-core`, while other components retain the global `nodeSelector`
- `io-engine` retains its component-level `nodeSelector` (`openebs.io/engine: mayastor` + `kubernetes.io/arch: amd64`)
- CSI node and HA node DaemonSets correctly merge per-component `nodeSelector` with topology segments
- `helm-docs` regenerates `README.md` with all new fields documented

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
