### PR TITLE
fix: add plugin version to bundle log file

### DIFF
--- a/k8s/supportability/src/collect/system_dump.rs
+++ b/k8s/supportability/src/collect/system_dump.rs
@@ -57,6 +57,8 @@ impl SystemDumper {
         init_tool_log_file(PathBuf::from(format!("{new_dir}/support_tool_logs.log")))
             .expect("Support Tool Log file should be created");
 
+        log(format!("Plugin {}", utils::version_info_str!()));
+
         // Creates an arcive file to dump mayastor resource information. If creation
         // of archive is failed then we can't continue process
         let archive = match archive::Archive::new(


### PR DESCRIPTION
When the plugin is outdated, it may miss some things, so it's useful to record which version the dump was taken with.

todo: collect helm install version