### PR TITLE
feat(supportability): add dump loki-limit, let LOKI_ENDPOINT env override discovery

### DIFF
--- a/k8s/supportability/src/collect/logs/loki.rs
+++ b/k8s/supportability/src/collect/logs/loki.rs
@@ -388,6 +388,39 @@ impl LokiClient {
         }
         Ok(())
     }
+
+    /// Fetches Loki's own `/config` endpoint and extracts
+    /// `limits_config.max_query_length` - the actual configured max
+    /// query-time-range, reflecting whatever the cluster's Loki Helm values
+    /// currently set rather than a number hardcoded elsewhere. Uses the same
+    /// TLS-aware `inner_client` as every other request this type makes, so a
+    /// caller never has to build its own connection to Loki just to ask this.
+    /// Returns `None` (not an error) if Loki isn't reachable, doesn't respond
+    /// successfully, or the field is missing/unparseable - callers should
+    /// treat that as "can't tell", not fail on it.
+    pub async fn max_query_length(&mut self) -> Result<Option<String>, LokiError> {
+        let request = http::Request::builder()
+            .method("GET")
+            .uri(format!("{}/config", self.uri))
+            .body(hyper_body::Body::empty())?;
+
+        let response = self.inner_client.ready().await?.call(request).await?;
+        if !response.status().is_success() {
+            return Ok(None);
+        }
+
+        let body_bytes = response.into_body().collect().await?.to_bytes();
+        let config: serde_yaml::Value = match serde_yaml::from_slice(&body_bytes) {
+            Ok(value) => value,
+            Err(_) => return Ok(None),
+        };
+
+        Ok(config
+            .get("limits_config")
+            .and_then(|v| v.get("max_query_length"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()))
+    }
 }
 
 /// Convert a Kubernetes label selector string into a comma-separated list of

--- a/k8s/supportability/src/lib.rs
+++ b/k8s/supportability/src/lib.rs
@@ -29,10 +29,13 @@ pub struct SupportArgs {
     #[clap(global = true, long, short, default_value = "24h")]
     since: humantime::Duration,
 
-    /// Endpoint of LOKI service, if left empty then it will try to parse endpoint
-    /// from Loki service(K8s service resource), if the tool is unable to parse
-    /// from service then logs will be collected using Kube-apiserver
-    #[clap(global = true, short, long)]
+    /// Endpoint of LOKI service. If left empty, falls back to the LOKI_ENDPOINT
+    /// environment variable (set by the Helm chart on the ops-agent pod, which
+    /// already knows the Service's address at deploy time); if that's not set
+    /// either, tries to discover it from the Loki Service (K8s service
+    /// resource) via a port-forward, and if that also fails, logs are
+    /// collected using the Kube-apiserver directly.
+    #[clap(global = true, short, long, env = "LOKI_ENDPOINT")]
     loki_endpoint: Option<String>,
 
     /// Endpoint of ETCD service, if left empty then will be parsed from the internal service name
@@ -120,6 +123,30 @@ impl ExecuteOperation for Resource {
 pub(crate) const ARCHIVE_PREFIX: &str = "mayastor";
 
 async fn execute_resource_dump(cli_args: SupportArgs, resource: Resource) -> Result<(), Error> {
+    // Handled before DumpConfig::new below, which otherwise moves several of
+    // these same SupportArgs fields for the archive-producing operations -
+    // this one never builds an archive, so it has no use for DumpConfig at all.
+    if matches!(resource, Resource::LokiLimit) {
+        let mut client = LokiClient::new(
+            cli_args.loki_endpoint,
+            cli_args.ctx.kubeconfig,
+            cli_args.ctx.namespace,
+            cli_args.since,
+            cli_args.timeout,
+            cli_args.tenant_id,
+        )
+        .await;
+        let max_query_length = match client.as_mut() {
+            Some(client) => client.max_query_length().await.unwrap_or(None),
+            None => None,
+        };
+        match max_query_length {
+            Some(limit) => println!("{{\"maxQueryLength\":\"{limit}\"}}"),
+            None => println!("{{\"maxQueryLength\":null}}"),
+        }
+        return Ok(());
+    }
+
     let mut config = DumpConfig::new(
         cli_args.output_directory_path,
         cli_args.ctx.namespace,
@@ -186,6 +213,7 @@ async fn execute_resource_dump(cli_args: SupportArgs, resource: Resource) -> Res
                 errors.push(e);
             }
         }
+        Resource::LokiLimit => unreachable!("handled above, before DumpConfig is built"),
     }
     if !errors.is_empty() {
         log("Failed to dump system state");

--- a/k8s/supportability/src/operations.rs
+++ b/k8s/supportability/src/operations.rs
@@ -28,6 +28,13 @@ pub(crate) enum Resource {
 
     /// Collects the Loki logs from the product's components
     Loki,
+
+    /// Reports Loki's own configured max query-time-range limit, as JSON
+    /// (`{"maxQueryLength":"<duration>"}`, or `null` if it can't be determined).
+    /// Uses the same TLS-aware discovery/connection as every other Loki
+    /// operation this tool performs - a caller wanting this value should use
+    /// this instead of building its own connection to Loki.
+    LokiLimit,
 }
 
 impl SystemDumpArgs {


### PR DESCRIPTION
## Summary
- New `dump loki-limit` subcommand: connects to Loki via the same client every other Loki operation uses, reads its configured `max_query_length` from `/config`, prints it as JSON (`{"maxQueryLength":"<duration>"}`, or `null` if it can't be determined). Lets a caller (e.g. the Headlamp plugin) learn Loki's real query-range limit without building its own separate connection to Loki.
- `loki_endpoint` now also reads from a `LOKI_ENDPOINT` environment variable (via clap's `env` support) when `--loki-endpoint` isn't passed on the command line, ahead of the existing port-forward-based Service discovery fallback. Lets a Helm chart hand the CLI Loki's address directly at deploy time (since the chart already knows it), skipping port-forward entirely for that case.

## Testing
- `cargo check -p supportability` passes.
- Live-tested against a real cluster: `dump loki-limit` returns the correct configured limit in well under a second.
- Live-tested `LOKI_ENDPOINT`: a bogus address fails with a connection error (proving it's read and used, not silently ignored); the real Service address works correctly with no port-forward involved.