### PR TITLE
feat: add global helm global values

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -123,6 +123,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 | apis.&ZeroWidthSpace;rest.&ZeroWidthSpace;tolerations | Set tolerations, overrides global | `[]` |
 | base.&ZeroWidthSpace;cache_poll_period | Cache timeout for core agent & diskpool deployment | `"30s"` |
 | base.&ZeroWidthSpace;default_req_timeout | Request timeout for rest & core agents | `"5s"` |
+| base.&ZeroWidthSpace;initContainers.&ZeroWidthSpace;image.&ZeroWidthSpace;registry | Image registry for init containers | `""` |
 | base.&ZeroWidthSpace;logging.&ZeroWidthSpace;color | Enable ansi color code for Pod StdOut/StdErr | `true` |
 | base.&ZeroWidthSpace;logging.&ZeroWidthSpace;format | Valid values for format are pretty, json and compact | `"pretty"` |
 | base.&ZeroWidthSpace;logging.&ZeroWidthSpace;silenceLevel | Silence specific module components | `nil` |
@@ -176,6 +177,10 @@ This removes all the Kubernetes components associated with the chart and deletes
 | etcd.&ZeroWidthSpace;podAntiAffinityPreset | Pod anti-affinity preset Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity | `"hard"` |
 | etcd.&ZeroWidthSpace;removeMemberOnContainerTermination | Use a PreStop hook to remove the etcd members from the etcd cluster on container termination Ignored if lifecycleHooks is set or replicaCount=1 | `false` |
 | etcd.&ZeroWidthSpace;replicaCount | Number of replicas of etcd | `3` |
+| global.&ZeroWidthSpace;analytics.&ZeroWidthSpace;enabled | Global overide for call home | `nil` |
+| global.&ZeroWidthSpace;imagePullPolicy | Global overide for image pull policy | `""` |
+| global.&ZeroWidthSpace;imagePullSecrets | Global override for image pull secrets - secret | `[]` |
+| global.&ZeroWidthSpace;imageRegistry | Global override for image registry | `""` |
 | image.&ZeroWidthSpace;pullPolicy | ImagePullPolicy for our images | `"Always"` |
 | image.&ZeroWidthSpace;pullSecrets | docker-secrets required to pull images if the container registry from image.registry is protected | `[]` |
 | image.&ZeroWidthSpace;registry | Image registry to pull our product images | `"docker.io"` |

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -83,9 +83,21 @@ Usage:
 {{ include "base_pull_secrets" . }}
 */}}
 {{- define "base_pull_secrets" -}}
-    {{- if (not (empty .Values.image.pullSecrets)) }}
-        {{- range .Values.image.pullSecrets | uniq -}}
+    {{- if (not (empty .Values.global.imagePullSecrets)) }}
+        {{- range .Values.global.imagePullSecrets | uniq -}}
+            {{- if kindIs "map" . -}}
+            {{ nindent 8 "- name:" }} {{ .name }}
+            {{- else -}}
             {{ nindent 8 "- name:" }} {{ . }}
+            {{- end }}
+        {{- end }}
+    {{- else if (not (empty .Values.image.pullSecrets)) }}
+        {{- range .Values.image.pullSecrets | uniq -}}
+            {{- if kindIs "map" . -}}
+            {{ nindent 8 "- name:" }} {{ .name }}
+            {{- else -}}
+            {{ nindent 8 "- name:" }} {{ . }}
+            {{- end }}
         {{- end }}
     {{- else -}}
         {{- if .Values.base.imagePullSecrets }}
@@ -98,6 +110,41 @@ Usage:
             {{- end }}
         {{- end }}
     {{- end }}
