### PR TITLE
adding pool alert metrics

### DIFF
--- a/metrics-exporter/src/bin/io_engine/cache/mod.rs
+++ b/metrics-exporter/src/bin/io_engine/cache/mod.rs
@@ -8,9 +8,9 @@ use crate::client::{
     replica_stat::ReplicaIoStats,
 };
 use once_cell::sync::OnceCell;
-use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
 
+/// NOTE: try to reference cache from the Collector.
 static CACHE: OnceCell<Mutex<Cache>> = OnceCell::new();
 
 /// Trait to be implemented by all Resource structs stored in Cache.
@@ -26,7 +26,7 @@ pub(crate) struct Cache {
 }
 
 /// Wrapper over all the data that has to be stored in cache.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
 pub(crate) struct Data {
     /// Contains Pool Capacity and state data.
     pools: Pools,

--- a/metrics-exporter/src/bin/io_engine/client/nexus_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/client/nexus_stat.rs
@@ -1,8 +1,7 @@
 use super::ticks_to_time;
-use serde::{Deserialize, Serialize};
 
 /// This stores IoStat information of a nexus.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct NexusIoStat {
     name: String,
     bytes_read: u64,
@@ -51,7 +50,7 @@ impl NexusIoStat {
 }
 
 /// Array of NexusIoStat objects.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct NexusIoStats {
     pub(crate) nexus_stats: Vec<NexusIoStat>,
 }

--- a/metrics-exporter/src/bin/io_engine/client/pool.rs
+++ b/metrics-exporter/src/bin/io_engine/client/pool.rs
@@ -1,7 +1,7 @@
-use serde::{Deserialize, Serialize};
+use rpc::v1::pb::{PoolAlert, PoolAlertStatus};
 
 /// This stores Capacity and state information of a pool.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct PoolInfo {
     name: String,
     used: u64,
