### PR TITLE
feat: additional envars for customization

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -200,9 +200,16 @@ This removes all the Kubernetes components associated with the chart and deletes
 | io_engine.&ZeroWidthSpace;logLevel | Log level for the io-engine service | `"info"` |
 | io_engine.&ZeroWidthSpace;nodeSelector | Node selectors to designate storage nodes for diskpool creation Note that if multi-arch images support 'kubernetes.io/arch: amd64' should be removed. | <pre>{<br>"kubernetes.io/arch":"amd64",<br>"openebs.io/engine":"mayastor"<br>}</pre> |
 | io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;ioTimeout | Timeout for IOs The default here is exaggerated for local disks, but we've observed that in shared virtual environments having a higher timeout value is beneficial. Please adjust this according to your hardware and needs. | `"110s"` |
-| io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;rdma.&ZeroWidthSpace;bufCacheSize | The number of shared buffers to reserve for each poll group | `"64"` |
-| io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;rdma.&ZeroWidthSpace;numSharedBuf | The number of pooled data buffers available to the transport | `"2047"` |
+| io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;rdma.&ZeroWidthSpace;bufCacheSize | The number of shared buffers to reserve for each poll group | `nil` |
+| io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;rdma.&ZeroWidthSpace;dataWrPoolSize | RDMA data WR pool size (RDMA only) | `"4095"` |
+| io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;rdma.&ZeroWidthSpace;inCapsuleDataSize | The max amount of payload data that can be transferred directly within the NVMe-oF Capsule command itself | `nil` |
+| io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;rdma.&ZeroWidthSpace;ioUnitSize | I/O unit size (bytes) | `"8192"` |
+| io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;rdma.&ZeroWidthSpace;maxIoSize | Max I/O size (bytes) | `nil` |
+| io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;rdma.&ZeroWidthSpace;numSharedBuf | The number of pooled data buffers available to the transport | `nil` |
 | io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;tcp.&ZeroWidthSpace;bufCacheSize | The number of shared buffers to reserve for each poll group | `"64"` |
+| io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;tcp.&ZeroWidthSpace;inCapsuleDataSize | The max amount of payload data that can be transferred directly within the NVMe-oF Capsule command itself | `"4096"` |
+| io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;tcp.&ZeroWidthSpace;ioUnitSize | I/O unit size (bytes) | `"131072"` |
+| io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;tcp.&ZeroWidthSpace;maxIoSize | Max I/O size (bytes) | `"131072"` |
 | io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;tcp.&ZeroWidthSpace;maxQpairsPerCtrl | Max number of IO qpairs per controller | `"32"` |
 | io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;tcp.&ZeroWidthSpace;maxQueueDepth | You may need to increase this for a higher outstanding IOs per volume | `"32"` |
 | io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;tcp.&ZeroWidthSpace;numSharedBuf | The number of pooled data buffers available to the transport | `"2047"` |

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -57,11 +57,25 @@ spec:
           value: "{{ .Values.io_engine.nvme.tcp.maxQpairsPerCtrl }}"
         - name: NVMF_TCP_MAX_QUEUE_DEPTH
           value: "{{ .Values.io_engine.nvme.tcp.maxQueueDepth }}"
+        - name: NVMF_TCP_IN_CAPSULE_DATA_SIZE
+          value: "{{ .Values.io_engine.nvme.tcp.inCapsuleDataSize }}"
+        - name: NVMF_TCP_MAX_IO_SIZE
+          value: "{{ .Values.io_engine.nvme.tcp.maxIoSize }}"
+        - name: NVMF_TCP_IO_UNIT_SIZE
+          value: "{{ .Values.io_engine.nvme.tcp.ioUnitSize }}"
         {{- if .Values.io_engine.target.nvmf.rdma.enabled }}
         - name: NVMF_RDMA_NUM_SHARED_BUF
           value: "{{ .Values.io_engine.nvme.rdma.numSharedBuf }}"
         - name: NVMF_RDMA_BUF_CACHE_SIZE
           value: "{{ .Values.io_engine.nvme.rdma.bufCacheSize }}"
+        - name: NVMF_RDMA_DATA_WR_POOL_SIZE
+          value: "{{ .Values.io_engine.nvme.rdma.dataWrPoolSize }}"
+        - name: NVMF_RDMA_MAX_IO_SIZE
+          value: "{{ .Values.io_engine.nvme.rdma.maxIoSize }}"
+        - name: NVMF_RDMA_IO_UNIT_SIZE
+          value: "{{ .Values.io_engine.nvme.rdma.ioUnitSize }}"
+        - name: NVMF_RDMA_IN_CAPSULE_DATA_SIZE
+          value: "{{ .Values.io_engine.nvme.rdma.inCapsuleDataSize }}"
         {{- end }}
         - name: NVME_TIMEOUT
           value: "{{ .Values.io_engine.nvme.ioTimeout }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -490,11 +490,25 @@ io_engine:
       numSharedBuf: "2047"
       # -- The number of shared buffers to reserve for each poll group
       bufCacheSize: "64"
+      # -- The max amount of payload data that can be transferred directly within the NVMe-oF Capsule command itself
+      inCapsuleDataSize: "4096"
+      # -- Max I/O size (bytes)
+      maxIoSize: "131072"
+      # -- I/O unit size (bytes)
+      ioUnitSize: "131072"
     rdma:
       # -- The number of pooled data buffers available to the transport
-      numSharedBuf: "2047"
+      numSharedBuf:
       # -- The number of shared buffers to reserve for each poll group
-      bufCacheSize: "64"
+      bufCacheSize:
+      # -- RDMA data WR pool size (RDMA only)
+      dataWrPoolSize: "4095"
+      # -- The max amount of payload data that can be transferred directly within the NVMe-oF Capsule command itself
+      inCapsuleDataSize:
+      # -- Max I/O size (bytes)
+      maxIoSize:
+      # -- I/O unit size (bytes)
+      ioUnitSize: "8192"
   # -- Pass additional arguments to the Environment Abstraction Layer.
   # Example: --set {product}.envcontext=iova-mode=pa
   envcontext: ""


### PR DESCRIPTION
## Description
Addition of following envvars for customization

TCP OPTS
NVMF_TCP_IN_CAPSULE_DATA_SIZE  4096
NVMF_TCP_MAX_IO_SIZE 131072
NVMF_TCP_IO_UNIT_SIZE 131072

RDMA OPTS
NVMF_RDMA_DATA_WR_POOL_SIZE  4095
NVMF_RDMA_MAX_IO_SIZE 131072
NVMF_RDMA_IO_UNIT_SIZE  8192
NVMF_RDMA_IN_CAPSULE_DATA_SIZE  4096

## Motivation and Context
Users can custiomize installation according to there environment needs for optimised performance.




<!-- If Yes, optionally please include version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Deployed chart on a 3 worker node cluster.
Checked the default values
did a in place upgrade and modified tcp opts, changes were reflected
did a in place upgrade after enabling rdma and changes were refelected in daemonset

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.