### PR TITLE
changes in metrics exporter

### DIFF
--- a/metrics-exporter/src/bin/io_engine/client/nexus_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/client/nexus_stat.rs
@@ -50,7 +50,7 @@ impl NexusIoStat {
 }
 
 /// Array of NexusIoStat objects.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct NexusIoStats {
     pub(crate) nexus_stats: Vec<NexusIoStat>,
 }

--- a/metrics-exporter/src/bin/io_engine/client/pool.rs
+++ b/metrics-exporter/src/bin/io_engine/client/pool.rs
@@ -110,7 +110,7 @@ impl PoolInfo {
 }
 
 /// Array of PoolInfo objects.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct Pools {
     pub(crate) pools: Vec<PoolInfo>,
 }

--- a/metrics-exporter/src/bin/io_engine/client/pool_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/client/pool_stat.rs
@@ -50,7 +50,7 @@ impl PoolIoStat {
 }
 
 /// Array of PoolIoStat objects.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct PoolIoStats {
     pub(crate) pool_stats: Vec<PoolIoStat>,
 }

--- a/metrics-exporter/src/bin/io_engine/client/replica_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/client/replica_stat.rs
@@ -57,7 +57,7 @@ impl ReplicaIoStat {
 }
 
 /// Array of NexusIoStat objects.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct ReplicaIoStats {
     pub(crate) replica_stats: Vec<ReplicaIoStat>,
 }

--- a/metrics-exporter/src/bin/io_engine/collector/nexus_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/nexus_stat.rs
@@ -1,5 +1,5 @@
 use super::init_volume_gauge_vec;
