### PR TITLE
fix(upgrade): add RBAC for OpenShift resources

### DIFF
--- a/k8s/upgrade/src/plugin/objects.rs
+++ b/k8s/upgrade/src/plugin/objects.rs
@@ -237,6 +237,12 @@ pub(crate) fn upgrade_job_cluster_role(
                 verbs: vec!["create", "list", "delete", "get", "patch"].into_vec(),
                 ..Default::default()
             },
+            PolicyRule {
+                api_groups: Some(vec!["security.openshift.io"].into_vec()),
+                resources: Some(vec!["securitycontextconstraints"].into_vec()),
+                verbs: vec!["create", "list", "delete", "get", "patch"].into_vec(),
+                ..Default::default()
+            },
         ]),
         ..Default::default()
     }


### PR DESCRIPTION
Adds create, delete, patch, list, get RBAC permissions for all security.openshift.io resources (OpenShift api group).