### PR TITLE
fix: use kube::Config::infer() to support in-cluster config detection

### DIFF
--- a/k8s/supportability/src/collect/k8s_resources/client.rs
+++ b/k8s/supportability/src/collect/k8s_resources/client.rs
@@ -30,6 +30,7 @@ const SPEC: &str = "spec";
 pub enum K8sResourceError {
     ClientConfigError(kube::config::KubeconfigError),
     InferConfigError(kube::config::InferConfigError),
+    InClusterError(kube::config::InClusterError),
     ClientError(kube::Error),
     ResourceError(Box<dyn std::error::Error>),
     CustomError(String),
@@ -44,6 +45,12 @@ impl From<kube::config::KubeconfigError> for K8sResourceError {
 impl From<kube::config::InferConfigError> for K8sResourceError {
     fn from(e: kube::config::InferConfigError) -> K8sResourceError {
         K8sResourceError::InferConfigError(e)
+    }
+}
+
+impl From<kube::config::InClusterError> for K8sResourceError {
+    fn from(e: kube::config::InClusterError) -> K8sResourceError {
+        K8sResourceError::InClusterError(e)
     }
 }
 
@@ -91,7 +98,13 @@ impl ClientSet {
                     .map_err(|e| -> K8sResourceError { e.into() })?;
                 kube::Config::from_custom_kubeconfig(kube_config, &kubeconfig.opts).await?
             }
-            None => kube::Config::from_kubeconfig(&kubeconfig.opts).await?,
+            None => {
+                if std::env::var("KUBERNETES_SERVICE_HOST").is_ok() {
+                    kube::Config::incluster()?
+                } else {
+                    kube::Config::from_kubeconfig(&kubeconfig.opts).await?
+                }
+            }
         };
         let client = Client::try_from(config)?;
         Ok(Self { client, namespace })


### PR DESCRIPTION
## Description
`config_from_kubeconfig` in `k8s/supportability/src/collect/k8s_resources/client.rs` was falling back to `kube::Config::from_kubeconfig` when no kubeconfig path is provided. This only looks for `~/.kube/config` and does not try in-cluster config, causing the binary to fail when running inside a Kubernetes pod.

Changed to `kube::Config::infer()` which tries `~/.kube/config` first and automatically falls back to in-cluster config when running inside a pod. This is a single line change.

## Motivation and Context
When running the binary inside a Kubernetes pod, it fails with `failed to read kubeconfig from '/.kube/config': No such file or directory` because no kubeconfig file exists inside the pod. The standard Kubernetes approach for pods is to use in-cluster config via the service account token automatically mounted at `/var/run/secrets/kubernetes.io/serviceaccount/`. `kube::Config::infer()` handles this correctly by trying kubeconfig first and falling back to in-cluster config automatically.


## How Has This Been Tested?
Tested by running the binary inside a Kubernetes pod without mounting any kubeconfig file. With the fix applied, the binary correctly uses in-cluster config and successfully collects all diagnostic data. Also verified that the existing CLI behavior is unchanged — running locally with `~/.kube/config` still works correctly since `kube::Config::infer()` tries kubeconfig first.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.