### PR TITLE
fix(plugin): enforce --limit by truncating records before output

### DIFF
--- a/k8s/plugin/src/resources/events.rs
+++ b/k8s/plugin/src/resources/events.rs
@@ -314,7 +314,10 @@ impl EventsArgs {
         // Sort newest-first.
         records.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
 
-        let truncated = self.limit > 0 && records.len() >= self.limit;
+        let truncated = self.limit > 0 && records.len() > self.limit;
+        if truncated {
+            records.truncate(self.limit);
+        }
 
         if records.is_empty() && output.none() {
             if raw_count == 0 {


### PR DESCRIPTION
The truncation flag was computed but records were never sliced, so print_table received the full set regardless of --limit. Also tighten the threshold from >= to > so the truncation message is not shown when the result count exactly equals the limit.