### PR TITLE
feat(metrics): add poolname and pooluuid labels to replica metrics

### DIFF
--- a/metrics-exporter/src/bin/io_engine/client/replica_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/client/replica_stat.rs
@@ -6,6 +6,8 @@ use crate::error::ExporterError;
 pub(crate) struct ReplicaIoStat {
     name: String,
     entity_id: String,
+    pool_name: String,
+    pool_uuid: String,
     bytes_read: u64,
     num_read_ops: u64,
     bytes_written: u64,
@@ -54,6 +56,16 @@ impl ReplicaIoStat {
     pub(crate) fn entity_id(&self) -> String {
         self.entity_id.clone()
     }
+
+    /// Get pool_name of the replica.
+    pub(crate) fn pool_name(&self) -> &str {
+        &self.pool_name
+    }
+
+    /// Get pool_uuid of the replica.
+    pub(crate) fn pool_uuid(&self) -> &str {
+        &self.pool_uuid
+    }
 }
 
 /// Array of NexusIoStat objects.
@@ -84,6 +96,8 @@ impl TryFrom<rpc::v1::stats::ReplicaIoStats> for ReplicaIoStat {
                     ))
                 }
             },
+            pool_name: value.poolname.unwrap_or_default(),
+            pool_uuid: value.pooluuid.unwrap_or_default(),
             bytes_read: stats.bytes_read,
             num_read_ops: stats.num_read_ops,
             bytes_written: stats.bytes_written,

--- a/metrics-exporter/src/bin/io_engine/collector/mod.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/mod.rs
@@ -75,7 +75,7 @@ fn init_volume_gauge_vec(metric_name: &str, metric_desc: &str, descs: &mut Vec<D
 /// Initializes a GaugeVec metric for replica with the provided metric name, description and
 /// descriptors.
 fn init_replica_gauge_vec(metric_name: &str, metric_desc: &str, descs: &mut Vec<Desc>) -> GaugeVec {
-    let label_refs = vec!["node", "name", "pv_name"];
+    let label_refs = vec!["node", "name", "pv_name", "pool_name", "pool_uuid"];
     let labels: Vec<String> = label_refs.iter().map(|s| s.to_string()).collect();
     let opts = Opts::new(metric_name, metric_desc)
         .subsystem("replica")

--- a/metrics-exporter/src/bin/io_engine/collector/replica_stat.rs
+++ b/metrics-exporter/src/bin/io_engine/collector/replica_stat.rs
@@ -95,11 +95,18 @@ impl Collector for ReplicaIoStatsCollector {
 
         for replica_stat in self.cache.replica_stats.iter() {
             let pv_name = format!("pvc-{}", replica_stat.entity_id());
-            let replica_bytes_read = match self.replica_bytes_read.get_metric_with_label_values(&[
+            let labels = &[
                 node_name.as_str(),
                 replica_stat.name().as_str(),
                 pv_name.as_str(),
-            ]) {
+                replica_stat.pool_name(),
+                replica_stat.pool_uuid(),
+            ];
+
+            let replica_bytes_read = match self
+                .replica_bytes_read
+                .get_metric_with_label_values(labels)
+            {
                 Ok(replica_bytes_read) => replica_bytes_read,
                 Err(error) => {
                     error!(%error, "Error while creating replica_bytes_read counter with label values");
@@ -110,13 +117,10 @@ impl Collector for ReplicaIoStatsCollector {
             let mut metric_vec = replica_bytes_read.collect();
             metric_family.extend(metric_vec.pop());
 
-            let replica_num_read_ops = match self.replica_num_read_ops.get_metric_with_label_values(
-                &[
-                    node_name.as_str(),
-                    replica_stat.name().as_str(),
-                    pv_name.as_str(),
-                ],
-            ) {
+            let replica_num_read_ops = match self
+                .replica_num_read_ops
+                .get_metric_with_label_values(labels)
+            {
                 Ok(replica_num_read_ops) => replica_num_read_ops,
                 Err(error) => {
                     error!(%error, "Error while creating replica_num_read_ops counter with label values");
@@ -129,11 +133,8 @@ impl Collector for ReplicaIoStatsCollector {
 
             let replica_bytes_written = match self
                 .replica_bytes_written
-                .get_metric_with_label_values(&[
-                    node_name.as_str(),
-                    replica_stat.name().as_str(),
-                    pv_name.as_str(),
-                ]) {
+                .get_metric_with_label_values(labels)
+            {
                 Ok(replica_bytes_written) => replica_bytes_written,
                 Err(error) => {
                     error!(%error, "Error while creating replica_bytes_written counter with label values");
@@ -146,11 +147,8 @@ impl Collector for ReplicaIoStatsCollector {
 
             let replica_num_write_ops = match self
                 .replica_num_write_ops
-                .get_metric_with_label_values(&[
-                    node_name.as_str(),
-                    replica_stat.name().as_str(),
-                    pv_name.as_str(),
-                ]) {
+                .get_metric_with_label_values(labels)
+            {
                 Ok(replica_num_write_ops) => replica_num_write_ops,
                 Err(error) => {
                     error!(%error, "Error while creating replica_num_write_ops counter with label values");
@@ -163,11 +161,8 @@ impl Collector for ReplicaIoStatsCollector {
 
             let replica_read_latency_us = match self
                 .replica_read_latency_us
-                .get_metric_with_label_values(&[
-                    node_name.as_str(),
-                    replica_stat.name().as_str(),
-                    pv_name.as_str(),
-                ]) {
+                .get_metric_with_label_values(labels)
+            {
                 Ok(replica_read_latency_us) => replica_read_latency_us,
                 Err(error) => {
                     error!(%error, "Error while creating replica_read_latency counter with label values");
@@ -180,11 +175,8 @@ impl Collector for ReplicaIoStatsCollector {
 
             let replica_write_latency_us = match self
                 .replica_write_latency_us
-                .get_metric_with_label_values(&[
-                    node_name.as_str(),
-                    replica_stat.name().as_str(),
-                    pv_name.as_str(),
-                ]) {
+                .get_metric_with_label_values(labels)
+            {
                 Ok(replica_write_latency_us) => replica_write_latency_us,
                 Err(error) => {
                     error!(%error, "Error while creating replica_write_latency counter with label values");


### PR DESCRIPTION
Add `poolname` and `pooluuid` from `ReplicaIoStats` proto to the metrics-exporter, exposing them as `pool_name` and `pool_uuid` labels on all replica metrics.

Depends on:
- https://github.com/openebs/mayastor-dependencies/pull/157 (merged)
- https://github.com/openebs/mayastor-control-plane/pull/1113 (merged)
- https://github.com/openebs/mayastor/pull/1991 (populates the fields at runtime)

Resolves: https://github.com/openebs/mayastor/issues/1990