### PR TITLE
feat(plugin): add volume fallback and typed filters for get events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,6 +1159,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-nats",
+ "chrono",
  "clap",
  "event-consumer",
  "events-api",
@@ -2255,6 +2256,7 @@ dependencies = [
  "tokio",
  "upgrade",
  "utils",
+ "uuid",
 ]
 
 [[package]]

--- a/eventing-aggregator/Cargo.toml
+++ b/eventing-aggregator/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 parse-size = { workspace = true }
+chrono = { workspace = true }
 rand = { workspace = true }
 clap = { workspace = true }
 url = { workspace = true }

--- a/eventing-aggregator/src/main.rs
+++ b/eventing-aggregator/src/main.rs
@@ -6,7 +6,7 @@ use constant::CHANNEL_CAPACITY;
 use event_consumer::{ConsumerConfig, ConsumerError, NatsConsumer, UnifiedMessage};
 use events_api::event::EventMessage;
 use exporter::{dir_size_limit, LogEvent};
-use std::time::Duration;
+use std::{io::BufRead, time::Duration};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 use url::Url;
@@ -72,6 +72,16 @@ struct CliArgs {
     /// Number of JetStream stream replicas. Must match the NATS cluster size.
     #[arg(long, default_value_t = 1)]
     events_replicas: usize,
+
+    /// Print stored events from --events-dir to stdout and exit.
+    /// No NATS connection is made in this mode. Used by the kubectl plugin to read
+    /// events from the container.
+    #[arg(long, default_value_t = false, requires = "events_dir")]
+    print_events: bool,
+
+    /// Skip events older than this RFC 3339 timestamp. Only used with --print-events.
+    #[arg(long, requires = "print_events")]
+    since: Option<String>,
 }
 
 impl CliArgs {
@@ -82,10 +92,58 @@ impl CliArgs {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let cli_args = CliArgs::args();
+
+    if cli_args.print_events {
+        use chrono::DateTime;
+        use std::hash::{DefaultHasher, Hash, Hasher};
+
+        // requires = "events_dir" guarantees events_dir is Some when print_events is true.
+        let events_dir = cli_args.events_dir.as_deref().unwrap();
+
+        let cutoff: Option<chrono::DateTime<chrono::Utc>> = cli_args
+            .since
+            .as_deref()
+            .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+            .map(|t| t.to_utc());
+
+        // HashSet<u64> stores a SipHash of each line rather than the full content,
+        // keeping dedup overhead at ~8 bytes/line regardless of event size.
+        let mut seen = std::collections::HashSet::<u64>::new();
+
+        // Read the active file first: if rotation renames it mid-read, the open fd still
+        // drains the original inode. Then read the rotated file for older events.
+        // In a rotation race the two files may share the same inode; dedup handles it.
+        for filename in [
+            constant::EVENTS_JSON_FILE,
+            constant::EVENTS_JSON_ROTATED_FILE,
+        ] {
+            let path = std::path::Path::new(events_dir).join(filename);
+            if let Ok(file) = std::fs::File::open(&path) {
+                for line in std::io::BufReader::new(file).lines().map_while(Result::ok) {
+                    if let Some(cutoff) = &cutoff {
+                        let ts = extract_timestamp(&line);
+                        if ts.map(|t| t < *cutoff).unwrap_or(false) {
+                            continue;
+                        }
+                    }
+                    let h = {
+                        let mut s = DefaultHasher::new();
+                        line.hash(&mut s);
+                        s.finish()
+                    };
+                    if seen.insert(h) {
+                        println!("{line}");
+                    }
+                }
+            }
+        }
+        return Ok(());
+    }
+
     TracingTelemetry::builder()
         .with_style(FmtStyle::Compact)
         .init(constant::SERVICE_NAME);
-    let cli_args = CliArgs::args();
 
     let (tx, rx) = mpsc::channel::<UnifiedMessage>(CHANNEL_CAPACITY);
 
@@ -279,4 +337,14 @@ fn process_message(
             ProcessingResult::PermanentFailure
         }
     }
+}
+
+// Extract the RFC 3339 timestamp from a stored event line.
+// Lines have the shape: {"type":"mbus_event","payload":{"metadata":{"timestamp":"..."}}}
+fn extract_timestamp(line: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+    let ts_str = v["payload"]["metadata"]["timestamp"].as_str()?;
+    chrono::DateTime::parse_from_rfc3339(ts_str)
+        .ok()
+        .map(|t| t.to_utc())
 }