@@ -10,6 +10,16 @@ pub(crate) struct PoolInfo {
     committed: u64,
     disk_capacity: u64,
     max_expandable_size: u64,
+    io_error_count: u64,
+    io_error_threshold: u64,
+    io_stalled: bool,
+    io_stall_transition_count: u64,
+    io_stall_transition_threshold: u64,
+    alert_status: PoolAlertStatus,
+    notice: Vec<PoolAlert>,
+    attention: Vec<PoolAlert>,
+    warning: Vec<PoolAlert>,
+    critical: Vec<PoolAlert>,
 }
 
 impl PoolInfo {
@@ -43,20 +53,94 @@ impl PoolInfo {
         self.max_expandable_size
     }
 
-    /// Get pool of the io_engine.
+    /// Get state of the Pool.
     pub(crate) fn state(&self) -> u64 {
         self.state
+    }
+
+    /// Get the count of IO errors on the pool.
+    pub(crate) fn io_error_count(&self) -> u64 {
+        self.io_error_count
+    }
+
+    /// Get the IO error threshold for the pool.
+    pub(crate) fn io_error_threshold(&self) -> u64 {
+        self.io_error_threshold
+    }
+
+    /// Get whether the pool is currently in stalled state.
+    pub(crate) fn io_stalled(&self) -> bool {
+        self.io_stalled
+    }
+
+    /// Get the count of IO stall transitions on the pool.
+    pub(crate) fn io_stall_transition_count(&self) -> u64 {
+        self.io_stall_transition_count
+    }
+
+    /// Get the IO stall transition threshold for the pool.
+    pub(crate) fn io_stall_transition_threshold(&self) -> u64 {
+        self.io_stall_transition_threshold
+    }
+
+    /// Get the alert status for the pool.
+    pub(crate) fn alert_status(&self) -> PoolAlertStatus {
+        self.alert_status
+    }
+
+    /// Get the collection of notice alert reasons for the pool.
+    pub(crate) fn notice(&self) -> &Vec<PoolAlert> {
+        &self.notice
+    }
+
+    /// Get the collection of attention alert reasons for the pool.
+    pub(crate) fn attention(&self) -> &Vec<PoolAlert> {
+        &self.attention
+    }
+
+    /// Get the collection of warning alert reasons for the pool.
+    pub(crate) fn warning(&self) -> &Vec<PoolAlert> {
+        &self.warning
+    }
+
+    /// Get the collection of critical alert reasons for the pool.
+    pub(crate) fn critical(&self) -> &Vec<PoolAlert> {
+        &self.critical
     }
 }
 
 /// Array of PoolInfo objects.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct Pools {
     pub(crate) pools: Vec<PoolInfo>,
 }
 
 impl From<rpc::v1::pool::Pool> for PoolInfo {
     fn from(value: rpc::v1::pool::Pool) -> Self {
+        let mut io_error_count: u64 = 0;
+        let mut io_error_threshold: u64 = 0;
+        let mut io_stalled: bool = false;
+        let mut io_stall_transition_count: u64 = 0;
+        let mut io_stall_transition_threshold: u64 = 0;
+        let mut alert_status: PoolAlertStatus = PoolAlertStatus::Healthy;
+        let mut notice: Vec<PoolAlert> = Vec::new();
+        let mut attention: Vec<PoolAlert> = Vec::new();
+        let mut warning: Vec<PoolAlert> = Vec::new();
+        let mut critical: Vec<PoolAlert> = Vec::new();
+        if let Some(errors) = value.errors.clone() {
+            io_error_count = errors.io_error_count;
+            io_error_threshold = errors.io_error_threshold;
+            io_stalled = errors.io_stalled;
+            io_stall_transition_count = errors.io_stall_transition_count;
+            io_stall_transition_threshold = errors.io_stall_transition_threshold;
+            if let Some(alerts) = errors.alerts {
+                alert_status = alerts.status();
+                notice = alerts.notice().collect();
+                attention = alerts.attention().collect();
+                warning = alerts.warning().collect();
+                critical = alerts.critical().collect();
+            }
+        }
         Self {
             name: value.name,
             used: value.used,
@@ -65,6 +149,16 @@ impl From<rpc::v1::pool::Pool> for PoolInfo {
             committed: value.committed,
             disk_capacity: value.disk_capacity,
             max_expandable_size: value.max_expandable_size.unwrap_or_default(),
+            io_error_count,
+            io_error_threshold,
+            io_stalled,
+            io_stall_transition_count,
+            io_stall_transition_threshold,
+            alert_status,
+            notice,
+            attention,
+            warning,
+            critical,
         }
     }
 }

--- a/metrics-exporter/src/bin/io_engine/client/pool_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/client/pool_stat.rs
@@ -1,8 +1,7 @@
 use super::ticks_to_time;
-use serde::{Deserialize, Serialize};
 
 /// This stores IoStat information of a pool.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct PoolIoStat {
     name: String,
     bytes_read: u64,
@@ -51,7 +50,7 @@ impl PoolIoStat {
 }
 
 /// Array of PoolIoStat objects.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct PoolIoStats {
     pub(crate) pool_stats: Vec<PoolIoStat>,
 }

--- a/metrics-exporter/src/bin/io_engine/client/replica_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/client/replica_stat.rs
@@ -1,9 +1,8 @@
 use super::ticks_to_time;
 use crate::error::ExporterError;
-use serde::{Deserialize, Serialize};
 
 /// This stores IoStat information of a replica.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct ReplicaIoStat {
     name: String,
     entity_id: String,
@@ -58,7 +57,7 @@ impl ReplicaIoStat {
 }
 
 /// Array of NexusIoStat objects.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct ReplicaIoStats {
     pub(crate) replica_stats: Vec<ReplicaIoStat>,
 }

