### PR TITLE
ci: restore shell.nix path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
           tar -xzf charts-staged/mayastor-"$VERSION".tgz -C charts-final
 
           mv charts-final/mayastor/* chart
+          git restore chart/shell.nix
 
       - name: Update the registry and the repository
         run: |


### PR DESCRIPTION
- Adds the shell.nix in chart for the symlink to work