### PR TITLE
feat(chart): add coresFromCgroup option for io-engine

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -314,6 +314,7 @@ Each Secret must contain `tls.crt`, `tls.key`, and `ca.crt` keys.
 | image.&ZeroWidthSpace;repo | Image registry's namespace | `"openebs"` |
 | image.&ZeroWidthSpace;tag | Release tag for our images | `"develop"` |
 | io_engine.&ZeroWidthSpace;coreList | If not empty, overrides the cpuCount and explicitly sets the list of cores. Example: --set='io_engine.coreList={30,31}' | `[]` |
+| io_engine.&ZeroWidthSpace;coresFromCgroup | Derive the io-engine core list from the pod's cgroup cpuset instead of cpuCount/coreList. See: https://github.com/openebs/mayastor/issues/1458 | `false` |
 | io_engine.&ZeroWidthSpace;cpuCount | The number of cores that each io-engine instance will bind to. | `"2"` |
 | io_engine.&ZeroWidthSpace;envcontext | Pass additional arguments to the Environment Abstraction Layer. Example: --set {product}.envcontext=iova-mode=pa | `""` |
 | io_engine.&ZeroWidthSpace;interruptMode | SPDK interrupt mode for io-engine reactors. When enabled, reactors sleep on epoll/timerfd instead of busy-polling, which dramatically reduces idle CPU usage. NVMe I/O queues are still polled, but on a periodic timer rather than continuously. | <pre>{<br>"enabled":false,<br>"nvmeIoQueuePollPeriod":"100us"<br>}</pre> |

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -121,7 +121,8 @@ spec:
         - "-N$(MY_NODE_NAME)"
         - "-Rhttps://{{ .Release.Name }}-agent-core:50051"
         - "-y/var/local/{{ .Release.Name }}/io-engine/config.yaml"
-        - "-l{{ include "cpuFlag" . }}"
+        - "-l{{ include "cpuFlag" . }}"{{ if .Values.io_engine.coresFromCgroup }}
+        - "--cores-from-cgroup"{{ end }}
         - "-p={{ include "etcdUrl" . }}"{{ if .Values.io_engine.target.nvmf.ptpl }}
         - "--ptpl-dir=/var/local/{{ .Release.Name }}/io-engine/ptpl/"{{ end }}
         - "--api-versions={{ .Values.io_engine.api }}"{{ if .Values.io_engine.target.nvmf.rdma.enabled }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -640,6 +640,9 @@ io_engine:
   # -- If not empty, overrides the cpuCount and explicitly sets the list of cores.
   # Example: --set='io_engine.coreList={30,31}'
   coreList: [ ]
+  # -- Derive the io-engine core list from the pod's cgroup cpuset instead of
+  # cpuCount/coreList. See: https://github.com/openebs/mayastor/issues/1458
+  coresFromCgroup: false
   # -- Node selectors to designate storage nodes for diskpool creation
   # Note that if multi-arch images support 'kubernetes.io/arch: amd64'
   # should be removed.


### PR DESCRIPTION
## Summary
- Adds `io_engine.coresFromCgroup` (default `false`) to `values.yaml`.
- When enabled, appends `--cores-from-cgroup` to the io-engine daemonset args, alongside the existing static `-l` core list.
- Companion to openebs/mayastor#2050, which adds the `--cores-from-cgroup` flag to io-engine so it derives its reactor core list from the pod's kubelet-assigned cgroup cpuset (addresses openebs/mayastor#1458).

## Test plan
- [x] `helm lint`
- [x] `helm template` with `coresFromCgroup=true` and default (`false`) — flag present/absent as expected
- [x] Manual deploy on a kubelet node with CPU Manager static policy enabled (Cgroup V2 only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)