### PR TITLE
build: use static CDN to pull crates

### DIFF
--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -27,6 +27,16 @@ rec {
     naersk_package = channel: pkgs.callPackage sources.naersk {
       rustc = channel.stable;
       cargo = channel.stable;
+      # Rewrite crates.io API URLs to static CDN to avoid intermittent 403s
+      fetchurl = attrs@{ url, ... }:
+        let
+          m = builtins.match "https://crates\\.io/api/v1/crates/([^/]+)/([^/]+)/download" url;
+          resolvedUrl =
+            if m != null then
+              "https://static.crates.io/crates/${builtins.elemAt m 0}/${builtins.elemAt m 0}-${builtins.elemAt m 1}.crate"
+            else url;
+        in
+        pkgs.fetchurl (attrs // { url = resolvedUrl; });
     };
     os = platform: builtins.replaceStrings [ "${platform.qemuArch}-" ] [ "" ] platform.system;
     hostPlatform = "${makeRustTarget pkgs.pkgsStatic.hostPlatform}";

--- a/nix/pkgs/extensions/cargo-project.nix
+++ b/nix/pkgs/extensions/cargo-project.nix
@@ -49,10 +49,7 @@ let
         rustc = stable_channel.rustc;
         cargo = stable_channel.cargo;
       };
-  naersk = pkgs.callPackage sources.naersk {
-    rustc = stable_channel.rustc;
-    cargo = stable_channel.cargo;
-  };
+  naersk = channel.naersk_package channel.default;
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";
   version = gitVersions.version;
@@ -151,6 +148,12 @@ let
     });
   cargoDeps = rustPlatform.importCargoLock {
     lockFile = ../../../Cargo.lock;
+    # Use static.crates.io (CDN) instead of crates.io/api to avoid the 1 req/sec
+    # rate limit on the API servers, which currently returns intermittent 403s.
+    # See https://github.com/rust-lang/crates.io/issues/13482
+    extraRegistries = {
+      "https://github.com/rust-lang/crates.io-index" = "https://static.crates.io/crates";
+    };
   };
   builder =
     if static then build_with_default


### PR DESCRIPTION
- Use static.crates.io (CDN) instead of crates.io/api to avoid the 1 req/sec rate limit on the API servers, which currently returns intermittent 403s. See https://github.com/rust-lang/crates.io/issues/13482