### PR TITLE
feat(supportability): collect eventing-aggregator events in system dump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,6 +3923,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tar",
+ "tokio",
  "tower 0.5.1",
  "urlencoding",
  "utils",

--- a/k8s/supportability/Cargo.toml
+++ b/k8s/supportability/Cargo.toml
@@ -28,6 +28,7 @@ constants = { path = "../../constants" }
 
 futures = { workspace = true }
 async-trait = { workspace = true }
+tokio = { workspace = true }
 
 kube = { workspace = true, features = ["derive"] }
 k8s-openapi = { workspace = true }

--- a/k8s/supportability/src/collect/events.rs
+++ b/k8s/supportability/src/collect/events.rs
@@ -1,0 +1,181 @@
+use crate::collect::{
+    error::Error,
+    k8s_resources::client::ClientSet,
+    logs::LokiClient,
+    utils::{log, write_to_log_file},
+};
+
+use k8s_openapi::api::core::v1::Pod;
+use kube::{
+    api::{AttachParams, ListParams},
+    Api,
+};
+use std::{io::Write, path::Path};
+
+const EVENTS_LABEL_SELECTOR: &str = "app=eventing-aggregator";
+const EVENTS_CONTAINER: &str = "eventing-aggregator";
+const MBUS_EVENT_TYPE: &str = "mbus_event";
+const EVENTS_VOLUME_DIR: &str = "/var/events";
+
+fn build_logql_filters() -> Vec<String> {
+    vec![format!("|= \"{MBUS_EVENT_TYPE}\"")]
+}
+
+/// Collect events into `path/events.ndjson`.
+///
+/// Prefers Loki when a client is provided (eventing-aggregator was deployed in Loki mode).
+/// Falls back to exec-ing the eventing-aggregator pod volume when Loki is unavailable.
+/// `since` is passed to the aggregator exec so only events within the dump window are streamed.
+pub(crate) async fn collect_events_to_file(
+    loki_client: Option<&mut LokiClient>,
+    client_set: &ClientSet,
+    path: &Path,
+    since: humantime::Duration,
+) -> Result<(), Error> {
+    std::fs::create_dir_all(path)?;
+    match loki_client {
+        Some(client) => collect_events_from_loki(client, path).await,
+        None => collect_events_from_volume(client_set, path, since).await,
+    }
+}
+
+/// Collect events from Loki into `path/events.ndjson`.
+///
+/// Queries Loki for the eventing-aggregator stream and applies a `|= "mbus_event"` substring
+/// filter so only event lines are written (tracing/other log lines are dropped server-side).
+/// Loki lines carry a tracing prefix before the JSON payload; this function strips everything
+/// before the first `{` so the output file contains valid NDJSON.
+/// Lines are written page-by-page as they arrive from Loki — no full result set is held in
+/// memory, keeping allocation bounded to a single page (~3000 lines) at a time.
+async fn collect_events_from_loki(loki_client: &mut LokiClient, path: &Path) -> Result<(), Error> {
+    log("Collecting events from Loki...");
+
+    let events_path = path.join("events.ndjson");
+    let mut file = std::fs::File::create(&events_path)?;
+    let mut count = 0usize;
+
+    loki_client.set_logql_filters(build_logql_filters());
+    loki_client
+        .fetch_lines_paged(
+            EVENTS_LABEL_SELECTOR.to_string(),
+            EVENTS_CONTAINER.to_string(),
+            |page| {
+                for line in page {
+                    // Loki lines have a tracing prefix before the JSON payload
+                    // (e.g. "2024-01-01 INFO eventing_aggregator: {...}").
+                    // Strip everything before the first '{' so the file contains
+                    // the same raw NDJSON format as the pod-volume path.
+                    if let Some(json_start) = line.find('{') {
+                        writeln!(file, "{}", line[json_start..].trim_end())?;
+                        count += 1;
+                    }
+                }
+                Ok(())
+            },
+        )
+        .await
+        .map_err(|e| Error::Generic(format!("Failed to fetch events from Loki: {e:?}")))?;
+
+    std::fs::write(path.join("events-source.txt"), "loki\n")
+        .map_err(|e| Error::Generic(format!("Failed to write events-source.txt: {e}")))?;
+
+    log(format!("Collected {count} events from Loki"));
+    let _ = write_to_log_file(format!("Events written to {}\n", events_path.display()));
+
+    Ok(())
+}
+
+/// Collect events from the eventing-aggregator pod volume into `path/events.ndjson`.
+///
+/// Finds a running eventing-aggregator pod and execs
+/// `/bin/eventing-aggregator --print-events --events-dir=/var/events --since=<rfc3339>`.
+/// The aggregator binary reads its on-disk event files, deduplicates, and streams NDJSON to
+/// stdout. Bytes are copied directly to disk via `tokio::io::copy` with no deserialization,
+/// making memory usage O(1) regardless of how many events are stored on the volume.
+/// If no running pod is found the function logs a warning and returns `Ok(())` so the
+/// rest of the dump can continue.
+async fn collect_events_from_volume(
+    client_set: &ClientSet,
+    path: &Path,
+    since: humantime::Duration,
+) -> Result<(), Error> {
+    let kube_client = client_set.kube_client();
+    let namespace = client_set.namespace();
+
+    let pods: Api<Pod> = Api::namespaced(kube_client, namespace);
+    let lp = ListParams::default().labels(EVENTS_LABEL_SELECTOR);
+
+    let pod_list = pods
+        .list(&lp)
+        .await
+        .map_err(|e| Error::Generic(format!("Failed to list eventing-aggregator pods: {e}")))?;
+
+    let pod_name = match pod_list
+        .items
+        .into_iter()
+        .find(|p| {
+            p.status
+                .as_ref()
+                .and_then(|s| s.phase.as_deref())
+                .map(|ph| ph == "Running")
+                .unwrap_or(false)
+        })
+        .and_then(|p| p.metadata.name)
+    {
+        Some(name) => name,
+        None => {
+            log(format!(
+                "No running eventing-aggregator pod found in namespace {namespace}; skipping events collection"
+            ));
+            return Ok(());
+        }
+    };
+
+    log(format!("Collecting events from pod volume ({pod_name})..."));
+
+    let ap = AttachParams::default()
+        .stdin(false)
+        .stdout(true)
+        .stderr(false);
+
+    let since_cutoff = chrono::Utc::now()
+        - chrono::Duration::from_std(*since)
+            .map_err(|e| Error::Generic(format!("--since duration is out of range: {e}")))?;
+    let events_dir_arg = format!("--events-dir={EVENTS_VOLUME_DIR}");
+    let since_arg = format!("--since={}", since_cutoff.to_rfc3339());
+    let mut attached = pods
+        .exec(
+            &pod_name,
+            vec![
+                "/bin/eventing-aggregator",
+                "--print-events",
+                &events_dir_arg,
+                &since_arg,
+            ],
+            &ap,
+        )
+        .await
+        .map_err(|e| Error::Generic(format!("Failed to exec into pod {pod_name}: {e}")))?;
+
+    let mut stdout = attached
+        .stdout()
+        .ok_or_else(|| Error::Generic("No stdout from pod exec".to_string()))?;
+
+    let events_path = path.join("events.ndjson");
+    let mut file = tokio::fs::File::create(&events_path)
+        .await
+        .map_err(|e| Error::Generic(format!("Failed to create {}: {e}", events_path.display())))?;
+
+    // Stream bytes directly from exec stdout — no deserialization, O(1) memory.
+    tokio::io::copy(&mut stdout, &mut file)
+        .await
+        .map_err(|e| Error::Generic(format!("Failed to stream events from pod {pod_name}: {e}")))?;
+
+    std::fs::write(path.join("events-source.txt"), format!("{pod_name}\n"))
+        .map_err(|e| Error::Generic(format!("Failed to write events-source.txt: {e}")))?;
+
+    log(format!("Collected events from pod {pod_name}"));
+    let _ = write_to_log_file(format!("Events written to {}\n", events_path.display()));
+
+    Ok(())
+}

