### PR TITLE
feat(chart): add WAL storage for alloy when eventing is enabled

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -198,6 +198,7 @@ Each Secret must contain `tls.crt`, `tls.key`, and `ca.crt` keys.
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;node.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;cpu | Cpu requests for ha node agent | `"100m"` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;node.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;memory | Memory requests for ha node agent | `"64Mi"` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;node.&ZeroWidthSpace;tolerations | Set tolerations, overrides global | `[]` |
+| alloy.&ZeroWidthSpace;alloy.&ZeroWidthSpace;extraEnv[0] | Expose the node name so the alloy config can scope discovery to this node only. | <pre>{<br>"name":"NODE_NAME",<br>"valueFrom":{<br>"fieldRef":{<br>"fieldPath":"spec.nodeName"<br>}<br>}<br>}</pre> |
 | alloy.&ZeroWidthSpace;logging_config.&ZeroWidthSpace;labels | Labels to enable scraping on, at-least one of these labels should be present. | <pre>{<br>"openebs.io/logging":true<br>}</pre> |
 | alloy.&ZeroWidthSpace;logging_config.&ZeroWidthSpace;tenant_id | X-Scope-OrgID to pe populated which pushing logs. Make sure the caller also uses the same. | `"openebs"` |
 | apis.&ZeroWidthSpace;rest.&ZeroWidthSpace;healthProbes.&ZeroWidthSpace;liveness.&ZeroWidthSpace;enabled | Toggle liveness probe. | `true` |

--- a/chart/README.md
+++ b/chart/README.md
@@ -199,6 +199,9 @@ Each Secret must contain `tls.crt`, `tls.key`, and `ca.crt` keys.
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;node.&ZeroWidthSpace;resources.&ZeroWidthSpace;requests.&ZeroWidthSpace;memory | Memory requests for ha node agent | `"64Mi"` |
 | agents.&ZeroWidthSpace;ha.&ZeroWidthSpace;node.&ZeroWidthSpace;tolerations | Set tolerations, overrides global | `[]` |
 | alloy.&ZeroWidthSpace;alloy.&ZeroWidthSpace;extraEnv[0] | Expose the node name so the alloy config can scope discovery to this node only. | <pre>{<br>"name":"NODE_NAME",<br>"valueFrom":{<br>"fieldRef":{<br>"fieldPath":"spec.nodeName"<br>}<br>}<br>}</pre> |
+| alloy.&ZeroWidthSpace;alloy.&ZeroWidthSpace;stabilityLevel | Minimum stability level of components to enable. Set to "experimental" when walEnabled is true, as loki.write WAL is an experimental feature. | `"generally-available"` |
+| alloy.&ZeroWidthSpace;alloy.&ZeroWidthSpace;storagePath | Path inside the container where alloy WAL data is stored. | `"/var/lib/alloy/wal"` |
+| alloy.&ZeroWidthSpace;controller.&ZeroWidthSpace;volumes.&ZeroWidthSpace;extra[0] | emptyDir volume for alloy WAL; survives pod restarts within the same pod lifecycle. | <pre>{<br>"emptyDir":{<br>"sizeLimit":"200Mi"<br>},<br>"name":"alloy-wal"<br>}</pre> |
 | alloy.&ZeroWidthSpace;logging_config.&ZeroWidthSpace;labels | Labels to enable scraping on, at-least one of these labels should be present. | <pre>{<br>"openebs.io/logging":true<br>}</pre> |
 | alloy.&ZeroWidthSpace;logging_config.&ZeroWidthSpace;tenant_id | X-Scope-OrgID to pe populated which pushing logs. Make sure the caller also uses the same. | `"openebs"` |
 | apis.&ZeroWidthSpace;rest.&ZeroWidthSpace;healthProbes.&ZeroWidthSpace;liveness.&ZeroWidthSpace;enabled | Toggle liveness probe. | `true` |

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -934,10 +934,22 @@ alloy:
       openebs.io/logging: true
     # -- X-Scope-OrgID to pe populated which pushing logs. Make sure the caller also uses the same.
     tenant_id: openebs