-use crate::{cache::Cache, get_node_name};
+use crate::{cache::Cache, client::nexus_stat::NexusIoStats, get_node_name};
 use prometheus::{
     core::{Collector, Desc},
     GaugeVec,
@@ -10,6 +10,7 @@ use tracing::error;
 /// Collects Nexus IoStat metrics from cache.
 #[derive(Clone, Debug)]
 pub(crate) struct NexusIoStatsCollector {
+    cache: NexusIoStats,
     nexus_bytes_read: GaugeVec,
     nexus_num_read_ops: GaugeVec,
     nexus_bytes_written: GaugeVec,
@@ -57,8 +58,17 @@ impl NexusIoStatsCollector {
             "Total write latency on the volume in usec",
             &mut descs,
         );
+        let cache = match Cache::get_cache().lock() {
+            Ok(cache) => cache,
+            Err(error) => {
+                error!(%error,"Error while getting cache resource");
+                panic!("panic");
+            }
+        };
+        let nexus_stat = cache.deref().nexus_iostat();
 
         Self {
+            cache: nexus_stat.clone(),
             nexus_bytes_read,
             nexus_num_read_ops,
             nexus_bytes_written,
@@ -76,16 +86,7 @@ impl Collector for NexusIoStatsCollector {
     }
 
     fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
-        let cache = match Cache::get_cache().lock() {
-            Ok(cache) => cache,
-            Err(error) => {
-                error!(%error,"Error while getting cache resource");
-                return Vec::new();
-            }
-        };
-        let cache_deref = cache.deref();
-        let mut metric_family =
-            Vec::with_capacity(6 * cache_deref.nexus_iostat().nexus_stats.capacity());
+        let mut metric_family = Vec::with_capacity(6 * self.cache.nexus_stats.capacity());
         let node_name = match get_node_name() {
             Ok(name) => name,
             Err(error) => {
@@ -94,7 +95,7 @@ impl Collector for NexusIoStatsCollector {
             }
         };
 
-        for nexus_stat in &cache_deref.nexus_iostat().nexus_stats {
+        for nexus_stat in self.cache.nexus_stats.clone() {
             let pv_name = "pvc-".to_string() + nexus_stat.name();
             let nexus_bytes_read = match self
                 .nexus_bytes_read

--- a/metrics-exporter/src/bin/io_engine/collector/nexus_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/nexus_stat.rs
@@ -58,17 +58,15 @@ impl NexusIoStatsCollector {
             "Total write latency on the volume in usec",
             &mut descs,
         );
-        let cache = match Cache::get_cache().lock() {
-            Ok(cache) => cache,
-            Err(error) => {
-                error!(%error,"Error while getting cache resource");
-                panic!("panic");
-            }
+
+        let nexus_stats = if let Ok(cache) = Cache::get_cache().lock() {
+            cache.deref().nexus_iostat().clone()
+        } else {
+            NexusIoStats::default()
         };
-        let nexus_stat = cache.deref().nexus_iostat();
 
         Self {
-            cache: nexus_stat.clone(),
+            cache: nexus_stats,
             nexus_bytes_read,
             nexus_num_read_ops,
             nexus_bytes_written,
@@ -95,7 +93,7 @@ impl Collector for NexusIoStatsCollector {
             }
         };
 
-        for nexus_stat in self.cache.nexus_stats.clone() {
+        for nexus_stat in self.cache.nexus_stats.iter() {
             let pv_name = "pvc-".to_string() + nexus_stat.name();
             let nexus_bytes_read = match self
                 .nexus_bytes_read

--- a/metrics-exporter/src/bin/io_engine/collector/pool.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/pool.rs
@@ -1,5 +1,6 @@
 use crate::{
     cache::Cache,
+    client::pool::Pools,
     collector::{init_diskpool_alert_reason_gauge_vec, init_diskpool_gauge_vec},
     get_node_name,
 };
@@ -8,15 +9,13 @@ use prometheus::{
     GaugeVec,
 };
 use rpc::v1::pb::PoolAlert;
-use std::{
-    fmt::Debug,
-    ops::{Deref, DerefMut},
-};
+use std::{fmt::Debug, ops::Deref};
 use tracing::error;
 
 /// Collects Pool capacity metrics from cache.
 #[derive(Clone, Debug)]
 pub(crate) struct PoolCapacityCollector {
+    cache: Pools,
     pool_total_size: GaugeVec,
     pool_used_size: GaugeVec,
     pool_committed_size: GaugeVec,
@@ -60,8 +59,17 @@ impl PoolCapacityCollector {
             "Maximum capacity upto which this pool can be expanded, in bytes",
             &mut descs,
         );
+        let cache = match Cache::get_cache().lock() {
+            Ok(cache) => cache,
+            Err(error) => {
+                error!(%error,"Error while getting cache resource");
+                panic!("panic");
+            }
+        };
+        let pools = cache.deref().pool();
 
         Self {
+            cache: pools.clone(),
             pool_total_size,
             pool_used_size,
             pool_committed_size,
@@ -78,15 +86,7 @@ impl Collector for PoolCapacityCollector {
     }
 
     fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
-        let cache = match Cache::get_cache().lock() {
-            Ok(cache) => cache,
-            Err(error) => {
-                error!(%error,"Error while getting cache resource");
-                return Vec::new();
-            }
-        };
-        let cache_deref = cache.deref();
-        let mut metric_family = Vec::with_capacity(5 * cache_deref.pool().pools.capacity());
+        let mut metric_family = Vec::with_capacity(5 * self.cache.pools.capacity());
         let node_name = match get_node_name() {
             Ok(name) => name,
             Err(error) => {
@@ -95,7 +95,7 @@ impl Collector for PoolCapacityCollector {
             }
         };
 
-        for pool in &cache_deref.pool().pools {
+        for pool in self.cache.pools.iter() {
             let pool_total_size = match self
                 .pool_total_size
                 .get_metric_with_label_values(&[node_name.clone().as_str(), pool.name().as_str()])
@@ -173,6 +173,7 @@ impl Collector for PoolCapacityCollector {
 /// Collects pool status info from cache.
 #[derive(Clone, Debug)]
 pub(crate) struct PoolStatusCollector {
+    cache: Pools,
     pool_status: GaugeVec,
     descs: Vec<Desc>,
 }
@@ -188,7 +189,19 @@ impl PoolStatusCollector {
     pub fn new() -> Self {
         let mut descs = Vec::new();
         let pool_status = init_diskpool_gauge_vec("status", "Status of the pool", &mut descs);
-        Self { pool_status, descs }
+        let cache = match Cache::get_cache().lock() {
+            Ok(cache) => cache,
+            Err(error) => {
+                error!(%error,"Error while getting cache resource");
+                panic!("panic");
+            }
+        };
+        let pools = cache.deref().pool();
+        Self {
+            cache: pools.clone(),
+            pool_status,
+            descs,
+        }
     }
 }
 
@@ -197,15 +210,7 @@ impl Collector for PoolStatusCollector {
         self.descs.iter().collect()
     }
     fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
-        let mut cache = match Cache::get_cache().lock() {
-            Ok(cache) => cache,
-            Err(error) => {
-                error!(%error,"Error while getting cache resource");
-                return Vec::new();
-            }
-        };
-        let cache_deref = cache.deref_mut();
-        let mut metric_family = Vec::with_capacity(3 * cache_deref.pool_mut().pools.capacity());
+        let mut metric_family = Vec::with_capacity(3 * self.cache.pools.capacity());
         let node_name = match get_node_name() {
             Ok(name) => name,
             Err(error) => {
@@ -213,7 +218,7 @@ impl Collector for PoolStatusCollector {
                 return metric_family;
             }
         };
-        for pool in &cache_deref.pool_mut().pools {
+        for pool in self.cache.pools.clone() {
             let pool_status = match self
                 .pool_status
                 .get_metric_with_label_values(&[node_name.clone().as_str(), pool.name().as_str()])
@@ -235,6 +240,7 @@ impl Collector for PoolStatusCollector {
 /// Collects pool alerts info from cache.
 #[derive(Clone, Debug)]
 pub(crate) struct PoolAlertCollector {
+    cache: Pools,
     io_error_count: GaugeVec,
     io_error_threshold: GaugeVec,
     io_stalled: GaugeVec,
@@ -313,7 +319,16 @@ impl PoolAlertCollector {
                 String::new()
             }
         };
+        let cache = match Cache::get_cache().lock() {
+            Ok(cache) => cache,
+            Err(error) => {
+                error!(%error,"Error while getting cache resource");
+                panic!("panic");
+            }
+        };
+        let pool = cache.deref().pool();
         Self {
+            cache: pool.clone(),
             io_error_count,
             io_error_threshold,
             io_stalled,
@@ -335,16 +350,8 @@ impl Collector for PoolAlertCollector {
         self.descs.iter().collect()
     }
     fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
-        let mut cache = match Cache::get_cache().lock() {
-            Ok(cache) => cache,
-            Err(error) => {
-                error!(%error,"Error while getting cache resource");
-                return Vec::new();
-            }
-        };
-        let cache_deref = cache.deref_mut();
-        let mut metric_family = Vec::with_capacity(10 * cache_deref.pool_mut().pools.capacity());
-        for pool in &cache_deref.pool_mut().pools {
+        let mut metric_family = Vec::with_capacity(10 * self.cache.pools.capacity());
+        for pool in self.cache.pools.clone() {
             let io_error_count = match self
                 .io_error_count
                 .get_metric_with_label_values(&[self.node_name.as_str(), pool.name().as_str()])

--- a/metrics-exporter/src/bin/io_engine/collector/pool.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/pool.rs
@@ -59,17 +59,15 @@ impl PoolCapacityCollector {
             "Maximum capacity upto which this pool can be expanded, in bytes",
             &mut descs,
         );
-        let cache = match Cache::get_cache().lock() {
-            Ok(cache) => cache,
-            Err(error) => {
-                error!(%error,"Error while getting cache resource");
-                panic!("panic");
-            }
+
+        let pools = if let Ok(cache) = Cache::get_cache().lock() {
+            cache.deref().pool().clone()
+        } else {
+            Pools::default()
         };
-        let pools = cache.deref().pool();
 
         Self {
-            cache: pools.clone(),
+            cache: pools,
             pool_total_size,
             pool_used_size,
             pool_committed_size,
@@ -189,16 +187,13 @@ impl PoolStatusCollector {
     pub fn new() -> Self {
         let mut descs = Vec::new();
         let pool_status = init_diskpool_gauge_vec("status", "Status of the pool", &mut descs);
-        let cache = match Cache::get_cache().lock() {
-            Ok(cache) => cache,
-            Err(error) => {
-                error!(%error,"Error while getting cache resource");
-                panic!("panic");
-            }
+        let pools = if let Ok(cache) = Cache::get_cache().lock() {
+            cache.deref().pool().clone()
+        } else {
+            Pools::default()
         };
-        let pools = cache.deref().pool();
         Self {
-            cache: pools.clone(),
+            cache: pools,
             pool_status,
             descs,
         }
@@ -319,16 +314,13 @@ impl PoolAlertCollector {
                 String::new()
             }
         };
-        let cache = match Cache::get_cache().lock() {
-            Ok(cache) => cache,
-            Err(error) => {
-                error!(%error,"Error while getting cache resource");
-                panic!("panic");
-            }
+        let pools = if let Ok(cache) = Cache::get_cache().lock() {
+            cache.deref().pool().clone()
+        } else {
+            Pools::default()
         };
-        let pool = cache.deref().pool();
         Self {
-            cache: pool.clone(),
+            cache: pools,
             io_error_count,
             io_error_threshold,
             io_stalled,
@@ -457,7 +449,8 @@ impl Collector for PoolAlertCollector {
                     return metric_family;
                 }
             };
-            io_alert_notice_reason.set(1_f64);
+            let metrics_value = notice_reason_set.metrics_value();
+            io_alert_notice_reason.set(metrics_value);
             let mut metric_vec = io_alert_notice_reason.collect();
             metric_family.extend(metric_vec.pop());
 
@@ -481,7 +474,8 @@ impl Collector for PoolAlertCollector {
                     return metric_family;
                 }
             };
-            io_alert_attention_reason.set(1_f64);
+            let metrics_value = attention_reason_set.metrics_value();
+            io_alert_attention_reason.set(metrics_value);
             let mut metric_vec = io_alert_attention_reason.collect();
             metric_family.extend(metric_vec.pop());
 
@@ -505,7 +499,8 @@ impl Collector for PoolAlertCollector {
                     return metric_family;
                 }
             };
-            io_alert_warning_reason.set(1_f64);
+            let metrics_value = warning_reason_set.metrics_value();
+            io_alert_warning_reason.set(metrics_value);
             let mut metric_vec = io_alert_warning_reason.collect();
             metric_family.extend(metric_vec.pop());
 
@@ -529,7 +524,8 @@ impl Collector for PoolAlertCollector {
                     return metric_family;
                 }
             };
-            io_alert_critical_reason.set(1_f64);
+            let metrics_value = critical_reason_set.metrics_value();
+            io_alert_critical_reason.set(metrics_value);
             let mut metric_vec = io_alert_critical_reason.collect();
             metric_family.extend(metric_vec.pop());
         }
@@ -561,5 +557,13 @@ impl AlertReasons {
                 PoolAlert::IoErrorExc => self.io_error_exc = 1,
             }
         }
+    }
+    fn metrics_value(&self) -> f64 {
+        (self.unknown
+            | self.io_stalled
+            | self.io_stall_intermittent
+            | self.io_stall_intermittent_exc
+            | self.io_error
+            | self.io_error_exc) as f64
     }
 }

--- a/metrics-exporter/src/bin/io_engine/collector/pool_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/pool_stat.rs
@@ -1,5 +1,6 @@
 use super::init_diskpool_gauge_vec;
-use crate::{cache::Cache, get_node_name};
+use crate::{cache::Cache, client::pool_stat::PoolIoStats, get_node_name};
+use core::panic;
 use prometheus::{
     core::{Collector, Desc},
     GaugeVec,
@@ -10,6 +11,7 @@ use tracing::error;
 /// Collects Pool IoStat metrics from cache.
 #[derive(Clone, Debug)]
 pub(crate) struct PoolIoStatsCollector {
+    cache: PoolIoStats,
     pool_bytes_read: GaugeVec,
     pool_num_read_ops: GaugeVec,
     pool_bytes_written: GaugeVec,
@@ -58,7 +60,17 @@ impl PoolIoStatsCollector {
             &mut descs,
         );
 
+        let cache = match Cache::get_cache().lock() {
+            Ok(cache) => cache,
+            Err(error) => {
+                error!(%error,"Error while getting cache resource");
+                panic!("panic");
+            }
+        };
+        let pool_stats = cache.deref().pool_iostat();
+
         Self {
+            cache: pool_stats.clone(),
             pool_bytes_read,
             pool_num_read_ops,
             pool_bytes_written,
@@ -76,16 +88,7 @@ impl Collector for PoolIoStatsCollector {
     }
 
     fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
-        let cache = match Cache::get_cache().lock() {
-            Ok(cache) => cache,
-            Err(error) => {
-                error!(%error,"Error while getting cache resource");
-                return Vec::new();
-            }
-        };
-        let cache_deref = cache.deref();
-        let mut metric_family =
-            Vec::with_capacity(6 * cache_deref.pool_iostat().pool_stats.capacity());
+        let mut metric_family = Vec::with_capacity(6 * self.cache.pool_stats.capacity());
         let node_name = match get_node_name() {
             Ok(name) => name,
             Err(error) => {
@@ -94,7 +97,7 @@ impl Collector for PoolIoStatsCollector {
             }
         };
 
-        for pool_stat in &cache_deref.pool_iostat().pool_stats {
+        for pool_stat in self.cache.pool_stats.clone() {
             let pool_bytes_read = match self.pool_bytes_read.get_metric_with_label_values(&[
                 node_name.clone().as_str(),
                 pool_stat.name().as_str(),

--- a/metrics-exporter/src/bin/io_engine/collector/pool_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/pool_stat.rs
@@ -1,6 +1,5 @@
 use super::init_diskpool_gauge_vec;
 use crate::{cache::Cache, client::pool_stat::PoolIoStats, get_node_name};
-use core::panic;
 use prometheus::{
     core::{Collector, Desc},
     GaugeVec,
@@ -60,17 +59,14 @@ impl PoolIoStatsCollector {
             &mut descs,
         );
 
-        let cache = match Cache::get_cache().lock() {
-            Ok(cache) => cache,
-            Err(error) => {
-                error!(%error,"Error while getting cache resource");
-                panic!("panic");
-            }
+        let pool_stats = if let Ok(cache) = Cache::get_cache().lock() {
+            cache.deref().pool_iostat().clone()
+        } else {
+            PoolIoStats::default()
         };
-        let pool_stats = cache.deref().pool_iostat();
 
         Self {
-            cache: pool_stats.clone(),
+            cache: pool_stats,
             pool_bytes_read,
             pool_num_read_ops,
             pool_bytes_written,
@@ -97,7 +93,7 @@ impl Collector for PoolIoStatsCollector {
             }
         };
 
-        for pool_stat in self.cache.pool_stats.clone() {
+        for pool_stat in self.cache.pool_stats.iter() {
             let pool_bytes_read = match self.pool_bytes_read.get_metric_with_label_values(&[
                 node_name.clone().as_str(),
                 pool_stat.name().as_str(),

--- a/metrics-exporter/src/bin/io_engine/collector/replica_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/replica_stat.rs
@@ -59,17 +59,14 @@ impl ReplicaIoStatsCollector {
             &mut descs,
         );
 
-        let cache = match Cache::get_cache().lock() {
-            Ok(cache) => cache,
-            Err(error) => {
-                error!(%error,"Error while getting cache resource");
-                panic!("panic");
-            }
+        let replica_stats = if let Ok(cache) = Cache::get_cache().lock() {
+            cache.deref().replica_iostat().clone()
+        } else {
+            ReplicaIoStats::default()
         };
-        let replica_stats = cache.deref().replica_iostat();
 
         Self {
-            cache: replica_stats.clone(),
+            cache: replica_stats,
             replica_bytes_read,
             replica_num_read_ops,
             replica_bytes_written,
@@ -96,7 +93,7 @@ impl Collector for ReplicaIoStatsCollector {
             }
         };
 
-        for replica_stat in self.cache.replica_stats.clone() {
+        for replica_stat in self.cache.replica_stats.iter() {
             let pv_name = format!("pvc-{}", replica_stat.entity_id());
             let replica_bytes_read = match self.replica_bytes_read.get_metric_with_label_values(&[
                 node_name.as_str(),

--- a/metrics-exporter/src/bin/io_engine/collector/replica_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/replica_stat.rs
@@ -1,5 +1,5 @@
 use super::init_replica_gauge_vec;
-use crate::{cache::Cache, get_node_name};
+use crate::{cache::Cache, client::replica_stat::ReplicaIoStats, get_node_name};
 use prometheus::{
     core::{Collector, Desc},
     GaugeVec,
@@ -10,6 +10,7 @@ use tracing::error;
 /// Collects Replica IoStat metrics from cache.
 #[derive(Clone, Debug)]
 pub(crate) struct ReplicaIoStatsCollector {
+    cache: ReplicaIoStats,
     replica_bytes_read: GaugeVec,
     replica_num_read_ops: GaugeVec,
     replica_bytes_written: GaugeVec,
@@ -58,7 +59,17 @@ impl ReplicaIoStatsCollector {
             &mut descs,
         );
 
+        let cache = match Cache::get_cache().lock() {
+            Ok(cache) => cache,
+            Err(error) => {
+                error!(%error,"Error while getting cache resource");
+                panic!("panic");
+            }
+        };
+        let replica_stats = cache.deref().replica_iostat();
+
         Self {
+            cache: replica_stats.clone(),
             replica_bytes_read,
             replica_num_read_ops,
             replica_bytes_written,
@@ -76,16 +87,7 @@ impl Collector for ReplicaIoStatsCollector {
     }
 
     fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
-        let cache = match Cache::get_cache().lock() {
-            Ok(cache) => cache,
-            Err(error) => {
-                error!(%error,"Error while getting cache resource");
-                return Vec::new();
-            }
-        };
-        let cache_deref = cache.deref();
-        let mut metric_family =
-            Vec::with_capacity(6 * cache_deref.replica_iostat().replica_stats.capacity());
+        let mut metric_family = Vec::with_capacity(6 * self.cache.replica_stats.capacity());
         let node_name = match get_node_name() {
             Ok(name) => name,
             Err(error) => {
@@ -94,7 +96,7 @@ impl Collector for ReplicaIoStatsCollector {
             }
         };
 
-        for replica_stat in &cache_deref.replica_iostat().replica_stats {
+        for replica_stat in self.cache.replica_stats.clone() {
             let pv_name = format!("pvc-{}", replica_stat.entity_id());
             let replica_bytes_read = match self.replica_bytes_read.get_metric_with_label_values(&[
                 node_name.as_str(),


### PR DESCRIPTION
commit 1:
global cache was accessed when the collect function was called on the Collector. In this PR, we have made it part of the collector structure.

Commit 2: 
Set pool alert reason gauge to 1 if any one of the AlertReason enum is set in the list.