### PR TITLE
ci: allow staging pre-releases

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build and push the release images
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --app-tag ${{ inputs.tag }} --override-chart ${{ inputs.tag }} ${{ inputs.tag }}" ./scripts/helm/shell.nix
+            nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --app-tag ${{ inputs.tag }}" ./scripts/helm/shell.nix
             ./scripts/release.sh --tag ${{ inputs.tag }} --registry ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.namespace }}
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             ./scripts/release.sh

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Publish locally in the workspace
         run: |
             # Note this does not commit the Chart.yaml changes this the branch
-            nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --app-tag ${{ inputs.tag }} --override-chart ${{ inputs.tag }} ${{ inputs.tag }}" ./scripts/helm/shell.nix
+            nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --app-tag ${{ inputs.tag }}" ./scripts/helm/shell.nix
             nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --app-tag "$TAG"" ./scripts/helm/shell.nix
             nix-shell --pure --run "./scripts/helm/update-reg-repo.sh --registry ghcr.io --repository ${{ github.repository_owner }}/mayastor/dev" ./shell.nix
             nix-shell --pure --run "./scripts/helm/images.sh generate" ./scripts/helm/shell.nix


### PR DESCRIPTION
Don't use override chart when preparing the chart. I'm not entirely sure why this is being used here, but I think should be fine to remove this parameter and rely on the git versions.
