### PR TITLE
ci(mergify): update merge queue configuration

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,6 +11,7 @@ queue_rules:
     merge_conditions:
       - check-success = ci
       - check-success = submodule-branch
+      - -label ~= do-not-merge
     queue_conditions:
       - check-success = commitlint
       - check-success = submodule-branch
@@ -18,8 +19,13 @@ queue_rules:
       - check-success = helm-ci / helm-chart-test
       - check-success = int-ci / int-tests
       - check-success = lint-ci / linter
+      - -label ~= do-not-merge
+      - -draft
+      - check-success = DCO
+    batch_max_wait_time: 15s
 merge_queue:
   max_parallel_checks: 2
+  status_comments: outcomes
 merge_protections_settings:
   reporting_method: check-runs
 pull_request_rules:


### PR DESCRIPTION
Don't merge if labels starting with do-not-merge is present, like
do-not-merge/hold or do-not-merge/work-in-progress

Adds DCO explicitly as a queue condition, as well as !draft

Sets max wait time to 15s, given most time we rather not wait

Reduces the noise by logging only the outcomes