--- a/metrics-exporter/src/bin/io_engine/collector/mod.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/mod.rs
@@ -16,11 +16,44 @@ fn init_diskpool_gauge_vec(
     metric_desc: &str,
     descs: &mut Vec<Desc>,
 ) -> GaugeVec {
+    let label_refs = vec!["node", "name"];
+    let labels: Vec<String> = label_refs.iter().map(|s| s.to_string()).collect();
     let opts = Opts::new(metric_name, metric_desc)
         .subsystem("diskpool")
-        .variable_labels(vec!["node".to_string(), "name".to_string()]);
-    let gauge_vec = GaugeVec::new(opts, &["node", "name"])
+        .variable_labels(labels);
+    let gauge_vec = GaugeVec::new(opts, &label_refs)
         .unwrap_or_else(|_| panic!("Unable to create gauge metric type for {metric_name}"));
+    descs.extend(gauge_vec.desc().into_iter().cloned());
+    gauge_vec
+}
+
+/// Initializes a GaugeVec metric for diskpool alert reason with the provided metric name, description and
+/// descriptors.
+fn init_diskpool_alert_reason_gauge_vec(
+    metric_name: &str,
+    metric_desc: &str,
+    descs: &mut Vec<Desc>,
+) -> GaugeVec {
+    let label_refs = vec![
+        "node",
+        "name",
+        "unknown",
+        "io_stalled",
+        "io_stall_intermittent",
+        "io_stall_intermittent_exc",
+        "io_error",
+        "io_error_exc",
+    ];
+
+    let labels: Vec<String> = label_refs.iter().map(|s| s.to_string()).collect();
+
+    let opts = Opts::new(metric_name, metric_desc)
+        .subsystem("diskpool_alert")
+        .variable_labels(labels);
+
+    let gauge_vec = GaugeVec::new(opts, &label_refs)
+        .unwrap_or_else(|_| panic!("Unable to create gauge metric type for {metric_name}"));
+
     descs.extend(gauge_vec.desc().into_iter().cloned());
     gauge_vec
 }