--- a/k8s/supportability/src/collect/logs/loki.rs
+++ b/k8s/supportability/src/collect/logs/loki.rs
@@ -24,6 +24,7 @@ pub enum LokiError {
     Serde(serde_json::Error),
     Hyper(hyper::Error),
     IOError(std::io::Error),
+    InvalidLabelSelector(String),
 }
 
 impl From<http::Error> for LokiError {
@@ -220,6 +221,12 @@ impl LokiClient {
         self
     }
 
+    /// Set LogQL filter expressions appended to every query.
+    /// Replaces any filters set via [`with_logql_filters`](Self::with_logql_filters).
+    pub fn set_logql_filters(&mut self, filters: Vec<String>) {
+        self.logql_filters = filters;
+    }
+
     /// Override the per-request page size (default: 3000).
     /// This controls how many log entries Loki returns in a single HTTP call.
     /// Use `fetch_lines()` to enforce a total result cap across pages.
@@ -245,7 +252,7 @@ impl LokiClient {
         container_name: String,
         limit: usize,
     ) -> Result<Vec<String>, LokiError> {
-        let label_filters = label_selector_to_logql(&label_selector);
+        let label_filters = label_selector_to_logql(&label_selector)?;
 
         let mut query_field = format!("{{{label_filters},container=\"{container_name}\"}}");
         for filter in &self.logql_filters {
@@ -284,6 +291,42 @@ impl LokiClient {
         Ok(lines)
     }
 
+    /// Paginate through all matching log lines and invoke `on_page` for each batch,
+    /// without accumulating the full result set in memory.
+    ///
+    /// Applies any `logql_filters` set via `with_logql_filters()`.
+    /// The callback receives a slice of raw log lines per Loki page and can write them
+    /// directly to disk. The callback's error type must be convertible to `LokiError`.
+    pub async fn fetch_lines_paged<F>(
+        &mut self,
+        label_selector: String,
+        container_name: String,
+        mut on_page: F,
+    ) -> Result<(), LokiError>
+    where
+        F: FnMut(&[String]) -> Result<(), LokiError>,
+    {
+        let label_filters = label_selector_to_logql(&label_selector)?;
+        let mut query_field = format!("{{{label_filters},container=\"{container_name}\"}}");
+        for filter in &self.logql_filters {
+            query_field.push_str(filter);
+        }
+        let encoded_query = urlencoding::encode(&query_field).into_owned();
+        let mut poller = LokiPoll {
+            uri: self.uri.clone(),
+            endpoint: self.logs_endpoint.clone(),
+            since: self.since,
+            encoded_query,
+            page_size: self.limit,
+            next_start_epoch_timestamp: 0,
+            client: self,
+        };
+        while let Some(batch) = poller.poll_next().await? {
+            on_page(&batch)?;
+        }
+        Ok(())
+    }
+
     /// fetch_and_dump_logs will do the following steps:
     /// 1. Creates poller to interact with Loki service based on provided arguments 1.1. Use poller
     ///    to fetch all available logs 1.2. Write fetched logs into file Continue above steps till
@@ -295,7 +338,7 @@ impl LokiClient {
         host_name: Option<String>,
         service_dir: PathBuf,
     ) -> Result<(), LokiError> {
-        let label_filters = label_selector_to_logql(&label_selector);
+        let label_filters = label_selector_to_logql(&label_selector)?;
         let (file_name, new_query_field) = match host_name {
             Some(host_name) => {
                 let file_name = format!("{host_name}-{SERVICE_NAME}-{container_name}.log");
@@ -357,15 +400,20 @@ impl LokiClient {
 /// Convert a Kubernetes label selector string into a comma-separated list of
 /// Loki label matchers, e.g. `"app=io-engine,openebs.io/logging=true"` becomes
 /// `app="io-engine",openebs_io_logging="true"`.
-fn label_selector_to_logql(selector: &str) -> String {
+/// Returns an error if any entry is missing the `=` separator.
+fn label_selector_to_logql(selector: &str) -> Result<String, LokiError> {
     selector
         .split(',')
-        .filter_map(|kv| {
-            let (k, v) = kv.split_once('=')?;
-            Some(format!("{}=\"{}\"", k.replace(['.', '/'], "_"), v))
+        .map(|kv| {
+            let (k, v) = kv.split_once('=').ok_or_else(|| {
+                LokiError::InvalidLabelSelector(format!(
+                    "malformed label selector entry (missing '='): {kv:?}"
+                ))
+            })?;
+            Ok(format!("{}=\"{}\"", k.replace(['.', '/'], "_"), v))
         })
-        .collect::<Vec<_>>()
-        .join(",")
+        .collect::<Result<Vec<_>, _>>()
+        .map(|parts| parts.join(","))
 }
 
 fn get_epoch_unix_time(since: humantime::Duration) -> SinceTime {

--- a/k8s/supportability/src/collect/logs/mod.rs
+++ b/k8s/supportability/src/collect/logs/mod.rs
@@ -233,6 +233,10 @@ impl Logger for LogCollection {
 
         self.get_logging_resources(pods).await
     }
+
+    fn loki_client_mut(&mut self) -> Option<&mut LokiClient> {
+        self.loki_client.as_mut()
+    }
 }
 
 /// Logger contains functionality to interact with service and fetch logs for requested service
@@ -247,6 +251,9 @@ pub(crate) trait Logger {
         &self,
         logging_label_selectors: String,
     ) -> Result<HashSet<LogResource>, LogError>;
+    /// Return a mutable reference to the inner Loki client, if one was successfully connected
+    /// at construction time. Returns `None` when Loki was not found or could not be reached.
+    fn loki_client_mut(&mut self) -> Option<&mut LokiClient>;
 }
 
 /// Creates specified directory path if not already exist

--- a/k8s/supportability/src/collect/mod.rs
+++ b/k8s/supportability/src/collect/mod.rs
@@ -2,6 +2,7 @@ pub mod archive;
 pub mod common;
 pub mod constants;
 pub mod error;
+pub mod events;
 pub mod k8s_resources;
 pub mod logs;
 pub mod persistent_store;

--- a/k8s/supportability/src/collect/system_dump.rs
+++ b/k8s/supportability/src/collect/system_dump.rs
@@ -3,6 +3,7 @@ use crate::{
         archive, common,
         common::DumpConfig,
         error::Error,
+        events,
         k8s_resources::{client::ClientSet, k8s_resource_dump::K8sResourceDumperClient},
         logs::{LogCollection, Logger},
         persistent_store::etcd::EtcdStore,
@@ -33,6 +34,7 @@ pub struct SystemDumper {
     k8s_resource_dumper: K8sResourceDumperClient,
     etcd_dumper: Option<EtcdStore>,
     logging_label_selectors: String,
+    since: humantime::Duration,
 }
 
 impl SystemDumper {
@@ -148,6 +150,7 @@ impl SystemDumper {
             k8s_resource_dumper,
             etcd_dumper,
             logging_label_selectors: config.logging_label_selectors().to_string(),
+            since: *config.since(),
         }
     }
 
@@ -245,6 +248,10 @@ impl SystemDumper {
         }
 
         if let Err(e) = self.dump_mayastor_etcd(&path).await {
+            errors.push(e);
+        }
+
+        if let Err(e) = self.dump_mayastor_events(&path).await {
             errors.push(e);
         }
 
@@ -388,6 +395,17 @@ impl SystemDumper {
         self.k8s_resource_dumper
             .dump_mayastor_k8s_resources(path, None)
             .await?;
+        Ok(())
+    }
+
+    /// Collects events into `path/events.ndjson`.
+    /// Uses Loki when available; falls back to the eventing-aggregator pod volume otherwise.
+    pub(crate) async fn dump_mayastor_events(&mut self, path: &Path) -> Result<(), Error> {
+        // Access the two fields directly so the borrow checker sees them as disjoint:
+        // self.logger (mut) and self.k8s_resource_dumper (shared) are different fields.
+        let loki_client = self.logger.loki_client_mut();
+        let k8s_client = self.k8s_resource_dumper.client_set();
+        events::collect_events_to_file(loki_client, k8s_client, path, self.since).await?;
         Ok(())
     }
 


### PR DESCRIPTION
Add mayastor/events.ndjson to the system dump archive. Events are collected from Loki when available (eventing-aggregator in Loki mode) or by exec-ing --print-events into the aggregator pod volume otherwise.

- New collect/events.rs with two paths:
  - Loki: queries {app=eventing-aggregator} with |= mbus_event filter, strips the tracing prefix from each line so the output is valid NDJSON
  - Volume: execs /bin/eventing-aggregator --print-events --since=<rfc3339>
    and streams stdout bytes directly to disk (O(1) memory, no parsing)
- Both paths write events-source.txt recording Loki or the pod name used
- Add take_loki_client() to the Logger trait so the existing LokiClient from log collection is reused rather than opening a second connection
- Store since on SystemDumper and pass it to the volume exec so both paths respect the dump's --since window consistently
- Graceful skip with a warning log if no running aggregator pod is found
- Added LokiError::InvalidLabelSelector(String) variant
- label_selector_to_logql now returns Result<String, LokiError> —
  uses map + collect::<Result<Vec<_>, _>>() so the first malformed entry
  (missing =) returns an Err immediately instead of silently skipping it