### PR TITLE
feat: add pool_name label to replica

### DIFF
--- a/metrics-exporter/src/bin/io_engine/cache/mod.rs
+++ b/metrics-exporter/src/bin/io_engine/cache/mod.rs
@@ -8,7 +8,7 @@ use crate::client::{
     replica_stat::ReplicaIoStats,
 };
 use once_cell::sync::OnceCell;
-use std::sync::Mutex;
+use std::{collections::HashMap, sync::Mutex};
 
 /// NOTE: try to reference cache from the Collector.
 static CACHE: OnceCell<Mutex<Cache>> = OnceCell::new();
@@ -36,6 +36,8 @@ pub(crate) struct Data {
     nexus_stats: NexusIoStats,
     /// Contains Replica IOStats data.
     replica_stats: ReplicaIoStats,
+    /// Maps replica name to pool_name.
+    replica_pool_map: HashMap<String, String>,
 }
 
 impl Cache {
@@ -88,6 +90,16 @@ impl Cache {
     pub(crate) fn replica_iostat_mut(&mut self) -> &mut ReplicaIoStats {
         &mut self.data.replica_stats
     }
+
+    /// Get a reference to replica_pool_map.
+    pub(crate) fn replica_pool_map(&self) -> &HashMap<String, String> {
+        &self.data.replica_pool_map
+    }
+
+    /// Get mutable reference to replica_pool_map.
+    pub(crate) fn replica_pool_map_mut(&mut self) -> &mut HashMap<String, String> {
+        &mut self.data.replica_pool_map
+    }
 }
 
 impl Default for Data {
@@ -108,6 +120,7 @@ impl Data {
             replica_stats: ReplicaIoStats {
                 replica_stats: vec![],
             },
+            replica_pool_map: HashMap::new(),
         }
     }
 }
@@ -118,4 +131,37 @@ pub(crate) async fn store_resource_data(client: &GrpcClient) {
     let _ = pool_stat::store_pool_stats_data(client).await;
     let _ = nexus_stat::store_nexus_stats_data(client).await;
     let _ = replica_stat::store_replica_stats_data(client).await;
+    store_replica_pool_map(client).await;
+}
+
+/// Fetches replica list and stores replica name → pool_name mapping in cache.
+/// Only refreshes when new replicas appear that aren't in the existing map.
+async fn store_replica_pool_map(client: &GrpcClient) {
+    let needs_refresh = {
+        let cache = match Cache::get_cache().lock() {
+            Ok(cache) => cache,
+            Err(_) => return,
+        };
+        let map = cache.replica_pool_map();
+        cache
+            .replica_iostat()
+            .replica_stats
+            .iter()
+            .any(|r| !map.contains_key(r.name()))
+    };
+
+    if !needs_refresh {
+        return;
+    }
+
+    match client.list_replicas().await {
+        Ok(new_map) => {
+            if let Ok(mut cache) = Cache::get_cache().lock() {
+                *cache.replica_pool_map_mut() = new_map;
+            }
+        }
+        Err(error) => {
+            tracing::error!(?error, "Error fetching replica list for pool mapping");
+        }
+    }
 }

--- a/metrics-exporter/src/bin/io_engine/cache/mod.rs
+++ b/metrics-exporter/src/bin/io_engine/cache/mod.rs
@@ -154,7 +154,7 @@ async fn store_replica_pool_map(client: &GrpcClient) {
         return;
     }
 