--- a/k8s/plugin/Cargo.toml
+++ b/k8s/plugin/Cargo.toml
@@ -29,7 +29,7 @@ prettytable-rs = { workspace = true }
 strum = { workspace = true }
 shutdown = { path = "../../dependencies/control-plane/utils/shutdown" }
 
-kube = { workspace = true, features = ["derive", "runtime"] }
+kube = { workspace = true, features = ["derive", "runtime", "ws"] }
 k8s-openapi = { workspace = true }
 kube-proxy = { path = "../../dependencies/control-plane/k8s/proxy" }
 kube-forward = { path = "../../dependencies/control-plane/k8s/forward" }
@@ -48,4 +48,5 @@ parse-size = { workspace = true }
 strum_macros = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uuid = { workspace = true }
 schemars = { workspace = true }

--- a/k8s/plugin/src/main.rs
+++ b/k8s/plugin/src/main.rs
@@ -1,5 +1,5 @@
 use plugin::ExecuteOperation;
-use resources::{init_rest, Error, Operations};
+use resources::{Error, Operations};
 
 use clap::Parser;
 use std::{env, ops::Deref, path::PathBuf};
@@ -105,9 +105,9 @@ async fn main() {
 
 impl CliArgs {
     async fn execute(self) -> Result<(), Error> {
-        // Initialise the REST client.
-        init_rest(&self.args).await?;
-
+        if self.operations.needs_rest_init() {
+            resources::init_rest(&self.args).await?;
+        }
         tokio::select! {
             shutdown = shutdown::Shutdown::wait_sig() => {
                 Err(anyhow::anyhow!("Interrupted by {shutdown:?}").into())

--- a/k8s/plugin/src/resources/events.rs
+++ b/k8s/plugin/src/resources/events.rs
@@ -1,22 +1,32 @@
 use anyhow::anyhow;
+use chrono::{DateTime, Utc};
 use clap::builder::TypedValueParser;
-use events_api::event::{Component, EventAction, EventCategory, EventMessage};
+use events_api::event::{
+    Component, EventAction, EventCategory, EventDetails, EventMessage, RebuildStatus,
+};
+use k8s_openapi::api::core::v1::Pod;
+use kube::{
+    api::{AttachParams, ListParams},
+    Api,
+};
 use plugin::resources::utils::{optional_cell, print_table, CreateRow, GetHeaderRow, OutputFormat};
 use prettytable::{row, Row};
 use serde::Serialize;
-use std::path::PathBuf;
 use strum::IntoEnumIterator;
 use supportability::KubeConfigArgs;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
 
 const EVENTS_CONTAINER: &str = "eventing-aggregator";
 const EVENTS_LABEL_SELECTOR: &str = "app=eventing-aggregator";
 const MBUS_EVENT_TYPE: &str = "mbus_event";
 const DEFAULT_LIMIT: usize = 1000;
+const EVENTS_VOLUME_DIR: &str = "/var/events";
 
 /// Args for `kubectl mayastor get events`.
 #[derive(Debug, clap::Args)]
 pub struct EventsArgs {
-    /// Loki base URL. If omitted, Loki is auto-discovered via the K8s service.
+    /// Loki base URL. If omitted, Loki is auto-discovered via the K8s service;
+    /// if discovery also fails, events are read from the eventing-aggregator pod volume.
     #[arg(long)]
     loki_endpoint: Option<String>,
 
@@ -36,6 +46,38 @@ pub struct EventsArgs {
     #[arg(long)]
     target: Option<String>,
 
+    /// Filter by source component (repeatable or comma-separated).
+    #[arg(long = "component", value_delimiter = ',', value_parser = component_parser())]
+    components: Vec<Component>,
+
+    /// Filter events for a pool (substring match on target).
+    #[arg(long)]
+    pool: Option<String>,
+
+    /// Filter events touching a volume (target, snapshot, volume_id).
+    #[arg(long)]
+    volume: Option<uuid::Uuid>,
+
+    /// Filter events by replica UUID.
+    #[arg(long)]
+    replica: Option<uuid::Uuid>,
+
+    /// Filter rebuild events by outcome (repeatable or comma-separated).
+    #[arg(long = "rebuild-status", value_delimiter = ',', value_parser = rebuild_status_parser())]
+    rebuild_statuses: Vec<RebuildStatus>,
+
+    /// Filter state-change events by state value (substring on previous or next state).
+    #[arg(long)]
+    state: Option<String>,
+
+    /// Filter by JSON field path and pattern: path=value (repeatable, AND logic).
+    /// Path is relative to the event payload, e.g.
+    /// --filter "metadata.source.eventDetails.replicaDetails.poolUuid=abc*".
+    /// Supports leading/trailing * wildcards. Events with an unknown or absent path
+    /// are excluded.
+    #[arg(long = "filter")]
+    filters: Vec<String>,
+
     /// Events from last duration (e.g. 1h, 30m).
     #[arg(long, default_value = "24h")]
     since: humantime::Duration,
@@ -44,7 +86,7 @@ pub struct EventsArgs {
     #[arg(long, default_value_t = DEFAULT_LIMIT)]
     limit: usize,
 
-    /// Loki tenant ID (X-Scope-OrgID header).
+    /// Loki tenant ID / X-Scope-OrgID header (loki source only).
     #[arg(long, default_value = "openebs")]
     tenant_id: String,
 }
@@ -69,6 +111,9 @@ pub struct EventRecord {
     pub node: String,
     #[serde(skip)]
     pub component: String,
+    /// Raw outer JSON — used by --filter dot-path traversal.
+    #[serde(skip)]
+    raw: serde_json::Value,
     /// Full typed payload; serialised for JSON/YAML output.
     #[serde(flatten)]
     pub event_message: EventMessage,
@@ -116,6 +161,7 @@ impl EventRecord {
             target,
             node,
             component,
+            raw: serde_json::Value::Null,
             event_message: msg,
         }
     }
@@ -175,51 +221,93 @@ pub fn parse_line(line: &str) -> Option<EventRecord> {
 
     let payload = outer.get("payload")?;
     let msg: EventMessage = serde_json::from_value(payload.clone()).ok()?;
-    Some(EventRecord::from_event_message(msg))
+    let mut record = EventRecord::from_event_message(msg);
+    record.raw = outer;
+    Some(record)
+}
+
+/// Stream NDJSON lines from any async reader, parse each into an `EventRecord` immediately.
+/// Used by the volume fallback (exec stdout) and `--from-file` (file handle).
+/// Raw JSON strings are never accumulated — each line is parsed and dropped.
+pub async fn read_events_from_reader<R: AsyncBufRead + Unpin>(reader: R) -> Vec<EventRecord> {
+    let mut lines = reader.lines();
+    let mut records = Vec::new();
+    while let Ok(Some(line)) = lines.next_line().await {
+        if let Some(record) = parse_line(&line) {
+            records.push(record);
+        }
+    }
+    records
 }
 
 impl EventsArgs {
-    /// Fetch events from Loki and print them according to the output format.
+    /// Fetch and print events according to the output format.
     pub async fn get_events(
         &self,
         namespace: &str,
-        kubeconfig: Option<PathBuf>,
-        context: Option<String>,
+        kube_client: kube::Client,
+        kubeconfig_args: KubeConfigArgs,
         timeout: humantime::Duration,
         output: &OutputFormat,
     ) -> anyhow::Result<()> {
-        let kubeconfig_args = KubeConfigArgs {
-            path: kubeconfig,
-            opts: kube_proxy::kubeconfig_options_from_context(context),
-        };
+        // Silence the "LogFile not initialised" noise from supportability's log()
+        // utility — that subsystem is only wired up in system-dump context.
+        supportability::init_no_log_file();
 
-        let mut loki_client = supportability::LokiClient::new(
+        let maybe_client = supportability::LokiClient::new(
             self.loki_endpoint.clone(),
-            kubeconfig_args,
+            kubeconfig_args.clone(),
             namespace.to_string(),
             self.since,
             timeout,
             self.tenant_id.clone(),
         )
-        .await
-        .ok_or_else(|| {
-            anyhow!(
-                "Loki not found. Provide --loki-endpoint or ensure Loki is deployed in the cluster."
-            )
-        })?
-        .with_logql_filters(build_logql_filters());
+        .await;
 
-        let lines = loki_client
-            .fetch_lines(
-                EVENTS_LABEL_SELECTOR.to_string(),
-                EVENTS_CONTAINER.to_string(),
-                self.limit,
-            )
-            .await
-            .map_err(|e| anyhow!("Failed to fetch events from Loki: {e:?}"))?;
+        let (records, source_label) = match maybe_client {
+            Some(client) => {
+                let lines = client
+                    .with_logql_filters(build_logql_filters())
+                    .fetch_lines(
+                        EVENTS_LABEL_SELECTOR.to_string(),
+                        EVENTS_CONTAINER.to_string(),
+                        self.limit,
+                    )
+                    .await
+                    .map_err(|e| anyhow!("Failed to fetch events from Loki: {e:?}"))?;
+                let records: Vec<EventRecord> =
+                    lines.iter().filter_map(|l| parse_line(l)).collect();
+                (records, "Loki")
+            }
+            None if self.loki_endpoint.is_some() => {
+                return Err(anyhow!(
+                    "Could not connect to Loki at {}. Check the endpoint and try again.",
+                    self.loki_endpoint.as_deref().unwrap_or_default()
+                ));
+            }
+            None => {
+                if output.none() {
+                    eprintln!(
+                        "Loki not found in cluster; falling back to eventing-aggregator pod volume."
+                    );
+                }
+                let since_cutoff =
+                    Utc::now() - chrono::Duration::from_std(*self.since).unwrap_or_default();
+                let records = fetch_from_volume(kube_client, since_cutoff)
+                    .await?
+                    .into_iter()
+                    .filter(|r| {
+                        DateTime::parse_from_rfc3339(&r.timestamp)
+                            .map(|t| t.to_utc() >= since_cutoff)
+                            .unwrap_or(true)
+                    })
+                    .collect();
+                (records, "eventing-aggregator volume")
+            }
+        };
 
-        let raw_count = lines.len();
-        let mut records: Vec<EventRecord> = lines.iter().filter_map(|l| parse_line(l)).collect();
+        let raw_count = records.len();
+        let mut records = records;
 
         records = apply_filters(records, self);
 
@@ -231,13 +319,13 @@ impl EventsArgs {
         if records.is_empty() && output.none() {
             if raw_count == 0 {
                 eprintln!(
-                    "No events found. Try widening the time range with --since (e.g. --since 24h) \
-                     or verify that Loki is scraping the eventing-aggregator pod."
+                    "No events found in {source_label}. \
+                     Verify the eventing-aggregator pod is running and has written events."
                 );
             } else {
                 eprintln!(
-                    "No events matched the applied filters ({raw_count} log lines fetched from Loki). \
-                     Try relaxing --category, --action, --node, or --target filters."
+                    "No events matched the applied filters ({raw_count} lines read from {source_label}). \
+                     Try relaxing filters."
                 );
             }
             return Ok(());
@@ -262,6 +350,65 @@ impl EventsArgs {
 /// Returns LogQL pipeline stages that pre-filter Loki lines to only event records.
 fn build_logql_filters() -> Vec<String> {
     vec![format!("|= \"{MBUS_EVENT_TYPE}\"")]
+}
+
+/// Exec into the eventing-aggregator pod and stream its ephemeral event files.
+///
+/// Passes `--since` to the binary so it filters at the source, reducing both the
+/// in-pod dedup HashSet and the data streamed over exec.
+/// Lines are parsed into EventRecords as they arrive; raw JSON is never buffered.
+async fn fetch_from_volume(
+    client: kube::Client,
+    since_cutoff: DateTime<Utc>,
+) -> anyhow::Result<Vec<EventRecord>> {
+    let namespace = client.default_namespace().to_owned();
+    let pods: Api<Pod> = Api::namespaced(client, &namespace);
+    let lp = ListParams::default().labels(EVENTS_LABEL_SELECTOR);
+    let pod_list = pods
+        .list(&lp)
+        .await
+        .map_err(|e| anyhow!("Failed to list eventing-aggregator pods: {e}"))?;
+
+    let pod_name = pod_list
+        .items
+        .into_iter()
+        .find(|p| {
+            p.status
+                .as_ref()
+                .and_then(|s| s.phase.as_deref())
+                .map(|ph| ph == "Running")
+                .unwrap_or(false)
+        })
+        .and_then(|p| p.metadata.name)
+        .ok_or_else(|| {
+            anyhow!("No running eventing-aggregator pod found in namespace {namespace}")
+        })?;
+
+    let ap = AttachParams::default()
+        .stdin(false)
+        .stdout(true)
+        .stderr(false);
+
+    let since_arg = format!("--since={}", since_cutoff.to_rfc3339());
+    let mut attached = pods
+        .exec(
+            &pod_name,
+            vec![
+                "/bin/eventing-aggregator",
+                "--print-events",
+                &format!("--events-dir={EVENTS_VOLUME_DIR}"),
+                &since_arg,
+            ],
+            &ap,
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to exec into pod {pod_name}: {e}"))?;
+
+    let stdout = attached
+        .stdout()
+        .ok_or_else(|| anyhow!("No stdout from pod exec"))?;
+
+    Ok(read_events_from_reader(BufReader::new(stdout)).await)
 }
 
 fn category_parser() -> impl clap::builder::TypedValueParser<Value = EventCategory> {
@@ -315,7 +462,155 @@ fn apply_filters(records: Vec<EventRecord>, args: &EventsArgs) -> Vec<EventRecor
                     return false;
                 }
             }
+            if !args.components.is_empty()
+                && !args
+                    .components
+                    .iter()
+                    .any(|c| c.as_str_name() == r.component)
+            {
+                return false;
+            }
+            if let Some(pool) = &args.pool {
+                if !r.target.contains(pool.as_str()) {
+                    return false;
+                }
+            }
+            if let Some(vol) = &args.volume {
+                let vol_str = vol.to_string();
+                let in_target = r.target == vol_str;
+                let in_details = get_event_details(r)
+                    .map(|d| {
+                        d.snapshot_details
+                            .as_ref()
+                            .map(|sd| sd.volume_id == vol_str)
+                            .unwrap_or(false)
+                            || d.clone_details
+                                .as_ref()
+                                .map(|cd| cd.source_uuid == vol_str)
+                                .unwrap_or(false)
+                    })
+                    .unwrap_or(false);
+                if !in_target && !in_details {
+                    return false;
+                }
+            }
+            if let Some(rep) = &args.replica {
+                let rep_str = rep.to_string();
+                let in_target = r.target == rep_str;
+                let in_details = get_event_details(r)
+                    .and_then(|d| d.replica_details.as_ref())
+                    .map(|rd| rd.replica_name == rep_str)
+                    .unwrap_or(false);
+                if !in_target && !in_details {
+                    return false;
+                }
+            }
+            if !args.rebuild_statuses.is_empty() {
+                let matched = get_event_details(r)
+                    .and_then(|d| d.rebuild_details.as_ref())
+                    .and_then(|rd| RebuildStatus::try_from(rd.rebuild_status).ok())
+                    .map(|rs| {
+                        args.rebuild_statuses
+                            .iter()
+                            .any(|s| s.as_str_name() == rs.as_str_name())
+                    })
+                    .unwrap_or(false);
+                if !matched {
+                    return false;
+                }
+            }
+            if let Some(state) = &args.state {
+                let state_lc = state.to_lowercase();
+                let matched = get_event_details(r)
+                    .and_then(|d| d.state_change_details.as_ref())
+                    .map(|sd| {
+                        sd.previous.to_lowercase().contains(&state_lc)
+                            || sd.next.to_lowercase().contains(&state_lc)
+                    })
+                    .unwrap_or(false);
+                if !matched {
+                    return false;
+                }
+            }
+            for expr in &args.filters {
+                let Some((path, pattern)) = expr.split_once('=') else {
+                    return false;
+                };
+                let payload = r.raw.get("payload").unwrap_or(&serde_json::Value::Null);
+                let Some(value) = traverse_json(payload, path) else {
+                    return false;
+                };
+                if !matches_pattern(&value, pattern) {
+                    return false;
+                }
+            }
             true
         })
         .collect()
+}
+
+/// Shortcut to reach the `EventDetails` sub-message inside a record.
+fn get_event_details(record: &EventRecord) -> Option<&EventDetails> {
+    record
+        .event_message
+        .metadata
+        .as_ref()?
+        .source
+        .as_ref()?
+        .event_details
+        .as_ref()
+}
+
+/// Walk a dot-separated path through a JSON value and return the leaf as a string.
+/// Returns `None` if any key in the path is missing or the leaf is an object/array.
+fn traverse_json(value: &serde_json::Value, path: &str) -> Option<String> {
+    let mut current = value;
+    for key in path.split('.') {
+        current = current.get(key)?;
+    }
+    match current {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+/// Pattern matching with leading/trailing `*` wildcards. Case-sensitive.
+/// A bare `*` matches everything. Interior `*` is treated as a literal character.
+fn matches_pattern(value: &str, pattern: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    match (pattern.starts_with('*'), pattern.ends_with('*')) {
+        (true, true) => value.contains(&pattern[1..pattern.len() - 1]),
+        (true, false) => value.ends_with(&pattern[1..]),
+        (false, true) => value.starts_with(&pattern[..pattern.len() - 1]),
+        (false, false) => value == pattern,
+    }
+}
+
+fn component_parser() -> impl clap::builder::TypedValueParser<Value = Component> {
+    clap::builder::PossibleValuesParser::new(
+        Component::iter()
+            .filter(|c| *c != Component::UnknownComponent)
+            .map(|c| c.to_string()),
+    )
+    .map(|s: String| {
+        Component::iter()
+            .find(|c| c.to_string() == s)
+            .expect("validated by PossibleValuesParser")
+    })
+}
+
+fn rebuild_status_parser() -> impl clap::builder::TypedValueParser<Value = RebuildStatus> {
+    clap::builder::PossibleValuesParser::new(
+        RebuildStatus::iter()
+            .filter(|s| *s != RebuildStatus::Unknown)
+            .map(|s| s.to_string()),
+    )
+    .map(|s: String| {
+        s.parse::<RebuildStatus>()
+            .expect("validated by PossibleValuesParser")
+    })
 }

--- a/k8s/plugin/src/resources/mod.rs
+++ b/k8s/plugin/src/resources/mod.rs
@@ -128,7 +128,7 @@ pub enum GetResourcesK8s {
     /// Get upgrade status
     UpgradeStatus(GetUpgradeArgs),
     /// Get events from the events-aggregator (Loki source)
-    Events(EventsArgs),
+    Events(Box<EventsArgs>),
 }
 
 /// The types of operations that are supported.
@@ -255,6 +255,13 @@ pub struct NodeDeleteArgs {
     pub cleanup: CleanupDspArgs,
 }
 
+impl Operations {
+    /// Returns true if this operation requires the REST client to be initialised.
+    pub fn needs_rest_init(&self) -> bool {
+        !matches!(self, Operations::Get(GetResourcesK8s::Events(_)))
+    }
+}
+
 #[async_trait::async_trait(?Send)]
 impl ExecuteOperation for Operations {
     type Args = CliArgs;
@@ -269,10 +276,15 @@ impl ExecuteOperation for Operations {
                     resources.get_upgrade(&cli_args.namespace, &client).await?
                 }
                 GetResourcesK8s::Events(args) => {
+                    let kube_client = cli_args.client().await?;
+                    let kubeconfig_args = supportability::KubeConfigArgs {
+                        path: cli_args.kubeconfig.clone(),
+                        opts: kube_proxy::kubeconfig_options_from_context(cli_args.context.clone()),
+                    };
                     args.get_events(
                         &cli_args.namespace,
-                        cli_args.kubeconfig.clone(),
-                        cli_args.context.clone(),
+                        kube_client,
+                        kubeconfig_args,
                         cli_args.timeout,
                         &cli_args.output,
                     )

--- a/k8s/supportability/src/collect/utils.rs
+++ b/k8s/supportability/src/collect/utils.rs
@@ -38,7 +38,7 @@ pub(crate) fn init_tool_log_file(file_path: PathBuf) -> Result<(), std::io::Erro
     Ok(())
 }
 /// Method to initialise the TOOL_LOG_FILE once cell without a log file.
-pub(crate) fn init_no_log_file() {
+pub fn init_no_log_file() {
     TOOL_LOG_FILE
         .set(None)
         .expect("Expect to be initialised only once");

--- a/k8s/supportability/src/lib.rs
+++ b/k8s/supportability/src/lib.rs
@@ -13,7 +13,10 @@ use std::path::PathBuf;
 pub mod collect;
 pub mod operations;
 
-pub use collect::logs::{LokiClient, LokiError};
+pub use collect::{
+    logs::{LokiClient, LokiError},
+    utils::init_no_log_file,
+};
 
 /// Collects state & log information of mayastor services running in the system and dump them.
 #[derive(Debug, Clone, clap::Args)]


### PR DESCRIPTION
Fall back to eventing-aggregator pod exec (kube ws) when Loki is not
found in the cluster. Explicit --loki-endpoint errors on failure;
auto-discovery silently falls back so the command always produces results.

Add eight new filter flags: --component, --pool, --volume, --replica,
--rebuild-status, --state, --filter. Typed flags use prost struct access;
--filter accepts a full JSON dot-path with leading/trailing * wildcards
and walks the raw event JSON so no hardcoded field list is needed.

Skip REST client init for the events subcommand since it uses kube
directly and never touches the REST API.