### PR TITLE
fix(supportability): use max timestamp across all Loki streams for pagination

### DIFF
--- a/k8s/supportability/src/collect/logs/loki.rs
+++ b/k8s/supportability/src/collect/logs/loki.rs
@@ -85,22 +85,15 @@ struct LokiResponse {
 type SinceTime = u128;
 
 impl LokiResponse {
-    // fetch last stream log epoch timestamp in nanoseconds
+    // Returns the maximum log entry timestamp (nanoseconds) across ALL streams.
     fn get_last_stream_unix_time(&self) -> SinceTime {
-        let unix_time = match self.data.result.last() {
-            Some(last_stream) => last_stream
-                .values
-                .last()
-                .unwrap_or(&vec![])
-                .first()
-                .unwrap_or(&"0".to_string())
-                .parse::<SinceTime>()
-                .unwrap_or(0),
-            None => {
-                return 0;
-            }
-        };
-        unix_time
+        self.data
+            .result
+            .iter()
+            .flat_map(|s| s.values.iter())
+            .filter_map(|v| v.first()?.parse::<SinceTime>().ok())
+            .max()
+            .unwrap_or(0)
     }
 }
 


### PR DESCRIPTION
Plugin was reporting duplicate events for same volume with same timestamp:
```
/kubectl-mayastor get events --category volume --action create 
 TIMESTAMP                       CATEGORY  ACTION  TARGET                                NODE    COMPONENT 
 2026-08-09T13:14:22.846801351Z  Volume    Create  8ec6120b-a984-4ae6-91bf-b22a93fb3e92  <none>  CoreAgent 
 2026-08-09T13:14:22.846801351Z  Volume    Create  8ec6120b-a984-4ae6-91bf-b22a93fb3e92  <none>  CoreAgent 
 2026-08-09T12:40:30.222242651Z  Volume    Create  11619dce-4530-4240-823c-407f5bc1dc22  <none>  CoreAgent 
 2026-08-09T12:23:01.340033450Z  Volume    Create  cc631a62-c9ec-4ac5-b9c8-b963636fa916  <none>  CoreAgent 
```

With this fix:
```
./kubectl-mayastor get events --category volume --action create
 TIMESTAMP                       CATEGORY  ACTION  TARGET                                NODE    COMPONENT 
 2026-08-09T13:14:22.846801351Z  Volume    Create  8ec6120b-a984-4ae6-91bf-b22a93fb3e92  <none>  CoreAgent 
 2026-08-09T12:40:30.222242651Z  Volume    Create  11619dce-4530-4240-823c-407f5bc1dc22  <none>  CoreAgent 
 2026-08-09T12:23:01.340033450Z  Volume    Create  cc631a62-c9ec-4ac5-b9c8-b963636fa916  <none>  CoreAgent
```
get_last_stream_unix_time was reading only result.last().values.last(), which is wrong when multiple streams are present and the last stream's final entry is older than another stream's entries. This caused the pagination cursor to advance to a point in the past, re-fetching already-seen entries on the next poll and producing duplicate events.

Affects get events (plugin), events.ndjson in system dump, and per-pod log files in system dump for any component with multiple replicas.