### PR TITLE
build: hoist naersk_package out of rustPlatformDeps

### DIFF
--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -5,6 +5,20 @@ let
 in
 rec {
   makeRustTarget = platform: platform.rust.rustcTargetSpec;
+  naersk_package = channel: pkgs.callPackage sources.naersk {
+    rustc = channel.stable;
+    cargo = channel.stable;
+    # Rewrite crates.io API URLs to static CDN to avoid intermittent 403s
+    fetchurl = attrs@{ url, ... }:
+      let
+        m = builtins.match "https://crates\\.io/api/v1/crates/([^/]+)/([^/]+)/download" url;
+        resolvedUrl =
+          if m != null then
+            "https://static.crates.io/crates/${builtins.elemAt m 0}/${builtins.elemAt m 0}-${builtins.elemAt m 1}.crate"
+          else url;
+      in
+      pkgs.fetchurl (attrs // { url = resolvedUrl; });
+  };
   rust_default = { override ? { } }: rec {
     nightly_pkg = pkgs.rust-bin.nightly."2026-07-16";
     stable_pkg = pkgs.rust-bin.stable."1.97.1";
@@ -24,20 +38,6 @@ rec {
   };
 
   rustPlatformDeps = { target, sources }: rec {
-    naersk_package = channel: pkgs.callPackage sources.naersk {
-      rustc = channel.stable;
-      cargo = channel.stable;
-      # Rewrite crates.io API URLs to static CDN to avoid intermittent 403s
-      fetchurl = attrs@{ url, ... }:
-        let
-          m = builtins.match "https://crates\\.io/api/v1/crates/([^/]+)/([^/]+)/download" url;
-          resolvedUrl =
-            if m != null then
-              "https://static.crates.io/crates/${builtins.elemAt m 0}/${builtins.elemAt m 0}-${builtins.elemAt m 1}.crate"
-            else url;
-        in
-        pkgs.fetchurl (attrs // { url = resolvedUrl; });
-    };
     os = platform: builtins.replaceStrings [ "${platform.qemuArch}-" ] [ "" ] platform.system;
     hostPlatform = "${makeRustTarget pkgs.pkgsStatic.hostPlatform}";
     targetPlatform = "${makeRustTarget pkgs.pkgsCross."${target}".hostPlatform}";


### PR DESCRIPTION
`nix/pkgs/extensions/cargo-project.nix` references `channel.naersk_package`, but `naersk_package` is defined inside the `rustPlatformDeps` function in `nix/lib/rust.nix`, so it is not an attribute of the channel set:

```
error: attribute 'naersk_package' missing
```

Nix laziness hides this until the incremental build path (`build_with_naersk`) is evaluated.

Move `naersk_package` to the top-level `rec` set. `rustPlatformDeps` keeps resolving it through lexical scope, so its own `naersk` is unchanged, and the static CDN crate rewrite now applies to the extensions incremental build as intended.

Same layout as openebs/mayastor-control-plane#1188.