### PR TITLE
chore: increase max ingestion limits for loki

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -736,6 +736,7 @@ loki:
     limits_config:
       ingestion_burst_size_mb: 1000
       ingestion_rate_mb: 10000
+      max_label_names_per_series: 20
   singleBinary:
     replicas: 3
     drivesPerNode: 1


### PR DESCRIPTION
- ETCD pod has 16 labels and loki by default supports maximum of 15 labels. We have this change on openebs to support this but was missing on mayastor. Increasing the max labels to 20. Not increasing too much as it slows down indexing.