### PR TITLE
feat: add app-nodes to system dump

### DIFF
--- a/call-home/src/common/errors.rs
+++ b/call-home/src/common/errors.rs
@@ -5,7 +5,7 @@ use snafu::Snafu;
 #[snafu(visibility(pub), context(suffix(false)))]
 #[allow(clippy::enum_variant_names)]
 pub enum K8sResourceError {
-    #[snafu(display("Json Parse Error : {}", source))]
+    #[snafu(display("Json Parse Error: {}", source))]
     SerdeError { source: serde_json::Error },
 
     #[snafu(display("K8Client Error: {}", source))]

--- a/k8s/supportability/src/collect/k8s_resources/k8s_resource_dump.rs
+++ b/k8s/supportability/src/collect/k8s_resources/k8s_resource_dump.rs
@@ -114,13 +114,13 @@ impl K8sResourceDumperClient {
         // Create the root dir path
         let mut root_dir = PathBuf::from(root_path);
         root_dir.push("k8s_resources");
-        create_directory_if_not_exist(root_dir.to_path_buf())?;
+        create_directory_if_not_exist(&root_dir)?;
 
         // Create the configurations path
         let mut configurations_path = root_dir.to_path_buf();
         configurations_path.push("configurations");
         // Create the configurations directory
-        create_directory_if_not_exist(configurations_path.to_path_buf())?;
+        create_directory_if_not_exist(&configurations_path)?;
 
         let mut errors = Vec::new();
 
@@ -172,7 +172,7 @@ impl K8sResourceDumperClient {
         required_pools: Option<Vec<String>>,
     ) -> Result<(), K8sResourceDumperError> {
         // Create the root dir path
-        create_directory_if_not_exist(root_path.to_path_buf())?;
+        create_directory_if_not_exist(root_path)?;
 
         let mut errors = Vec::new();
 
@@ -225,22 +225,20 @@ fn create_app_configurations<T: EntityName>(
     for app in apps {
         let serialized = match serde_yaml::to_string(&app) {
             Ok(value) => value,
-            Err(e) => {
+            Err(error) => {
                 log(format!(
-                    "Error serializing the app : {} , error: {}",
+                    "Error serializing the app: {}, error: {error}",
                     app.name(),
-                    e
                 ));
                 continue;
             }
         };
         match create_file_and_write(dir_path.clone(), format!("{}.yaml", app.name()), serialized) {
             Ok(_) => {}
-            Err(e) => {
+            Err(error) => {
                 log(format!(
-                    "Error creating or writing file for the app : {} , error: {}",
+                    "Error creating or writing file for the app: {}, error: {error}",
                     app.name(),
-                    e
                 ));
                 continue;
             }

--- a/k8s/supportability/src/collect/logs/k8s_log.rs
+++ b/k8s/supportability/src/collect/logs/k8s_log.rs
@@ -101,11 +101,10 @@ impl K8sLoggerClient {
                 .await
             {
                 Ok(()) => {}
-                Err(err) => {
+                Err(error) => {
                     log(format!(
-                        "Error fetching logs for pod : {}, error: {:?}",
+                        "Error fetching logs for pod: {}, error: {error:?}",
                         pod.meta().name.as_ref().unwrap_or(&"".to_string()),
-                        err
                     ));
                     continue;
                 }
@@ -146,7 +145,7 @@ impl K8sLoggerClient {
         let host_name = self.k8s_client.get_hostname(node_name).await?;
 
         pod_dir.push(format!("{}_{}", host_name, pod_name.clone()));
-        create_directory_if_not_exist(pod_dir.clone())?;
+        create_directory_if_not_exist(&pod_dir)?;
 
         let mut container_restart_map: HashMap<String, bool> = HashMap::new();
 

--- a/k8s/supportability/src/collect/logs/mod.rs
+++ b/k8s/supportability/src/collect/logs/mod.rs
@@ -9,7 +9,7 @@ use crate::collect::{
 
 use async_trait::async_trait;
 use k8s_openapi::api::core::v1::Pod;
-use std::{collections::HashSet, path::PathBuf};
+use std::{collections::HashSet, path::Path};
 
 /// Error that can occur while interacting with logs module
 #[derive(Debug)]
@@ -178,7 +178,7 @@ impl Logger for LogCollection {
                 .join("logs")
                 .join(resource.service_type.clone());
 
-            create_directory_if_not_exist(service_dir.clone())?;
+            create_directory_if_not_exist(&service_dir)?;
             if let Some(loki_client) = &mut self.loki_client {
                 let _ = loki_client
                     .fetch_and_dump_logs(
@@ -248,7 +248,7 @@ pub(crate) trait Logger {
 }
 
 /// Creates specified directory path if not already exist
-pub fn create_directory_if_not_exist(dir_path: PathBuf) -> Result<(), std::io::Error> {
+pub fn create_directory_if_not_exist(dir_path: &Path) -> Result<(), std::io::Error> {
     if !dir_path.exists() {
         std::fs::create_dir_all(dir_path)?;
     }

--- a/k8s/supportability/src/collect/resources/app_node.rs
+++ b/k8s/supportability/src/collect/resources/app_node.rs
@@ -1,0 +1,115 @@
+use crate::{
+    collect::{
+        logs::create_directory_if_not_exist,
+        resources,
+        resources::{traits, utils},
+        rest_wrapper::RestClient,
+    },
+    log,
+};
+use openapi::models::AppNode;
+use resources::ResourceError;
+use traits::{Resourcer, Topologer};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::{fs::File, io::Write, path::PathBuf};
+
+/// NodeTopology represents information about mayastor application/csi nodes.
+/// todo: add nvmf devices and their subsystems.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct AppNodeTopology {
+    node: AppNode,
+}
+
+/// Topologer Contains methods to build topology information for generic Object
+/// which interns supports inspecting topology resources
+#[async_trait(?Send)]
+impl Topologer for AppNodeTopology {
+    /// Convert node topology into JSON structure
+    fn get_printable_topology(&self) -> Result<(String, String), ResourceError> {
+        let topology_as_pretty = serde_json::to_string_pretty(self)?;
+        let file_path = format!("app-node-{}-topology.json", self.node.id);
+        Ok((file_path, topology_as_pretty))
+    }
+
+    /// Writes topology information into a file in specified directory
+    fn dump_topology_info(&self, dir_path: PathBuf) -> Result<(), ResourceError> {
+        create_directory_if_not_exist(dir_path.clone())?;
+        let file_path = dir_path.join(format!("app-node-{}-topology.json", self.node.id));
+        let mut topo_file = File::create(file_path)?;
+        let topology_as_pretty = serde_json::to_string_pretty(self)?;
+        topo_file.write_all(topology_as_pretty.as_bytes())?;
+        topo_file.flush()?;
+        Ok(())
+    }
+}
+
+// Wrapper around mayastor REST client
+#[derive(Debug)]
+pub(crate) struct AppNodeClientWrapper {
+    pub rest_client: RestClient,
+}
+
+impl AppNodeClientWrapper {
+    /// Creates new instance of AppNodeClientWrapper
+    pub(crate) fn new(rest_client: RestClient) -> Self {
+        Self { rest_client }
+    }
+
+    async fn list_nodes(&self) -> Result<Vec<AppNode>, ResourceError> {
+        let mut app_nodes: Vec<AppNode> = Vec::new();
+        let mut next_token: Option<isize> = Some(0);
+        let max_entries: isize = utils::MAX_SMALL_RESOURCE_ENTRIES;
+        let client = self.rest_client.app_nodes_api();
+        loop {
+            let api_resp = client.get_app_nodes(max_entries, next_token).await?;
+            let content = api_resp.into_body();
+
+            app_nodes.extend(content.entries);
+            if content.next_token.is_none() {
+                break;
+            }
+            next_token = content.next_token;
+        }
+        Ok(app_nodes)
+    }
+
+    async fn get_node(&self, id: &str) -> Result<AppNode, ResourceError> {
+        let node = self.rest_client.app_nodes_api().get_app_node(id).await?;
+        Ok(node.into_body())
+    }
+}
+
+#[async_trait(?Send)]
+impl Resourcer for AppNodeClientWrapper {
+    type ID = String;
+
+    async fn get_topologer(
+        &self,
+        id: Option<Self::ID>,
+    ) -> Result<Box<dyn Topologer>, ResourceError> {
+        // When ID is provided then caller needs topologer for given node name
+        if let Some(node_id) = id {
+            let node = self.get_node(&node_id).await?;
+            // todo: fetch connected nvmf devices and subsystems
+            let node_topology = AppNodeTopology { node };
+            return Ok(Box::new(node_topology));
+        }
+        // When ID is not provided then caller needs topology information to build for all
+        // available nodes
+        let mut nodes_topology: Vec<AppNodeTopology> = Vec::new();
+        let nodes = self.list_nodes().await?;
+        for node in nodes {
+            let node_topology = AppNodeTopology { node };
+            nodes_topology.push(node_topology);
+        }
+        if nodes_topology.is_empty() {
+            log("No AppNode resources, are the csi-node daemonset pods in Running State?!!");
+            return Err(ResourceError::CustomError(
+                "No AppNode resources".to_string(),
+            ));
+        }
+        Ok(Box::new(nodes_topology))
+    }
+}

--- a/k8s/supportability/src/collect/resources/app_node.rs
+++ b/k8s/supportability/src/collect/resources/app_node.rs
@@ -35,7 +35,7 @@ impl Topologer for AppNodeTopology {
 
     /// Writes topology information into a file in specified directory
     fn dump_topology_info(&self, dir_path: PathBuf) -> Result<(), ResourceError> {
-        create_directory_if_not_exist(dir_path.clone())?;
+        create_directory_if_not_exist(&dir_path)?;
         let file_path = dir_path.join(format!("app-node-{}-topology.json", self.node.id));
         let mut topo_file = File::create(file_path)?;
         let topology_as_pretty = serde_json::to_string_pretty(self)?;

--- a/k8s/supportability/src/collect/resources/mod.rs
+++ b/k8s/supportability/src/collect/resources/mod.rs
@@ -1,6 +1,7 @@
 pub use error::ResourceError;
 pub(crate) use traits::Resourcer;
 
+pub mod app_node;
 pub mod error;
 pub mod node;
 pub mod pool;

--- a/k8s/supportability/src/collect/resources/node.rs
+++ b/k8s/supportability/src/collect/resources/node.rs
@@ -33,7 +33,7 @@ impl Topologer for NodeTopology {
 
     /// Writes topology information into a file in specified directory
     fn dump_topology_info(&self, dir_path: PathBuf) -> Result<(), ResourceError> {
-        create_directory_if_not_exist(dir_path.clone())?;
+        create_directory_if_not_exist(&dir_path)?;
         let file_path = dir_path.join(format!("node-{}-topology.json", self.node.id));
         let mut topo_file = File::create(file_path)?;
         let topology_as_pretty = serde_json::to_string_pretty(self)?;

--- a/k8s/supportability/src/collect/resources/pool.rs
+++ b/k8s/supportability/src/collect/resources/pool.rs
@@ -31,7 +31,7 @@ impl Topologer for PoolTopology {
     }
 
     fn dump_topology_info(&self, dir_path: PathBuf) -> Result<(), ResourceError> {
-        create_directory_if_not_exist(dir_path.clone())?;
+        create_directory_if_not_exist(&dir_path)?;
         let file_path = dir_path.join(format!("pool-{}-topology.json", self.pool.id));
         let mut topo_file = File::create(file_path)?;
         let topology_as_pretty = serde_json::to_string_pretty(self)?;

--- a/k8s/supportability/src/collect/resources/snapshot.rs
+++ b/k8s/supportability/src/collect/resources/snapshot.rs
@@ -27,7 +27,7 @@ impl Topologer for VolumeSnapshotTopology {
     }
 
     fn dump_topology_info(&self, dir_path: PathBuf) -> Result<(), ResourceError> {
-        create_directory_if_not_exist(dir_path.clone())?;
+        create_directory_if_not_exist(&dir_path)?;
         let file_path = dir_path.join(format!(
             "snapshot-{}-topology.json",
             self.snapshot.definition.spec.uuid

--- a/k8s/supportability/src/collect/resources/utils.rs
+++ b/k8s/supportability/src/collect/resources/utils.rs
@@ -6,6 +6,9 @@ use std::path::PathBuf;
 /// Defines maximum entries REST service can fetch at one network call
 pub(crate) const MAX_RESOURCE_ENTRIES: isize = 200;
 
+/// Defines maximum entries REST service can fetch at one network call, for small resources.
+pub(crate) const MAX_SMALL_RESOURCE_ENTRIES: isize = 500;
+
 impl<T> Topologer for Vec<T>
 where
     T: Topologer + Serialize,

--- a/k8s/supportability/src/collect/resources/volume.rs
+++ b/k8s/supportability/src/collect/resources/volume.rs
@@ -37,7 +37,7 @@ impl Topologer for VolumeTopology {
     }
 
     fn dump_topology_info(&self, dir_path: PathBuf) -> Result<(), ResourceError> {
-        create_directory_if_not_exist(dir_path.clone())?;
+        create_directory_if_not_exist(&dir_path)?;
         let file_path = dir_path.join(format!("volume-{}-topology.json", self.volume.spec.uuid));
         let mut topo_file = File::create(file_path)?;
         let topology_as_pretty = serde_json::to_string_pretty(self)?;

--- a/k8s/supportability/src/collect/system_dump.rs
+++ b/k8s/supportability/src/collect/system_dump.rs
@@ -289,7 +289,7 @@ impl SystemDumper {
                 });
             }
             Err(e) => errors.push(Error::ResourceError(e)),
-        };
+        }
 
         match VolumeSnapshotClientWrapper::new(rest_client.clone())
             .get_topologer(None)
@@ -311,7 +311,7 @@ impl SystemDumper {
                     });
             }
             Err(e) => errors.push(Error::ResourceError(e)),
-        };
+        }
 
         // Dump information of all pools topologies exist in the system
         match PoolClientWrapper::new(rest_client.clone())
@@ -332,7 +332,7 @@ impl SystemDumper {
                 });
             }
             Err(e) => errors.push(Error::ResourceError(e)),
-        };
+        }
 
         match NodeClientWrapper::new(rest_client.clone())
             .get_topologer(None)
@@ -350,13 +350,11 @@ impl SystemDumper {
                     ));
                     errors.push(Error::ResourceError(e));
                 });
-                Some(topologer)
             }
             Err(e) => {
                 errors.push(Error::ResourceError(e));
-                None
             }
-        };
+        }
 
         match AppNodeClientWrapper::new(rest_client)
             .get_topologer(None)

--- a/k8s/supportability/src/collect/system_dump.rs
+++ b/k8s/supportability/src/collect/system_dump.rs
@@ -7,7 +7,7 @@ use crate::{
         logs::{LogCollection, Logger},
         persistent_store::etcd::EtcdStore,
         resources::{
-            node::NodeClientWrapper, pool::PoolClientWrapper,
+            app_node::AppNodeClientWrapper, node::NodeClientWrapper, pool::PoolClientWrapper,
             snapshot::VolumeSnapshotClientWrapper, volume::VolumeClientWrapper, Resourcer,
         },
         rest_wrapper,
@@ -334,7 +334,7 @@ impl SystemDumper {
             Err(e) => errors.push(Error::ResourceError(e)),
         };
 
-        match NodeClientWrapper::new(rest_client)
+        match NodeClientWrapper::new(rest_client.clone())
             .get_topologer(None)
             .await
         {
@@ -357,6 +357,29 @@ impl SystemDumper {
                 None
             }
         };
+
+        match AppNodeClientWrapper::new(rest_client)
+            .get_topologer(None)
+            .await
+        {
+            Ok(topologer) => {
+                log("\t Collecting app-node topology information");
+                let mut node_topo_path = path.to_path_buf();
+                node_topo_path.push("topology");
+                node_topo_path.push("app-node");
+
+                let _ = topologer.dump_topology_info(node_topo_path).map_err(|e| {
+                    log(format!(
+                        "\t Failed to dump app-node topology information, {e:?}"
+                    ));
+                    errors.push(Error::ResourceError(e));
+                });
+            }
+            Err(e) => {
+                errors.push(Error::ResourceError(e));
+            }
+        }
+
         log("Completed collection of topology information");
         Ok(())
     }

--- a/k8s/upgrade/src/plugin/error.rs
+++ b/k8s/upgrade/src/plugin/error.rs
@@ -33,54 +33,54 @@ pub enum Error {
     VolumeRebuildInProgress,
 
     /// K8s client error.
-    #[snafu(display("K8Client Error: {}", source))]
+    #[snafu(display("K8Client Error: {source}"))]
     K8sClient { source: kube::Error },
 
     /// Deserialization error for event.
-    #[snafu(display("Error in deserializing upgrade event {} Error {}", event, source))]
+    #[snafu(display("Error in deserializing upgrade event {event}: {source}"))]
     EventSerdeDeserialization {
         event: String,
         source: serde_json::Error,
     },
 
     /// Failed in creating service account.
-    #[snafu(display("Service account: {} creation failed Error: {}", name, source))]
+    #[snafu(display("Service account: {name} creation failed: {source}"))]
     ServiceAccountCreate { name: String, source: kube::Error },
 
     /// Failed in deletion service account.
-    #[snafu(display("Service account: {} deletion failed Error: {}", name, source))]
+    #[snafu(display("Service account: {name} deletion failed: {source}"))]
     ServiceAccountDelete { name: String, source: kube::Error },
 
     /// Failed in creating cluster role.
-    #[snafu(display("Cluster role: {} creation failed Error: {}", name, source))]
+    #[snafu(display("Cluster role: {name} creation failed: {source}"))]
     ClusterRoleCreate { name: String, source: kube::Error },
 
     /// Failed in deletion cluster role.
-    #[snafu(display("Cluster role: {} deletion Error: {}", name, source))]
+    #[snafu(display("Cluster role: {name} deletion failed: {source}"))]
     ClusterRoleDelete { name: String, source: kube::Error },
 
     /// Failed in deletion cluster role binding.
-    #[snafu(display("Cluster role binding: {} deletion failed Error: {}", name, source))]
+    #[snafu(display("Cluster role binding: {name} deletion failed: {source}"))]
     ClusterRoleBindingDelete { name: String, source: kube::Error },
 
     /// Failed in creating cluster role binding.
-    #[snafu(display("Cluster role binding: {} creation failed Error: {}", name, source))]
+    #[snafu(display("Cluster role binding: {name} creation failed: {source}"))]
     ClusterRoleBindingCreate { name: String, source: kube::Error },
 
     /// Failed in creating config map.
-    #[snafu(display("Config Map: {} creation failed Error: {}", name, source))]
+    #[snafu(display("Config Map: {name} creation failed: {source}"))]
     UpgradeConfigMapCreate { name: String, source: kube::Error },
 
     /// Failed in creating upgrade job.
-    #[snafu(display("Upgrade Job: {} creation failed Error: {}", name, source))]
+    #[snafu(display("Upgrade Job: {name} creation failed: {source}"))]
     UpgradeJobCreate { name: String, source: kube::Error },
 
     /// Failed in deleting upgrade job.
-    #[snafu(display("Upgrade Job: {} deletion failed Error: {}", name, source))]
+    #[snafu(display("Upgrade Job: {name} deletion failed: {source}"))]
     UpgradeJobDelete { name: String, source: kube::Error },
 
     /// Failed in deleting upgrade config map.
-    #[snafu(display("Upgrade Config Map: {} deletion failed Error: {}", name, source))]
+    #[snafu(display("Upgrade Config Map: {name} deletion failed: {source}"))]
     UpgradeConfigMapDelete { name: String, source: kube::Error },
 
     /// Error for when the image format is invalid.
@@ -104,7 +104,7 @@ pub enum Error {
     ReferenceDeploymentNoContainers,
 
     /// Node spec not present error.
-    #[snafu(display("Node spec not present, node: {}", node))]
+    #[snafu(display("Node spec not present, node: {node}"))]
     NodeSpecNotPresent { node: String },
 
     /// Error for when the pod.metadata.name is a None.
@@ -112,21 +112,16 @@ pub enum Error {
     PodNameNotPresent,
 
     /// Error for when the job.status is a None.
-    #[snafu(display("Upgrade Job: {} status not present.", name))]
+    #[snafu(display("Upgrade Job: {name} status not present."))]
     UpgradeJobStatusNotPresent { name: String },
 
     /// Error for when the upgrade job is not present.
-    #[snafu(display("Upgrade Job: {} in namespace {} does not exist.", name, namespace))]
+    #[snafu(display("Upgrade Job: {name} in namespace {namespace} does not exist."))]
     UpgradeJobNotPresent { name: String, namespace: String },
 
     /// Error for when a Kubernetes API request for GET-ing a list of Pods filtered by label(s)
     /// fails.
-    #[snafu(display(
-        "Failed to list Pods with label {} in namespace {}: {}",
-        label,
-        namespace,
-        source
-    ))]
+    #[snafu(display("Failed to list Pods with label {label} in namespace {namespace}: {source}"))]
     ListPodsWithLabel {
         source: kube::Error,
         label: String,
@@ -136,10 +131,7 @@ pub enum Error {
     /// Error for when a Kubernetes API request for GET-ing a list of Deployments filtered by
     /// label(s) fails.
     #[snafu(display(
-        "Failed to list Deployments with label {} in namespace {}: {}",
-        label,
-        namespace,
-        source
+        "Failed to list Deployments with label {label} in namespace {namespace}: {source}"
     ))]
     ListDeploymantsWithLabel {
         source: kube::Error,
@@ -149,50 +141,50 @@ pub enum Error {
 
     /// Error for when a Kubernetes API request for GET-ing a list of events filtered by
     /// filed selector fails.
-    #[snafu(display("Failed to list Events with field selector {}: {}", field, source))]
+    #[snafu(display("Failed to list Events with field selector {field}: {source}"))]
     ListEventsWithFieldSelector { source: kube::Error, field: String },
 
     /// Error for when a Kubernetes API request for Deleting a list of events filtered by
     /// filed selector fails.
-    #[snafu(display("Failed to delete Events with field selector {}: {}", field, source))]
+    #[snafu(display("Failed to delete Events with field selector {field}: {source}"))]
     DeleteEventsWithFieldSelector { source: kube::Error, field: String },
 
     /// Error listing the pvc list.
-    #[snafu(display("Failed to list pvc : {}", source))]
+    #[snafu(display("Failed to list pvc: {source}"))]
     ListPVC { source: kube::Error },
 
     /// Error listing the volumes.
-    #[snafu(display("Failed to list volumes : {}", source))]
+    #[snafu(display("Failed to list volumes: {source}"))]
     ListVolumes {
         source: openapi::tower::client::Error<openapi::models::RestJsonError>,
     },
 
     /// Error when a Get Upgrade job fails.
-    #[snafu(display("Failed to get Upgrade Job {}: {}", name, source))]
+    #[snafu(display("Failed to get Upgrade Job {name}: {source}"))]
     GetUpgradeJob { source: kube::Error, name: String },
 
     /// Error when a Get Upgrade config map fails.
-    #[snafu(display("Failed to get Upgrade Config Map {}: {}", name, source))]
+    #[snafu(display("Failed to get Upgrade Config Map {name}: {source}"))]
     GetUpgradeConfigMap { source: kube::Error, name: String },
 
     /// Error when a Get ServiceAccount fails.
-    #[snafu(display("Failed to get service account {}: {}", name, source))]
+    #[snafu(display("Failed to get service account {name}: {source}"))]
     GetServiceAccount { source: kube::Error, name: String },
 
     /// Error when a Get ClusterRole fails.
-    #[snafu(display("Failed to get cluster role {}: {}", name, source))]
+    #[snafu(display("Failed to get cluster role {name}: {source}"))]
     GetClusterRole { source: kube::Error, name: String },
 
     /// Error when a Get CLusterRoleBinding fails.
-    #[snafu(display("Failed to get cluster role binding {}: {}", name, source))]
+    #[snafu(display("Failed to get cluster role binding {name}: {source}"))]
     GetClusterRoleBinding { source: kube::Error, name: String },
 
     /// Error for when Kubernetes API client generation fails.
-    #[snafu(display("Failed to generate kubernetes client: {}", source))]
+    #[snafu(display("Failed to generate kubernetes client: {source}"))]
     K8sClientGeneration { source: kube::Error },
 
     /// Error for when REST API configuration fails.
-    #[snafu(display("Failed to configure REST API client : {:?}", source,))]
+    #[snafu(display("Failed to configure REST API client: {source:?}"))]
     RestClientConfiguration {
         #[snafu(source(false))]
         source: openapi::clients::tower::configuration::Error,
@@ -205,36 +197,36 @@ pub enum Error {
     },
 
     /// Openapi configuration error.
-    #[snafu(display("openapi configuration Error: {}", source))]
+    #[snafu(display("openapi configuration Error: {source}"))]
     OpenapiClientConfiguration { source: kube_proxy::Error },
 
     /// Error when opening a file.
-    #[snafu(display("Failed to open file {}: {}", filepath.display(), source))]
+    #[snafu(display("Failed to open file {}: {source}", filepath.display()))]
     OpeningFile {
         source: std::io::Error,
         filepath: PathBuf,
     },
 
     /// Error for when yaml could not be parsed from a file (Reader).
-    #[snafu(display("Failed to parse YAML at {}: {}", filepath.display(), source))]
+    #[snafu(display("Failed to parse YAML at {}: {source}", filepath.display()))]
     YamlParseFromFile {
         source: serde_yaml::Error,
         filepath: PathBuf,
     },
 
     /// Error when reading the entire contents of a file into a string.
-    #[snafu(display("Failed to read file at {}: {}", filepath.display(), source))]
+    #[snafu(display("Failed to read file at {}: {source}", filepath.display()))]
     ReadFromFile {
         source: std::io::Error,
         filepath: PathBuf,
     },
 
     /// Error for when yaml could not be parsed from bytes.
-    #[snafu(display("Failed to parse unsupported versions yaml: {}", source))]
+    #[snafu(display("Failed to parse unsupported versions yaml: {source}"))]
     YamlParseBufferForUnsupportedVersion { source: serde_yaml::Error },
 
     /// Error for failures in generating semver::Value from a &str input.
-    #[snafu(display("Failed to parse {} as a valid semver: {}", version_string, source))]
+    #[snafu(display("Failed to parse {version_string} as a valid semver: {source}"))]
     SemverParse {
         source: semver::Error,
         version_string: String,
@@ -253,7 +245,7 @@ pub enum Error {
     InvalidUpgradePath,
 
     /// Error when set-file arguments are not in proper format.
-    #[snafu(display("Error parsing set-file argument: {} ", arguments))]
+    #[snafu(display("Error parsing set-file argument: {arguments} "))]
     InvalidSetFileArguments { arguments: String },
 
     /// Error for key not present in Map.


### PR DESCRIPTION
    refactor: more idiomatic support and upgrade changes
    
    Use Path where possible, avoid cloning.
    More consistent errors with source.
    Define format errors inline.
    
---

    feat: add app-nodes to system dump
    
    Adds AppNode resource from the public API to the topology section
    of the system dump.
    todo: collect nvmf device and subsystems.
