### PR TITLE
feat(deployment): mount kubelet directory in io-engine pods

### DIFF
--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -152,6 +152,8 @@ spec:
           mountPath: /var/local/{{ .Release.Name }}/io-engine/
         - name: hugepages-2mi
           mountPath: /dev/hugepages-2mi
+        - name: kubelet-dir
+          mountPath: /var/lib/kubelet
         {{- if .Values.io_engine.resources.requests.hugepages1Gi }}
         - name: hugepages-1gi
           mountPath: /dev/hugepages-1gi
@@ -226,3 +228,7 @@ spec:
           path: /var/local/{{ .Release.Name }}/io-engine/
           type: DirectoryOrCreate
       {{- include "rest_api_tls_client_volume" (dict "ctx" . "secretName" (include "rest_api_tls_metrics_exporter_client_secret_name" .)) | nindent 6 }}
+      - name: kubelet-dir
+        hostPath:
+          path: {{ .Values.csi.node.kubeletDir }}
+          type: Directory


### PR DESCRIPTION
Mount the kubelet directory into io-engine pods to enable access to CPUManager state information required for dynamic reactor affinity updates.

Add a hostPath mount for /var/lib/kubelet in the
io-engine DaemonSet template.

Signed-off-by: Susobhan Dey [susobhan.dey@datacore.com](mailto:susobhan.dey@datacore.com)