+{{- end -}}
+
+{{/*
+Concatenates imagepullsecrets for preupgradehook and handles different formats (example - secret or - name: secret)
+*/}}
+{{- define "mayastor.preUpgradeHook.pullSecrets" -}}
+{{- $names := list -}}
+{{- with .Values.global.imagePullSecrets -}}
+  {{- range . -}}
+    {{- if kindIs "map" . }}
+      {{- if and (hasKey . "name") (not (empty .name)) -}}
+        {{ $names = append $names .name }}
+      {{- end -}}
+    {{- else if not (empty .) -}}
+      {{ $names = append $names . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- with .Values.preUpgradeHook.imagePullSecrets -}}
+  {{- range . }}
+    {{- if kindIs "map" . -}}
+      {{- if and (hasKey . "name") (not (empty .name)) -}}
+        {{- $names = append $names .name }}
+      {{- end -}}
+    {{- else if not (empty .) -}}
+      {{- $names = append $names . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $names = uniq $names -}}
+{{- if $names -}}
+  {{- range $names }}
+- name: {{ . }}
+  {{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -326,14 +373,15 @@ Renders init containers. If unset it sets the container image.
     {{- $containers := list }}
     {{- $image := .context.Values.base.initContainers.image }}
     {{- $values_image := .context.Values.image }}
+    {{- $global := .context.Values.global }}
     {{- range .value -}}
         {{ $container := . }}
         {{- if not (hasKey . "imagePullPolicy") }}
-            {{- $pullPolicy := $image.pullPolicy | default $values_image.pullPolicy }}
+            {{- $pullPolicy := $global.imagePullPolicy | default $image.pullPolicy | default $values_image.pullPolicy }}
             {{- $_ := set $container "imagePullPolicy" $pullPolicy }}
         {{- end }}
         {{- if or (not $image) (not (hasKey . "image")) }}
-            {{- $registry := $image.registry | default $values_image.registry | default "docker.io" }}
+            {{- $registry := $global.imageRegistry | default $image.registry | default $values_image.registry }}
             {{- $namespace := $image.namespace | default $values_image.repo }}
             {{- $name := $image.name | default "alpine-sh" }}
             {{- $tag := $image.tag | default "4.1.0" }}

--- a/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
+++ b/chart/templates/mayastor/agents/core/agent-core-deployment.yaml
@@ -43,8 +43,8 @@ spec:
             requests:
               cpu: {{ .Values.agents.core.resources.requests.cpu | quote }}
               memory: {{ .Values.agents.core.resources.requests.memory | quote }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-agent-core:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ default .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-agent-core:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
+          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.global.imagePullPolicy }}
           args:
             - "--store={{ include "etcdUrl" . }}"
             - "--request-timeout={{ default .Values.base.default_req_timeout .Values.agents.core.requestTimeout }}"
@@ -104,8 +104,8 @@ spec:
             requests:
               cpu: {{ .Values.agents.ha.cluster.resources.requests.cpu | quote }}
               memory: {{ .Values.agents.ha.cluster.resources.requests.memory | quote }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-agent-ha-cluster:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ default .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-agent-ha-cluster:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
+          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.global.imagePullPolicy }}
           args:
             - "-g=[::]:50052"
             - "--store=http://{{ include "etcdUrl" . }}"

--- a/chart/templates/mayastor/agents/ha/ha-node-daemonset.yaml
+++ b/chart/templates/mayastor/agents/ha/ha-node-daemonset.yaml
@@ -48,8 +48,8 @@ spec:
       {{- end }}
       containers:
       - name: agent-ha-node
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-agent-ha-node:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "{{ default .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-agent-ha-node:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
+        imagePullPolicy: {{ default .Values.image.pullPolicy .Values.global.imagePullPolicy }}
         securityContext:
           privileged: true
         env:

--- a/chart/templates/mayastor/apis/api-rest-deployment.yaml
+++ b/chart/templates/mayastor/apis/api-rest-deployment.yaml
@@ -42,8 +42,8 @@ spec:
             requests:
               cpu: {{ .Values.apis.rest.resources.requests.cpu | quote }}
               memory: {{ .Values.apis.rest.resources.requests.memory | quote }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-api-rest:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ default .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-api-rest:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
+          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.global.imagePullPolicy}}
           args:
             - "--dummy-certificates"
             - "--no-auth"

--- a/chart/templates/mayastor/csi/csi-controller-deployment.yaml
+++ b/chart/templates/mayastor/csi/csi-controller-deployment.yaml
@@ -46,8 +46,8 @@ spec:
             requests:
               cpu: {{ .Values.csi.controller.resources.requests.cpu | quote }}
               memory: {{ .Values.csi.controller.resources.requests.memory | quote }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-csi-controller:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ default .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-csi-controller:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
+          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.global.imagePullPolicy }}
           args:
             - "--csi-socket=/var/lib/csi/sockets/pluginproxy/csi.sock"
             - "--rest-endpoint=http://{{ .Release.Name }}-api-rest:8081"{{ if .Values.base.jaeger.enabled }}