@@ -28,10 +61,12 @@ fn init_diskpool_gauge_vec(
 /// Initializes a GaugeVec metric for volume with the provided metric name, description and
 /// descriptors.
 fn init_volume_gauge_vec(metric_name: &str, metric_desc: &str, descs: &mut Vec<Desc>) -> GaugeVec {
+    let label_refs = vec!["node", "pv_name"];
+    let labels: Vec<String> = label_refs.iter().map(|s| s.to_string()).collect();
     let opts = Opts::new(metric_name, metric_desc)
         .subsystem("volume")
-        .variable_labels(vec!["node".to_string(), "pv_name".to_string()]);
-    let gauge_vec = GaugeVec::new(opts, &["node", "pv_name"])
+        .variable_labels(labels);
+    let gauge_vec = GaugeVec::new(opts, &label_refs)
         .unwrap_or_else(|_| panic!("Unable to create gauge metric type for {metric_name}"));
     descs.extend(gauge_vec.desc().into_iter().cloned());
     gauge_vec
@@ -40,14 +75,12 @@ fn init_volume_gauge_vec(metric_name: &str, metric_desc: &str, descs: &mut Vec<D
 /// Initializes a GaugeVec metric for replica with the provided metric name, description and
 /// descriptors.
 fn init_replica_gauge_vec(metric_name: &str, metric_desc: &str, descs: &mut Vec<Desc>) -> GaugeVec {
+    let label_refs = vec!["node", "name", "pv_name"];
+    let labels: Vec<String> = label_refs.iter().map(|s| s.to_string()).collect();
     let opts = Opts::new(metric_name, metric_desc)
         .subsystem("replica")
-        .variable_labels(vec![
-            "node".to_string(),
-            "name".to_string(),
-            "pv_name".to_string(),
-        ]);
-    let gauge_vec = GaugeVec::new(opts, &["node", "name", "pv_name"])
+        .variable_labels(labels);
+    let gauge_vec = GaugeVec::new(opts, &label_refs)
         .unwrap_or_else(|_| panic!("Unable to create gauge metric type for {metric_name}"));
     descs.extend(gauge_vec.desc().into_iter().cloned());
     gauge_vec

--- a/metrics-exporter/src/bin/io_engine/collector/pool.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/pool.rs
@@ -1,8 +1,13 @@
-use crate::{cache::Cache, collector::init_diskpool_gauge_vec, get_node_name};
+use crate::{
+    cache::Cache,
+    collector::{init_diskpool_alert_reason_gauge_vec, init_diskpool_gauge_vec},
+    get_node_name,
+};
 use prometheus::{
     core::{Collector, Desc},
     GaugeVec,
 };
+use rpc::v1::pb::PoolAlert;
 use std::{
     fmt::Debug,
     ops::{Deref, DerefMut},
@@ -81,7 +86,7 @@ impl Collector for PoolCapacityCollector {
             }
         };
         let cache_deref = cache.deref();
-        let mut metric_family = Vec::with_capacity(3 * cache_deref.pool().pools.capacity());
+        let mut metric_family = Vec::with_capacity(5 * cache_deref.pool().pools.capacity());
         let node_name = match get_node_name() {
             Ok(name) => name,
             Err(error) => {
@@ -224,5 +229,330 @@ impl Collector for PoolStatusCollector {
             metric_family.extend(metric_vec.pop());
         }
         metric_family
+    }
+}
+
+/// Collects pool alerts info from cache.
+#[derive(Clone, Debug)]
+pub(crate) struct PoolAlertCollector {
+    io_error_count: GaugeVec,
+    io_error_threshold: GaugeVec,
+    io_stalled: GaugeVec,
+    io_stall_transition_count: GaugeVec,
+    io_stall_transition_threshold: GaugeVec,
+    io_alert_status: GaugeVec,
+    io_alert_notice_reason: GaugeVec,
+    io_alert_attention_reason: GaugeVec,
+    io_alert_warning_reason: GaugeVec,
+    io_alert_critical_reason: GaugeVec,
+    node_name: String,
+    descs: Vec<Desc>,
+}
+
+impl Default for PoolAlertCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PoolAlertCollector {
+    /// Initialize all the metrics to be defined for pools alerts collector.
+    pub fn new() -> Self {
+        let mut descs = Vec::new();
+        let io_error_count = init_diskpool_gauge_vec(
+            "io_error_count",
+            "Count of I/O errors for the pool",
+            &mut descs,
+        );
+        let io_error_threshold = init_diskpool_gauge_vec(
+            "io_error_threshold",
+            "Threshold for I/O errors in the pool",
+            &mut descs,
+        );
+        let io_stalled = init_diskpool_gauge_vec(
+            "io_stalled",
+            "Stalled I/O operations in the pool",
+            &mut descs,
+        );
+        let io_stall_transition_count = init_diskpool_gauge_vec(
+            "io_stall_transition_count",
+            "Count of I/O stall transitions in the pool",
+            &mut descs,
+        );
+        let io_stall_transition_threshold = init_diskpool_gauge_vec(
+            "io_stall_transition_threshold",
+            "Threshold for I/O stall transitions in the pool",
+            &mut descs,
+        );
+        let io_alert_status =
+            init_diskpool_gauge_vec("io_alert_status", "DiskPool alert status", &mut descs);
+        let io_alert_notice_reason = init_diskpool_alert_reason_gauge_vec(
+            "notice_reason",
+            "Collection of reason for notice alert",
+            &mut descs,
+        );
+        let io_alert_attention_reason = init_diskpool_alert_reason_gauge_vec(
+            "attention_reason",
+            "Collection of reason for attention alert",
+            &mut descs,
+        );
+        let io_alert_warning_reason = init_diskpool_alert_reason_gauge_vec(
+            "warning_reason",
+            "Collection of reason for warning alert",
+            &mut descs,
+        );
+        let io_alert_critical_reason = init_diskpool_alert_reason_gauge_vec(
+            "critical_reason",
+            "Collection of reason for critical alert",
+            &mut descs,
+        );
+        let node_name = match get_node_name() {
+            Ok(name) => name,
+            Err(error) => {
+                error!(?error, "Unable to get node name");
+                String::new()
+            }
+        };
+        Self {
+            io_error_count,
+            io_error_threshold,
+            io_stalled,
+            io_stall_transition_count,
+            io_stall_transition_threshold,
+            io_alert_status,
+            io_alert_notice_reason,
+            io_alert_attention_reason,
+            io_alert_warning_reason,
+            io_alert_critical_reason,
+            node_name,
+            descs,
+        }
+    }
+}
+
+impl Collector for PoolAlertCollector {
+    fn desc(&self) -> Vec<&prometheus::core::Desc> {
+        self.descs.iter().collect()
+    }
+    fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
+        let mut cache = match Cache::get_cache().lock() {
+            Ok(cache) => cache,
+            Err(error) => {
+                error!(%error,"Error while getting cache resource");
+                return Vec::new();
+            }
+        };
+        let cache_deref = cache.deref_mut();
+        let mut metric_family = Vec::with_capacity(10 * cache_deref.pool_mut().pools.capacity());
+        for pool in &cache_deref.pool_mut().pools {
+            let io_error_count = match self
+                .io_error_count
+                .get_metric_with_label_values(&[self.node_name.as_str(), pool.name().as_str()])
+            {
+                Ok(io_error_count) => io_error_count,
+                Err(error) => {
+                    error!(%error, "Error while creating io_error_count gauge with label values");
+                    return metric_family;
+                }
+            };
+            io_error_count.set(pool.io_error_count() as f64);
+            let mut metric_vec = io_error_count.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let io_error_threshold = match self
+                .io_error_threshold
+                .get_metric_with_label_values(&[self.node_name.as_str(), pool.name().as_str()])
+            {
+                Ok(io_error_threshold) => io_error_threshold,
+                Err(error) => {
+                    error!(%error, "Error while creating io_error_threshold gauge with label values");
+                    return metric_family;
+                }
+            };
+            io_error_threshold.set(pool.io_error_threshold() as f64);
+            let mut metric_vec = io_error_threshold.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let io_stalled = match self
+                .io_stalled
+                .get_metric_with_label_values(&[self.node_name.as_str(), pool.name().as_str()])
+            {
+                Ok(io_stalled) => io_stalled,
+                Err(error) => {
+                    error!(%error, "Error while creating io_stalled gauge with label values");
+                    return metric_family;
+                }
+            };
+            let io_stalled_metrics: f64 = if pool.io_stalled() { 1_f64 } else { 0_f64 };
+            io_stalled.set(io_stalled_metrics);
+            let mut metric_vec = io_stalled.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let io_stall_transition_count = match self
+                .io_stall_transition_count
+                .get_metric_with_label_values(&[self.node_name.as_str(), pool.name().as_str()])
+            {
+                Ok(io_stall_transition_count) => io_stall_transition_count,
+                Err(error) => {
+                    error!(%error, "Error while creating io_stall_transition_count gauge with label values");
+                    return metric_family;
+                }
+            };
+            io_stall_transition_count.set(pool.io_stall_transition_count() as f64);
+            let mut metric_vec = io_stall_transition_count.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let io_stall_transition_threshold = match self
+                .io_stall_transition_threshold
+                .get_metric_with_label_values(&[self.node_name.as_str(), pool.name().as_str()])
+            {
+                Ok(io_stall_transition_threshold) => io_stall_transition_threshold,
+                Err(error) => {
+                    error!(%error, "Error while creating io_stall_transition_threshold gauge with label values");
+                    return metric_family;
+                }
+            };
+            io_stall_transition_threshold.set(pool.io_stall_transition_threshold() as f64);
+            let mut metric_vec = io_stall_transition_threshold.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let io_alert_status = match self
+                .io_alert_status
+                .get_metric_with_label_values(&[self.node_name.as_str(), pool.name().as_str()])
+            {
+                Ok(io_alert_status) => io_alert_status,
+                Err(error) => {
+                    error!(%error, "Error while creating io_alert_status gauge with label values");
+                    return metric_family;
+                }
+            };
+            io_alert_status.set(pool.alert_status() as i32 as f64);
+            let mut metric_vec = io_alert_status.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let mut notice_reason_set = AlertReasons::default();
+            notice_reason_set.update_alerts(pool.notice());
+            let io_alert_notice_reason = match self
+                .io_alert_notice_reason
+                .get_metric_with_label_values(&[
+                    self.node_name.as_str(),
+                    pool.name().as_str(),
+                    &notice_reason_set.unknown.to_string(),
+                    &notice_reason_set.io_stalled.to_string(),
+                    &notice_reason_set.io_stall_intermittent.to_string(),
+                    &notice_reason_set.io_stall_intermittent_exc.to_string(),
+                    &notice_reason_set.io_error.to_string(),
+                    &notice_reason_set.io_error_exc.to_string(),
+                ]) {
+                Ok(io_alert_notice_reason) => io_alert_notice_reason,
+                Err(error) => {
+                    error!(%error, "Error while creating io_alert_notice_reason gauge with label values");
+                    return metric_family;
+                }
+            };
+            io_alert_notice_reason.set(1_f64);
+            let mut metric_vec = io_alert_notice_reason.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let mut attention_reason_set = AlertReasons::default();
+            attention_reason_set.update_alerts(pool.attention());
+            let io_alert_attention_reason = match self
+                .io_alert_attention_reason
+                .get_metric_with_label_values(&[
+                    self.node_name.as_str(),
+                    pool.name().as_str(),
+                    &attention_reason_set.unknown.to_string(),
+                    &attention_reason_set.io_stalled.to_string(),
+                    &attention_reason_set.io_stall_intermittent.to_string(),
+                    &attention_reason_set.io_stall_intermittent_exc.to_string(),
+                    &attention_reason_set.io_error.to_string(),
+                    &attention_reason_set.io_error_exc.to_string(),
+                ]) {
+                Ok(io_alert_attention_reason) => io_alert_attention_reason,
+                Err(error) => {
+                    error!(%error, "Error while creating io_alert_attention_reason gauge with label values");
+                    return metric_family;
+                }
+            };
+            io_alert_attention_reason.set(1_f64);
+            let mut metric_vec = io_alert_attention_reason.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let mut warning_reason_set = AlertReasons::default();
+            warning_reason_set.update_alerts(pool.warning());
+            let io_alert_warning_reason = match self
+                .io_alert_warning_reason
+                .get_metric_with_label_values(&[
+                    self.node_name.as_str(),
+                    pool.name().as_str(),
+                    &warning_reason_set.unknown.to_string(),
+                    &warning_reason_set.io_stalled.to_string(),
+                    &warning_reason_set.io_stall_intermittent.to_string(),
+                    &warning_reason_set.io_stall_intermittent_exc.to_string(),
+                    &warning_reason_set.io_error.to_string(),
+                    &warning_reason_set.io_error_exc.to_string(),
+                ]) {
+                Ok(io_alert_warning_reason) => io_alert_warning_reason,
+                Err(error) => {
+                    error!(%error, "Error while creating io_alert_warning_reason gauge with label values");
+                    return metric_family;
+                }
+            };
+            io_alert_warning_reason.set(1_f64);
+            let mut metric_vec = io_alert_warning_reason.collect();
+            metric_family.extend(metric_vec.pop());
+
+            let mut critical_reason_set = AlertReasons::default();
+            critical_reason_set.update_alerts(pool.critical());
+            let io_alert_critical_reason = match self
+                .io_alert_critical_reason
+                .get_metric_with_label_values(&[
+                    self.node_name.as_str(),
+                    pool.name().as_str(),
+                    &critical_reason_set.unknown.to_string(),
+                    &critical_reason_set.io_stalled.to_string(),
+                    &critical_reason_set.io_stall_intermittent.to_string(),
+                    &critical_reason_set.io_stall_intermittent_exc.to_string(),
+                    &critical_reason_set.io_error.to_string(),
+                    &critical_reason_set.io_error_exc.to_string(),
+                ]) {
+                Ok(io_alert_critical_reason) => io_alert_critical_reason,
+                Err(error) => {
+                    error!(%error, "Error while creating io_alert_critical_reason gauge with label values");
+                    return metric_family;
+                }
+            };
+            io_alert_critical_reason.set(1_f64);
+            let mut metric_vec = io_alert_critical_reason.collect();
+            metric_family.extend(metric_vec.pop());
+        }
+
+        metric_family
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+/// Struct to hold the reasons for each alert type, with default values set to 0 (indicating no reason).
+struct AlertReasons {
+    unknown: i32,
+    io_stalled: i32,
+    io_stall_intermittent: i32,
+    io_stall_intermittent_exc: i32,
+    io_error: i32,
+    io_error_exc: i32,
+}
+
+impl AlertReasons {
+    fn update_alerts(&mut self, pool_alerts: &Vec<PoolAlert>) {
+        for alert in pool_alerts {
+            match alert {
+                PoolAlert::Unknown => self.unknown = 1,
+                PoolAlert::IoStalled => self.io_stalled = 1,
+                PoolAlert::IoStallIntermittent => self.io_stall_intermittent = 1,
+                PoolAlert::IoStallIntermittentExc => self.io_stall_intermittent_exc = 1,
+                PoolAlert::IoError => self.io_error = 1,
+                PoolAlert::IoErrorExc => self.io_error_exc = 1,
+            }
+        }
     }
 }

--- a/metrics-exporter/src/bin/io_engine/serve/handler.rs
+++ b/metrics-exporter/src/bin/io_engine/serve/handler.rs
@@ -3,7 +3,7 @@ use crate::{
     collector::{
         nexus_stat::NexusIoStatsCollector,
         node_status::NodeStatusCollector,
-        pool::{PoolCapacityCollector, PoolStatusCollector},
+        pool::{PoolAlertCollector, PoolCapacityCollector, PoolStatusCollector},
         pool_stat::PoolIoStatsCollector,
         replica_stat::ReplicaIoStatsCollector,
     },
@@ -34,6 +34,7 @@ pub(crate) async fn metrics_handler() -> impl Responder {
     let pools_collector = PoolCapacityCollector::default();
     let pool_status_collector = PoolStatusCollector::default();
     let pool_iostat_collector = PoolIoStatsCollector::default();
+    let pool_alert_collector = PoolAlertCollector::default();
     let nexus_iostat_collector = NexusIoStatsCollector::default();
     let replica_iostat_collector = ReplicaIoStatsCollector::default();
     let node_status_collector = NodeStatusCollector::new(node);
@@ -45,6 +46,9 @@ pub(crate) async fn metrics_handler() -> impl Responder {
     }
     if let Err(error) = Registry::register(&registry, Box::new(pool_status_collector)) {
         warn!(%error, "Pool status collector already registered");
+    }
+    if let Err(error) = Registry::register(&registry, Box::new(pool_alert_collector)) {
+        warn!(%error, "Pool alert collector already registered");
     }
     if let Err(error) = Registry::register(&registry, Box::new(pool_iostat_collector)) {
         warn!(%error, "Pool IoStat collector already registered");


### PR DESCRIPTION
This PR adds additional metrics on the diskpool to expose alert related information.

Here is the list of new alerts being exposed:

diskpool_io_error_count
diskpool_io_error_threshold
diskpool_io_stalled
diskpool_io_stall_transition_count
diskpool_io_stall_transition_threshold
diskpool_io_alert_status

Following alerts are exposed in diskpool_alert namespace:

diskpool_alert_io_alert_notice_reason
diskpool_alert_io_alert_attention_reason
diskpool_alert_io_alert_warning_reason
idiskpool_alert_o_alert_critical_reason