### PR TITLE
feat(chart): allow Guaranteed QoS for the io-engine pod

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -238,12 +238,14 @@ Each Secret must contain `tls.crt`, `tls.key`, and `ca.crt` keys.
 | apis.&ZeroWidthSpace;rest.&ZeroWidthSpace;tolerations | Set tolerations, overrides global | `[]` |
 | base.&ZeroWidthSpace;cache_poll_period | Cache timeout for core agent & diskpool deployment | `"30s"` |
 | base.&ZeroWidthSpace;default_req_timeout | Request timeout for rest & core agents | `"5s"` |
+| base.&ZeroWidthSpace;initContainers.&ZeroWidthSpace;defaultResources | Resources applied to io-engine init containers which do not define their own. Init containers without resources force the pod to QoS class Burstable, which disqualifies it from exclusive CPUs under the static CPU manager policy. Scope is limited to the io-engine DaemonSet: the shared helper receives these defaults explicitly from that call site only. | <pre>{<br><br>}</pre> |
 | base.&ZeroWidthSpace;initContainers.&ZeroWidthSpace;image.&ZeroWidthSpace;registry | Image registry for init containers | `""` |
 | base.&ZeroWidthSpace;logging.&ZeroWidthSpace;color | Enable ansi color code for Pod StdOut/StdErr | `true` |
 | base.&ZeroWidthSpace;logging.&ZeroWidthSpace;format | Valid values for format are pretty, json and compact | `"pretty"` |
 | base.&ZeroWidthSpace;logging.&ZeroWidthSpace;silenceLevel | Silence specific module components | `nil` |
 | base.&ZeroWidthSpace;metrics.&ZeroWidthSpace;enabled | Enable the metrics exporter | `true` |
 | base.&ZeroWidthSpace;metrics.&ZeroWidthSpace;port | Container port for the metrics exporter service | `9502` |
+| base.&ZeroWidthSpace;metrics.&ZeroWidthSpace;resources | Resources for the metrics exporter sidecar. Required for the io-engine pod to qualify as QoS class Guaranteed when metrics are enabled: a container without matching requests and limits keeps the whole pod in Burstable. | <pre>{<br><br>}</pre> |
 | crds.&ZeroWidthSpace;csi.&ZeroWidthSpace;volumeSnapshots.&ZeroWidthSpace;enabled | Install Volume Snapshot CRDs | `true` |
 | crds.&ZeroWidthSpace;enabled | Disables the installation of all CRDs if set to false | `true` |
 | csi.&ZeroWidthSpace;controller.&ZeroWidthSpace;logLevel | Log level for the csi controller | `"info"` |

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -42,7 +42,7 @@ Usage:
 */}}
 {{- define "base_init_containers" -}}
     {{- if .Values.base.initContainers.enabled }}
-    {{- include "render_init_containers" (dict "value" .Values.base.initContainers.containers "context" $) | nindent 8 }}
+    {{- include "render_init_containers" (dict "value" .Values.base.initContainers.containers "context" $ "defaultResources" .Values.base.initContainers.defaultResources) | nindent 8 }}
     {{- end }}
     {{- include "jaeger_collector_init_container" . }}
 {{- end -}}
@@ -388,6 +388,7 @@ Renders init containers. If unset it sets the container image.
     {{- $values_image := .context.Values.image }}
     {{- $global := .context.Values.global }}
     {{- $ctx := .context }}
+    {{- $defaultResources := .defaultResources }}
     {{- range .value -}}
         {{ $container := deepCopy . }}
         {{- if hasKey $container "command" }}
@@ -403,6 +404,9 @@ Renders init containers. If unset it sets the container image.
         {{- end }}
         {{- if not (hasKey $container "image") }}
             {{- $_ := set $container "image" (include "render_init_container_image" $ctx ) }}
+        {{- end }}
+        {{- if and (not (hasKey $container "resources")) $defaultResources }}
+            {{- $_ := set $container "resources" $defaultResources }}
         {{- end }}
         {{- $containers = append $containers $container }}
     {{- end -}}

--- a/chart/templates/mayastor/io/io-engine-daemonset.yaml
+++ b/chart/templates/mayastor/io/io-engine-daemonset.yaml
@@ -192,6 +192,9 @@ spec:
           - containerPort: {{ default 9502 .Values.base.metrics.port }}
             protocol: TCP
             name: metrics
+          {{- if .Values.base.metrics.resources }}
+          resources: {{ toYaml .Values.base.metrics.resources | nindent 10 }}
+          {{- end }}
         args:
           - "--metrics-endpoint=[::]:{{ default 9502 .Values.base.metrics.port }}"
           - "--grpc-port={{ default 10124 .Values.io_engine.port }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -138,6 +138,13 @@ base:
       pullPolicy: IfNotPresent
       # -- Image registry for init containers
       registry: ""
+    # -- Resources applied to io-engine init containers which do not define
+    # their own. Init containers without resources force the pod to QoS class
+    # Burstable, which disqualifies it from exclusive CPUs under the static
+    # CPU manager policy.
+    # Scope is limited to the io-engine DaemonSet: the shared helper receives
+    # these defaults explicitly from that call site only.
+    defaultResources: {}
     containers:
       - name: agent-core-grpc-probe
         command: [ 'sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-agent-core 50051; do date; echo "Waiting for agent-core-grpc services..."; sleep 1; done;' ]
@@ -158,6 +165,11 @@ base:
     enabled: true
     # -- Container port for the metrics exporter service
     port: 9502
+    # -- Resources for the metrics exporter sidecar. Required for the io-engine
+    # pod to qualify as QoS class Guaranteed when metrics are enabled: a
+    # container without matching requests and limits keeps the whole pod in
+    # Burstable.
+    resources: {}
   jaeger:
     # Enable jaeger tracing (for development only).
     # Since version 1.31 the Jaeger Operator uses webhooks to validate Jaeger custom resources (CRs).


### PR DESCRIPTION
## Problem

Exclusive CPUs under the kubelet `static` CPU manager policy are only granted
to pods in QoS class Guaranteed, which requires matching requests and limits on
**every** container in the pod. Two chart-side gaps make that unreachable for
io-engine today:

- the init containers (`agent-core-grpc-probe`, `etcd-probe`) carry no
  resources, and attaching them means restating the whole
  `base.initContainers.containers` list in values;
- `metrics-exporter-io-engine` has no `resources` section at all, so enabling
  metrics silently drops the pod back to Burstable.

## Changes

- `base.initContainers.defaultResources` — applied only to init containers that
  do not declare their own. Passed explicitly from the io-engine call site, so
  the other five call sites of `render_init_containers` (agent-core, ha-node,
  csi-node, api-rest, jaeger) are unaffected.
- `base.metrics.resources` — for the exporter sidecar.

Both default to empty; rendered output is unchanged for existing installations.

## Why this matters

This is a prerequisite for #962 / mayastor#2050: `--cores-from-cgroup` reads the
pod's cpuset, but without Guaranteed QoS that cpuset is the whole shared pool
rather than the exclusively assigned cores.

Verified on a 32-core node, Kubernetes v1.35, kernel 6.12, with
`cpuManagerPolicy: static` and `strict-cpu-reservation: true`:

    {
        "policyName": "static",
        "defaultCpuSet": "4-31",
        "entries": {
            "00e08908-035e-4e3b-a7db-a8bf82170873": { "io-engine": "2-3" }
        }
    }

## Test plan

- [x] `helm lint`
- [x] `helm template` with defaults — output byte-identical to upstream
- [x] `helm template` with `defaultResources` set — resources appear on the
      io-engine init containers only
- [x] `chart/README.md` regenerated