### PR TITLE
ci: allow staging pre-releases

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -57,7 +57,6 @@ jobs:
       - name: Build and push the release images
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            nix-shell --pure --run "./scripts/helm/publish-chart-yaml.sh --app-tag ${{ inputs.tag }}" ./scripts/helm/shell.nix
             ./scripts/release.sh --tag ${{ inputs.tag }} --registry ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.namespace }}
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             ./scripts/release.sh


### PR DESCRIPTION
Build still fails in the image because the chart has already being updated. I don't think we need to even have this pre-step because the build already does this during the image phase?
