### PR TITLE
fix(supportability): fix Loki auto-discovery timeout, raise default --timeout

### DIFF
--- a/k8s/supportability/src/collect/logs/loki.rs
+++ b/k8s/supportability/src/collect/logs/loki.rs
@@ -153,10 +153,17 @@ impl LokiClient {
     ) -> Option<Self> {
         let (uri, client) = match uri {
             None => {
+                // Without this, ConfigBuilder's own Default impl applies a
+                // hardcoded 5s timeout here regardless of the CLI's --timeout
+                // value - fine for a short --since window, but Loki
+                // genuinely needs longer than that to search a large one
+                // (e.g. 30d), so every query timed out well before Loki
+                // could respond.
                 let (uri, svc) = match kube_proxy::ConfigBuilder::default_loki()
                     .with_kube_config(kubeconfig_args.path.clone())
                     .with_context(kubeconfig_args.opts.context.clone())
                     .with_target_mod(|t| t.with_namespace(namespace))
+                    .with_timeout(*timeout)
                     .build()
                     .await
                 {

--- a/k8s/supportability/src/lib.rs
+++ b/k8s/supportability/src/lib.rs
@@ -19,7 +19,7 @@ pub use collect::logs::{LokiClient, LokiError};
 #[derive(Debug, Clone, clap::Args)]
 pub struct SupportArgs {
     /// Specifies the timeout value to interact with other modules of system
-    #[clap(global = true, long, short, default_value = "10s")]
+    #[clap(global = true, long, short, default_value = "30s")]
     timeout: humantime::Duration,
 
     /// Period states to collect all logs from last specified duration


### PR DESCRIPTION
## Description
LokiClient's auto-discovery path (no explicit `--loki-endpoint`, the common case) never called `.with_timeout()` on its `ConfigBuilder`, so it silently used the builder's own hardcoded 5s default instead of `--timeout`, too short for large windows (a 30-day search needs 60s+). Fixed.

Also raised the shared `--timeout` default from 10s to 30s, since it's shared across etcd, REST, Loki, and k8s log fetches (each call still gets its own fresh timeout window, not one shared deadline).

Earlier this PR also added a manual timeout on the k8s-native per-container log fetch, since a hung kubelet was seen blocking `dump system` indefinitely. Removed after review, since `kube::Client` already has a built-in 295s read timeout at the transport layer, making the manual wrapper redundant. Will revisit if the underlying hang is found to slip past that built-in timeout.

## Motivation and Context
Investigating repeated `dump system` timeouts/hangs against a real cluster.

## Regression
No, only widens/corrects timeout windows; normal, responsive calls are unaffected.

## How Has This Been Tested?
Verified live: a 30-day `--since` with a 60s `--timeout` completes successfully end-to-end where it previously failed with `Loki(Tower(Elapsed(())))` on every service. `cargo check -p supportability` passes after the manual-timeout removal.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.