### PR TITLE
fix: imageurl without quotes

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -387,23 +387,39 @@ Renders init containers. If unset it sets the container image.
     {{- $image := .context.Values.base.initContainers.image }}
     {{- $values_image := .context.Values.image }}
     {{- $global := .context.Values.global }}
+    {{- $ctx := .context }}
     {{- range .value -}}
-        {{ $container := . }}
-        {{- if not (hasKey . "imagePullPolicy") }}
+        {{ $container := deepCopy . }}
+        {{- if hasKey $container "command" }}
+          {{- $renderedCmd := list }}
+            {{- range $container.command }}
+              {{- $renderedCmd = append $renderedCmd (tpl . $ctx) }}
+            {{- end }}
+           {{- $_ := set $container "command" $renderedCmd }}
+        {{- end }}
+        {{- if not (hasKey $container "imagePullPolicy") }}
             {{- $pullPolicy := $global.imagePullPolicy | default $image.pullPolicy | default $values_image.pullPolicy }}
             {{- $_ := set $container "imagePullPolicy" $pullPolicy }}
         {{- end }}
-        {{- if or (not $image) (not (hasKey . "image")) }}
-            {{- $registry := $global.imageRegistry | default $image.registry | default $values_image.registry }}
-            {{- $namespace := $image.namespace | default $values_image.repo }}
-            {{- $name := $image.name | default "alpine-sh" }}
-            {{- $tag := $image.tag | default "4.1.0" }}
-            {{- $_ := set $container "image" (printf "%s/%s/%s:%s" $registry $namespace $name $tag) }}
+        {{- if not (hasKey $container "image") }}
+            {{- $_ := set $container "image" (include "render_init_container_image" $ctx ) }}
         {{- end }}
         {{- $containers = append $containers $container }}
     {{- end -}}
-    {{- tpl ($containers | toYaml) .context }}
+    {{- $containers | toYaml }}
 {{- end -}}
+
+{{- define "render_init_container_image" -}}
+{{- $image := .Values.base.initContainers.image }}
+{{- $values_image := .Values.image }}
+{{- $global := .Values.global }}
+{{- $registry := $global.imageRegistry | default $image.registry | default $values_image.registry }}
+{{- $namespace := $image.namespace | default $values_image.repo }}
+{{- $name := $image.name | default "alpine-sh" }}
+{{- $tag := $image.tag | default "4.1.0" }}
+{{- printf "%s/%s/%s:%s" $registry $namespace $name $tag }}
+{{- end -}}
+
 
 {{/*
 Get the Events Jetstream Replica Count

--- a/chart/templates/pre-upgrade-hook.yaml
+++ b/chart/templates/pre-upgrade-hook.yaml
@@ -124,7 +124,7 @@ spec:
             defaultMode: 0777
       containers:
         - name: mayastor-pre-upgrade-hook
-          image: {{ default .Values.preUpgradeHook.image.registry .Values.global.imageRegistry }}/{{ .Values.preUpgradeHook.image.repo }}:{{ .Values.preUpgradeHook.image.tag }}
+          image: "{{ default .Values.preUpgradeHook.image.registry .Values.global.imageRegistry }}/{{ .Values.preUpgradeHook.image.repo }}:{{ .Values.preUpgradeHook.image.tag }}"
           imagePullPolicy: {{ default .Values.preUpgradeHook.image.pullPolicy .Values.global.imagePullPolicy }}
           command:
             - "sh"


### PR DESCRIPTION
Issue:
image url containing {{ }} is being interpreted as a function on mayastor helm chart
Root Cause: 
image url being rendered using tpl which treats it as helm function
Steps to Reproduce:
values.yaml
```
global:
  imageRegistry: "{{ my_registry }}/my-org/"
```
Command : 
`helm template chartsdirectory -f values.yaml`

Error:
`Error: template: mayastor/templates/mayastor/agents/ha/ha-node-daemonset.yaml:31:12: executing "mayastor/templates/mayastor/agents/ha/ha-node-daemonset.yaml" at <include "base_init_ha_node_containers" .>: error calling include: template: mayastor/templates/_helpers.tpl:34:8: executing "base_init_ha_node_containers" at <include "render_init_containers" (dict "value" .Values.base.initHaNodeContainers.containers "context" $)>: error calling include: template: mayastor/templates/_helpers.tpl:405:8: executing "render_init_containers" at <tpl ($containers | toYaml) .context>: error calling tpl: cannot parse template "- command:\n  - sh\n  - -c\n  - trap \"exit 1\" TERM; until nc -vzw 5 {{ .Release.Name }}-agent-core 50052; do date;\n    echo \"Waiting for agent-cluster-grpc services...\"; sleep 1; done;\n  image: '{{ my_registry }}/my-org//openebs/alpine-sh:4.5.0'\n  imagePullPolicy: IfNotPresent\n  name: agent-cluster-grpc-probe": template: gotpl:6: function "my_registry" not defined
 
Use --debug flag to render out invalid YAML
(END)`

Solution:
Only render the initcontainer command with tpl and eveyrthing else wihout it.

This PR also fixes preupgrade hook image url which had no quotes in previous versions.