+    # -- Enable WAL for the loki.write component. Classified experimental in Alloy v1.8.1;
+    # -- keep false until validated on a stable Alloy release.
+    # -- To enable WAL: --set alloy.alloy.stabilityLevel=experimental --set alloy.logging_config.walEnabled=true
+    walEnabled: false
   enabled: true
   alloy:
+    # -- Minimum stability level of components to enable. Set to "experimental" when walEnabled is true,
+    # as loki.write WAL is an experimental feature.
+    stabilityLevel: "generally-available"
+    # -- Path inside the container where alloy WAL data is stored.
+    storagePath: /var/lib/alloy/wal
     mounts:
       varlog: true
+      extra:
+        - name: alloy-wal
+          mountPath: /var/lib/alloy/wal
     configMap:
       create: true
       content: |
@@ -1047,6 +1059,11 @@ alloy:
             url       = "http://{{ .Release.Name }}-loki:3100/loki/api/v1/push"
             tenant_id = "{{ .Values.logging_config.tenant_id }}"
           }
+          {{- if .Values.logging_config.walEnabled }}
+          wal {
+            enabled = true
+          }
+          {{- end }}
           external_labels = {}
         }
 
@@ -1074,6 +1091,13 @@ alloy:
         valueFrom:
           fieldRef:
             fieldPath: spec.nodeName
+  controller:
+    volumes:
+      extra:
+        # -- emptyDir volume for alloy WAL; survives pod restarts within the same pod lifecycle.
+        - name: alloy-wal
+          emptyDir:
+            sizeLimit: 200Mi
 # Eventing which enables or disables eventing-related components.
 eventing:
   enabled: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -949,6 +949,10 @@ alloy:
 
         discovery.kubernetes "{{ $releaseName }}_pods_name" {
           role = "pod"
+          selectors {
+            role  = "pod"
+            field = "spec.nodeName=" + env("NODE_NAME")
+          }
         }
 
         discovery.relabel "{{ $releaseName }}_pods_name" {
@@ -1064,6 +1068,12 @@ alloy:
         {{- end -}}
         {{- join "|" $regexParts -}}
         {{- end -}}
+    extraEnv:
+      # -- Expose the node name so the alloy config can scope discovery to this node only.
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
 # Eventing which enables or disables eventing-related components.
 eventing:
   enabled: true


### PR DESCRIPTION
- Enable alloy WAL (loki.write) with a emptyDir volume on each DaemonSet node pod. WAL buffers logs to disk during Loki unavailability and auto-cleans segments after 1h (default).
- Scope alloy pod discovery to its own node via field selector.
Add NODE_NAME downward API env var to the alloy DaemonSet so each pod
can reference its own node name in the alloy config. Use the
discovery.kubernetes selectors block (selectors { role = "pod"; field =
"spec.nodeName=" + env("NODE_NAME") }) to scope each alloy instance to
only watch pods on its own node.
This prevents alloy daemonSet log collector
should only watch pods on its own node, not cluster-wide.

Alloy had no WAL configured, so it used only an in-memory queue for buffering logs before shipping to Loki.

Scenario that triggered log loss:

1. Loki started but wasn't ready yet (needed "at least 2 live replicas"), 
2. During that time all three alloy pods were collecting pod logs and trying to push to Loki
3. Loki responded with HTTP 500 on every push attempt
4. With no WAL, alloy's in-memory queue eventually filled up
5. Alloy on node-0 and node-1 exhausted all retries and went silent — their in-memory buffers were full and they started dropping logs
6. Only alloy on node-2 recovered when Loki finally became healthy
7. Result: pods scheduled on node-0 and node-1 had no logs in Loki

Loki collected pod logs  — only from node-2. Events that existed in the NATS stream were not visible via the Loki path because the eventing-aggregator pod logs were lost as eventing-aggregator pod was scheduled on node-0.

Fix: Instead of dropping logs when the in-memory queue fills, alloy writes them to disk (/var/local/alloy/wal). When Loki recovers, alloy replays the WAL. Segments older than 1h (default value) are dropped automatically if alloy is unable to push logs to Loki.