@@ -70,7 +70,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: "{{ .Values.csi.image.registry }}/{{ .Values.csi.image.repo }}/csi-provisioner:{{ .Values.csi.image.provisionerTag }}"
+          image: "{{ default .Values.csi.image.registry .Values.global.imageRegistry }}/{{ .Values.csi.image.repo }}/csi-provisioner:{{ .Values.csi.image.provisionerTag }}"
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"
@@ -86,12 +86,12 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
+          imagePullPolicy: {{ default .Values.csi.image.pullPolicy .Values.global.imagePullPolicy }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: "{{ .Values.csi.image.registry }}/{{ .Values.csi.image.repo }}/csi-attacher:{{ .Values.csi.image.attacherTag }}"
+          image: "{{ default .Values.csi.image.registry .Values.global.imageRegistry }}/{{ .Values.csi.image.repo }}/csi-attacher:{{ .Values.csi.image.attacherTag }}"
           args:
             - "--v=2"
             - "--timeout=36s"
@@ -99,19 +99,19 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
+          imagePullPolicy: {{ default .Values.csi.image.pullPolicy .Values.global.imagePullPolicy }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: "{{ .Values.csi.image.registry }}/{{ .Values.csi.image.repo }}/csi-snapshotter:{{ .Values.csi.image.snapshotterTag }}"
+          image: "{{ default .Values.csi.image.registry .Values.global.imageRegistry }}/{{ .Values.csi.image.repo }}/csi-snapshotter:{{ .Values.csi.image.snapshotterTag }}"
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
+          imagePullPolicy: {{ default .Values.csi.image.pullPolicy .Values.global.imagePullPolicy }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -122,8 +122,8 @@ spec:
             {{- if default .Values.csi.controller.preventVolumeModeConversion }}
             - "--prevent-volume-mode-conversion"
             {{- end }}
-          image: "{{ .Values.csi.image.registry }}/{{ .Values.csi.image.repo }}/snapshot-controller:{{ .Values.csi.image.snapshotControllerTag }}"
-          imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
+          image: "{{ default .Values.csi.image.registry .Values.global.imageRegistry }}/{{ .Values.csi.image.repo }}/snapshot-controller:{{ .Values.csi.image.snapshotControllerTag }}"
+          imagePullPolicy: {{ default .Values.csi.image.pullPolicy .Values.global.imagePullPolicy }}
         - name: csi-resizer
           args:
             - "--v=2"
@@ -132,8 +132,8 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: "{{ .Values.csi.image.registry }}/{{ .Values.csi.image.repo }}/csi-resizer:{{ .Values.csi.image.resizerTag }}"
-          imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
+          image: "{{ default .Values.csi.image.registry .Values.global.imageRegistry }}/{{ .Values.csi.image.repo }}/csi-resizer:{{ .Values.csi.image.resizerTag }}"
+          imagePullPolicy: {{ default .Values.csi.image.pullPolicy .Values.global.imagePullPolicy }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/chart/templates/mayastor/csi/csi-node-daemonset.yaml
+++ b/chart/templates/mayastor/csi/csi-node-daemonset.yaml
@@ -55,8 +55,8 @@ spec:
       # the same.
       containers:
       - name: csi-node
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-csi-node:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "{{ default .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-csi-node:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
+        imagePullPolicy: {{ default .Values.image.pullPolicy .Values.global.imagePullPolicy }}
         # we need privileged because we mount filesystems and use mknod
         securityContext:
           privileged: true
@@ -127,8 +127,8 @@ spec:
             cpu: {{ .Values.csi.node.resources.requests.cpu | quote }}
             memory: {{ .Values.csi.node.resources.requests.memory | quote }}
       - name: csi-driver-registrar
-        image: "{{ .Values.csi.image.registry }}/{{ .Values.csi.image.repo }}/csi-node-driver-registrar:{{ .Values.csi.image.registrarTag }}"
-        imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
+        image: "{{ default .Values.csi.image.registry .Values.global.imageRegistry }}/{{ .Values.csi.image.repo }}/csi-node-driver-registrar:{{ .Values.csi.image.registrarTag }}"
+        imagePullPolicy: {{ default .Values.csi.image.pullPolicy .Values.global.imagePullPolicy }}
         args:
         - "--csi-address={{ default .Values.csi.node.pluginMountPath .Values.csi.node.pluginMounthPath }}/{{ .Values.csi.node.socketPath }}"
         - "--kubelet-registration-path={{ .Values.csi.node.kubeletDir }}/plugins/io.openebs.mayastor/csi.sock"

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -42,8 +42,8 @@ spec:
         {{- include "base_init_containers" . }}
       containers:
       - name: io-engine
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-io-engine:{{ default .Values.image.tag .Values.image.repoTags.dataPlane }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "{{ default .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-io-engine:{{ default .Values.image.tag .Values.image.repoTags.dataPlane }}"
+        imagePullPolicy: {{ default .Values.image.pullPolicy .Values.global.imagePullPolicy }}
         env:
         - name: RUST_LOG
           value: {{ .Values.io_engine.logLevel }}
@@ -137,8 +137,8 @@ spec:
           name: io-engine
       {{- if .Values.base.metrics.enabled }}
       - name: metrics-exporter-io-engine
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-metrics-exporter-io-engine:{{ default .Values.image.tag .Values.image.repoTags.extensions }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "{{ default .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-metrics-exporter-io-engine:{{ default .Values.image.tag .Values.image.repoTags.extensions }}"
+        imagePullPolicy: {{ default .Values.image.pullPolicy .Values.global.imagePullPolicy }}
         env:
         - name: MY_NODE_NAME
           valueFrom:

--- a/chart/templates/mayastor/obs/obs-callhome-deployment.yaml
+++ b/chart/templates/mayastor/obs/obs-callhome-deployment.yaml
@@ -1,4 +1,10 @@
-{{- if .Values.obs.callhome.enabled }}
+{{- $analytics := false }}
+{{- if kindIs "bool" .Values.global.analytics.enabled }}
+{{- $analytics = .Values.global.analytics.enabled }}
+{{- else }}
+{{- $analytics = .Values.obs.callhome.enabled }}
+{{- end }}
+{{- if $analytics }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -35,7 +41,7 @@ spec:
       {{- end }}
       containers:
         - name: obs-callhome
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-obs-callhome:{{ default .Values.image.tag .Values.image.repoTags.extensions }}"
+          image: "{{ default .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-obs-callhome:{{ default .Values.image.tag .Values.image.repoTags.extensions }}"
           args:
             - "-e http://{{ .Release.Name }}-api-rest:8081"
             - "-n {{ .Release.Namespace }}"{{ if .Values.eventing.enabled }}
@@ -50,7 +56,7 @@ spec:
             - name: CALLHOME_PRODUCT_NAME
               value: {{ .Values.obs.callhome.productName | quote }}
           {{- end }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.global.imagePullPolicy }}
           resources:
             limits:
               cpu: {{ .Values.obs.callhome.resources.limits.cpu | quote }}
@@ -60,7 +66,7 @@ spec:
               memory: {{ .Values.obs.callhome.resources.requests.memory | quote }}
         {{- if .Values.eventing.enabled }}
         - name: obs-callhome-stats
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-obs-callhome-stats:{{ default .Values.image.tag .Values.image.repoTags.extensions }}"
+          image: "{{ default .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-obs-callhome-stats:{{ default .Values.image.tag .Values.image.repoTags.extensions }}"
           args:
             - "--namespace={{ .Release.Namespace }}"
             - "--release-name={{ .Release.Name }}"
@@ -75,7 +81,7 @@ spec:
           env:
             - name: RUST_LOG
               value: {{ .Values.obs.stats.logLevel }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.global.imagePullPolicy }}
           resources:
             limits:
               cpu: {{ .Values.obs.stats.resources.limits.cpu | quote }}

--- a/chart/templates/mayastor/obs/stats-service.yaml
+++ b/chart/templates/mayastor/obs/stats-service.yaml
@@ -1,4 +1,10 @@
-{{- if .Values.obs.callhome.enabled }}
+{{- $analytics := false }}
+{{- if kindIs "bool" .Values.global.analytics.enabled }}
+{{- $analytics = .Values.global.analytics.enabled }}
+{{- else }}
+{{- $analytics = .Values.obs.callhome.enabled }}
+{{- end }}
+{{- if $analytics }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/chart/templates/mayastor/operators/operator-diskpool-deployment.yaml
+++ b/chart/templates/mayastor/operators/operator-diskpool-deployment.yaml
@@ -43,8 +43,8 @@ spec:
             requests:
               cpu: {{ .Values.operators.pool.resources.requests.cpu | quote }}
               memory: {{ .Values.operators.pool.resources.requests.memory | quote }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-operator-diskpool:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ default .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repo }}/{{ include "image_prefix" . }}-operator-diskpool:{{ default .Values.image.tag .Values.image.repoTags.controlPlane }}"
+          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.global.imagePullPolicy }}
           args:
             - "-e http://{{ .Release.Name }}-api-rest:8081"
             - "-n{{ .Release.Namespace }}"

--- a/chart/templates/pre-upgrade-hook.yaml
+++ b/chart/templates/pre-upgrade-hook.yaml
@@ -124,8 +124,8 @@ spec:
             defaultMode: 0777
       containers:
         - name: mayastor-pre-upgrade-hook
-          image: {{ .Values.preUpgradeHook.image.registry }}/{{ .Values.preUpgradeHook.image.repo }}:{{ .Values.preUpgradeHook.image.tag }}
-          imagePullPolicy: {{ .Values.preUpgradeHook.image.pullPolicy }}
+          image: {{ default .Values.preUpgradeHook.image.registry .Values.global.imageRegistry }}/{{ .Values.preUpgradeHook.image.repo }}:{{ .Values.preUpgradeHook.image.tag }}
+          imagePullPolicy: {{ default .Values.preUpgradeHook.image.pullPolicy .Values.global.imagePullPolicy }}
           command:
             - "sh"
             - "-c"
@@ -134,8 +134,9 @@ spec:
           volumeMounts:
             - name: scripts
               mountPath: /scripts
-      {{- if .Values.preUpgradeHook.imagePullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.preUpgradeHook.imagePullSecrets | nindent 8 }}
+      {{- if or .Values.global.imagePullSecrets .Values.preUpgradeHook.imagePullSecrets }}
+      imagePullSecrets:
+{{- include "mayastor.preUpgradeHook.pullSecrets" . | indent 8 }}
       {{- end }}
 {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,6 +7,16 @@ crds:
       enabled: true
 
 global:
+  # -- Global override for image registry
+  imageRegistry: ""
+  # -- Global overide for image pull policy
+  imagePullPolicy: ""
+  # -- Global override for image pull secrets
+  # - secret
+  imagePullSecrets: []
+  analytics:
+    # -- Global overide for call home
+    enabled:
   security:
     allowInsecureImages: true
 
@@ -73,6 +83,8 @@ base:
       name: alpine-sh
       tag: 4.4.0
       pullPolicy: IfNotPresent
+      # -- Image registry for init containers
+      registry: ""
     containers:
       - name: agent-core-grpc-probe
         command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-agent-core 50051; do date; echo "Waiting for agent-core-grpc services..."; sleep 1; done;' ]
@@ -972,7 +984,13 @@ storageClass:
 localpv-provisioner:
   # -- Enables the openebs dynamic-localpv-provisioner. If disabled, modify etcd and loki storage class accordingly.
   enabled: true
+  globalImageRegistryOverride: true
+  helperPod:
+    image:
+      registry: "docker.io"
   localpv:
+    image:
+      registry: "docker.io"
     # -- Set the PriorityClass for the LocalPV Hostpath provisioner Deployment.
     priorityClassName: "{{ .Release.Name }}-cluster-critical"
   hostpathClass:


### PR DESCRIPTION
Resolves https://github.com/openebs/openebs/issues/4171

## Why is this PR required? What issue does it fix?

Currently, the Helm charts do not provide global variables for configuring common parameters such as the image registry, image pull secrets, image pull policy, and analytics settings.

When deploying the OpenEBS Helm charts, users often need to override these values across multiple subcharts and components. This makes it difficult to locate and configure all the required fields consistently. Providing global variables simplifies configuration and improves the user experience.

## What does this PR do?

This PR introduces the following global configuration variables:
```yaml
global:
  # -- Global override for image registry
  imageRegistry: ""
  # -- Global overide for image pull policy
  imagePullPolicy: ""
  # -- Global override for image pull secrets
  # - secret
  imagePullSecrets: []
  analytics:
    # -- Global overide for call home
    enabled:
```

These variables allow users to configure common settings in a single place, which will then be applied across the chart components.

## Does this PR require any upgrade changes?

No.
This change is backward compatible and does not require any upgrade steps.

## Verification

The changes were verified using the following scenarios:

Rendered the templates using helm template to confirm correct value substitution.

Deployed the chart on a Kubernetes cluster with 3 worker nodes (kubeadm-based setup).

Verified that the global values are rendered and applied correctly across the components.