-    match client.list_replicas().await {
+    match client.fetch_replica_pool_mapping().await {
         Ok(new_map) => {
             if let Ok(mut cache) = Cache::get_cache().lock() {
                 *cache.replica_pool_map_mut() = new_map;

--- a/metrics-exporter/src/bin/io_engine/client/grpc_client.rs
+++ b/metrics-exporter/src/bin/io_engine/client/grpc_client.rs
@@ -51,12 +51,14 @@ impl GrpcContext {
 /// The V1 PoolClient.
 type PoolClient = rpc::v1::pool::pool_rpc_client::PoolRpcClient<Channel>;
 type StatsClient = rpc::v1::stats::StatsRpcClient<Channel>;
+type ReplicaClient = rpc::v1::replica::replica_rpc_client::ReplicaRpcClient<Channel>;
 
 /// A wrapper for client for the V1 dataplane interface.
 #[derive(Clone, Debug)]
 pub(crate) struct MayaClientV1 {
     pub(crate) pool: PoolClient,
     pub(crate) stats: StatsClient,
+    pub(crate) replica: ReplicaClient,
 }
 
 /// Dataplane grpc client.
@@ -77,8 +79,9 @@ impl GrpcClient {
             if let Ok(channel) = context.endpoint.connect().await {
                 let pool = PoolClient::new(channel.clone());
                 let stats = StatsClient::new(channel.clone());
+                let replica = ReplicaClient::new(channel.clone());
                 return Ok(Self {
-                    client: Some(MayaClientV1 { pool, stats }),
+                    client: Some(MayaClientV1 { pool, stats, replica }),
                 });
             } else {
                 if num_retires > SILENT_RETRIES {
@@ -199,5 +202,24 @@ impl GrpcClient {
             Err(error) => Err(ExporterError::GrpcResponseError(error.to_string())),
         }?;
         Ok(ReplicaIoStats { replica_stats })
+    }
+
+    /// Lists all replicas to build a replica name → pool_name mapping.
+    pub(crate) async fn list_replicas(
+        &self,
+    ) -> Result<std::collections::HashMap<String, String>, ExporterError> {
+        let replicas = match self
+            .client_v1()?
+            .replica
+            .list_replicas(rpc::v1::replica::ListReplicaOptions::default())
+            .await
+        {
+            Ok(response) => response.into_inner().replicas,
+            Err(error) => return Err(ExporterError::GrpcResponseError(error.to_string())),
+        };
+        Ok(replicas
+            .into_iter()
+            .map(|r| (r.name, r.poolname))
+            .collect())
     }
 }

--- a/metrics-exporter/src/bin/io_engine/client/grpc_client.rs
+++ b/metrics-exporter/src/bin/io_engine/client/grpc_client.rs
@@ -204,8 +204,8 @@ impl GrpcClient {
         Ok(ReplicaIoStats { replica_stats })
     }
 
-    /// Lists all replicas to build a replica name → pool_name mapping.
-    pub(crate) async fn list_replicas(
+    /// Fetches all replicas to build a replica name → pool_name mapping.
+    pub(crate) async fn fetch_replica_pool_mapping(
         &self,
     ) -> Result<std::collections::HashMap<String, String>, ExporterError> {
         let replicas = match self

--- a/metrics-exporter/src/bin/io_engine/collector/mod.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/mod.rs
@@ -75,7 +75,7 @@ fn init_volume_gauge_vec(metric_name: &str, metric_desc: &str, descs: &mut Vec<D
 /// Initializes a GaugeVec metric for replica with the provided metric name, description and
 /// descriptors.
 fn init_replica_gauge_vec(metric_name: &str, metric_desc: &str, descs: &mut Vec<Desc>) -> GaugeVec {
-    let label_refs = vec!["node", "name", "pv_name"];
+    let label_refs = vec!["node", "name", "pv_name", "pool_name"];
     let labels: Vec<String> = label_refs.iter().map(|s| s.to_string()).collect();
     let opts = Opts::new(metric_name, metric_desc)
         .subsystem("replica")

--- a/metrics-exporter/src/bin/io_engine/collector/replica_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/replica_stat.rs
@@ -93,14 +93,22 @@ impl Collector for ReplicaIoStatsCollector {
                 return metric_family;
             }
         };
+        let replica_pool_map = cache_deref.replica_pool_map();
 
         for replica_stat in &cache_deref.replica_iostat().replica_stats {
             let pv_name = format!("pvc-{}", replica_stat.entity_id());
-            let replica_bytes_read = match self.replica_bytes_read.get_metric_with_label_values(&[
+            let pool_name = replica_pool_map
+                .get(replica_stat.name())
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let labels = &[
                 node_name.as_str(),
                 replica_stat.name().as_str(),
                 pv_name.as_str(),
-            ]) {
+                pool_name,
+            ];
+
+            let replica_bytes_read = match self.replica_bytes_read.get_metric_with_label_values(labels) {
                 Ok(replica_bytes_read) => replica_bytes_read,
                 Err(error) => {
                     error!(%error, "Error while creating replica_bytes_read counter with label values");
@@ -111,13 +119,7 @@ impl Collector for ReplicaIoStatsCollector {
             let mut metric_vec = replica_bytes_read.collect();
             metric_family.extend(metric_vec.pop());
 
-            let replica_num_read_ops = match self.replica_num_read_ops.get_metric_with_label_values(
-                &[
-                    node_name.as_str(),
-                    replica_stat.name().as_str(),
-                    pv_name.as_str(),
-                ],
-            ) {
+            let replica_num_read_ops = match self.replica_num_read_ops.get_metric_with_label_values(labels) {
                 Ok(replica_num_read_ops) => replica_num_read_ops,
                 Err(error) => {
                     error!(%error, "Error while creating replica_num_read_ops counter with label values");
@@ -128,13 +130,7 @@ impl Collector for ReplicaIoStatsCollector {
             let mut metric_vec = replica_num_read_ops.collect();
             metric_family.extend(metric_vec.pop());
 
-            let replica_bytes_written = match self
-                .replica_bytes_written
-                .get_metric_with_label_values(&[
-                    node_name.as_str(),
-                    replica_stat.name().as_str(),
-                    pv_name.as_str(),
-                ]) {
+            let replica_bytes_written = match self.replica_bytes_written.get_metric_with_label_values(labels) {
                 Ok(replica_bytes_written) => replica_bytes_written,
                 Err(error) => {
                     error!(%error, "Error while creating replica_bytes_written counter with label values");
@@ -145,13 +141,7 @@ impl Collector for ReplicaIoStatsCollector {
             let mut metric_vec = replica_bytes_written.collect();
             metric_family.extend(metric_vec.pop());
 
-            let replica_num_write_ops = match self
-                .replica_num_write_ops
-                .get_metric_with_label_values(&[
-                    node_name.as_str(),
-                    replica_stat.name().as_str(),
-                    pv_name.as_str(),
-                ]) {
+            let replica_num_write_ops = match self.replica_num_write_ops.get_metric_with_label_values(labels) {
                 Ok(replica_num_write_ops) => replica_num_write_ops,
                 Err(error) => {
                     error!(%error, "Error while creating replica_num_write_ops counter with label values");
@@ -162,13 +152,7 @@ impl Collector for ReplicaIoStatsCollector {
             let mut metric_vec = replica_num_write_ops.collect();
             metric_family.extend(metric_vec.pop());
 
-            let replica_read_latency_us = match self
-                .replica_read_latency_us
-                .get_metric_with_label_values(&[
-                    node_name.as_str(),
-                    replica_stat.name().as_str(),
-                    pv_name.as_str(),
-                ]) {
+            let replica_read_latency_us = match self.replica_read_latency_us.get_metric_with_label_values(labels) {
                 Ok(replica_read_latency_us) => replica_read_latency_us,
                 Err(error) => {
                     error!(%error, "Error while creating replica_read_latency counter with label values");
@@ -179,13 +163,7 @@ impl Collector for ReplicaIoStatsCollector {
             let mut metric_vec = replica_read_latency_us.collect();
             metric_family.extend(metric_vec.pop());
 
-            let replica_write_latency_us = match self
-                .replica_write_latency_us
-                .get_metric_with_label_values(&[
-                    node_name.as_str(),
-                    replica_stat.name().as_str(),
-                    pv_name.as_str(),
-                ]) {
+            let replica_write_latency_us = match self.replica_write_latency_us.get_metric_with_label_values(labels) {
                 Ok(replica_write_latency_us) => replica_write_latency_us,
                 Err(error) => {
                     error!(%error, "Error while creating replica_write_latency counter with label values");


### PR DESCRIPTION
## Description

Add `pool_name` label to all replica I/O metrics (`replica_bytes_read`, `replica_num_read_ops`, `replica_bytes_written`, `replica_num_write_ops`, `replica_read_latency_us`, `replica_write_latency_us`).

The metrics-exporter now calls `ListReplicas` gRPC to build a replica name → pool_name mapping and includes it as a label when emitting replica metrics. The map is only refreshed when a new replica appears that isn't already cached, so there's zero additional gRPC overhead during steady-state operation.


## Motivation and Context

Described at [#1990](https://github.com/openebs/mayastor/issues/1990)

Replica I/O metrics currently have no `pool_name` label. The only shared dimension between replica metrics and disk pool metrics (`diskpool_*`) is `node`, which means correlating a specific replica's I/O to its backing pool requires visual inference ("same node = same pool") — this breaks on nodes with multiple disk pools.

With this change, users can directly query:
```promql
rate(replica_num_read_ops{pool_name="pool-1"}[5m])

```


or join with pool metrics:

`replica_num_read_ops * on(pool_name, node) group_left() diskpool_total_size_bytes`

**Regression**
No

How Has This Been Tested?

- [x] Verified that the Replica gRPC message already exposes poolname (field 8 in replica.proto)
- [x] Confirmed ListReplicaOptions::default() returns all replicas on the node
- [x] Validated that the cache-miss-only refresh logic avoids unnecessary gRPC calls in steady state
- [x] Existing metric labels (node, name, pv_name) remain unchanged; pool_name is additive
- [ ] Deploy the changes and validate on an actual cluster 

Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.