### PR TITLE
Fix ci tests from user fork

### DIFF
--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Login to Docker Hub
         env:
           has_username: ${{ secrets.DOCKERHUB_USERNAME != '' }}
-        if: ${{ !inputs.helm-pins && env.has_username }}
+        if: ${{ !inputs.helm-pins && env.has_username == 'true' }}
         uses: docker/login-action@v3
         with:
           registry: docker.io

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -56,9 +56,19 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              name: 'ci/test',
-            });
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'ci/test',
+              });
+            } catch (error) {
+              const status = error.status || error.response?.status;
+              if (status === 403 || status === 404) {
+                const reason = status === 403 ? 'insufficient permissions' : 'label not found';
+                console.log(`Skipping ci/test label removal due to ${reason}: ${error.message}`);
+                return;
+              }
+              throw error;
+            }


### PR DESCRIPTION
Fix previous change for docker username presence.
Don't error out when removing label fails with 403 (PR from user fork) or 404 (label manually removed).