### PR TITLE
ci: run basic K8s test on arm

### DIFF
--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -17,7 +17,13 @@ on:
 
 jobs:
   k8s-ci:
-    runs-on: cncf-ubuntu-8-32-x86
+    strategy:
+      fail-fast: false
+      matrix:
+        # The pinned chart is architecture-independent and is pushed once, so
+        # with helm-pins only x86 runs; anything else exercises both.
+        runner: ${{ fromJSON(inputs.helm-pins && '["cncf-ubuntu-8-32-x86"]' || '["cncf-ubuntu-8-32-x86", "cncf-ubuntu-8-32-arm"]') }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -127,7 +133,7 @@ jobs:
           name: k8s-dump
           path: dump
       # debugging
-  #      - name: Setup tmate session
-  #        if: ${{ failure() }}
-  #        timeout-minutes: 120
-  #        uses: mxschmitt/action-tmate@v3
+      # - name: Setup tmate session
+      #   if: ${{ failure() }}
+      #   timeout-minutes: 120
+      #   uses: owenthereal/action-upterm@v1

--- a/chart/README.md
+++ b/chart/README.md
@@ -323,7 +323,7 @@ Each Secret must contain `tls.crt`, `tls.key`, and `ca.crt` keys.
 | io_engine.&ZeroWidthSpace;interruptMode.&ZeroWidthSpace;enabled | Enable interrupt mode by setting ENABLE_INTERRUPT_MODE=true on the io-engine container (equivalent to passing the --enable-interrupt-mode CLI flag). | `false` |
 | io_engine.&ZeroWidthSpace;interruptMode.&ZeroWidthSpace;nvmeIoQueuePollPeriod | NVMe I/O queue poll period (SPDK NVME_IOQ_POLL_PERIOD). A value of "0" disables timed polling (busy poll). Typical values: "100us", "1000us". Higher values reduce CPU further at the cost of latency. | `"100us"` |
 | io_engine.&ZeroWidthSpace;logLevel | Log level for the io-engine service | `"info"` |
-| io_engine.&ZeroWidthSpace;nodeSelector | Node selectors to designate storage nodes for diskpool creation Note that if multi-arch images support 'kubernetes.io/arch: amd64' should be removed. | <pre>{<br>"kubernetes.io/arch":"amd64",<br>"openebs.io/engine":"mayastor"<br>}</pre> |
+| io_engine.&ZeroWidthSpace;nodeSelector | Node selectors to designate storage nodes for diskpool creation The images are built for amd64 and arm64, so no architecture is selected here. | <pre>{<br>"openebs.io/engine":"mayastor"<br>}</pre> |
 | io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;ioTimeout | Timeout for IOs The default here is exaggerated for local disks, but we've observed that in shared virtual environments having a higher timeout value is beneficial. Please adjust this according to your hardware and needs. | `"110s"` |
 | io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;rdma.&ZeroWidthSpace;bufCacheSize | The number of shared buffers to reserve for each poll group | `nil` |
 | io_engine.&ZeroWidthSpace;nvme.&ZeroWidthSpace;rdma.&ZeroWidthSpace;dataWrPoolSize | RDMA data WR pool size (RDMA only) | `"4095"` |
@@ -370,7 +370,7 @@ Each Secret must contain `tls.crt`, `tls.key`, and `ca.crt` keys.
 | loki.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;minio.&ZeroWidthSpace;basePath | Host path where local minio data is stored in. | `"/var/local/{{ .Release.Name }}/localpv-hostpath/minio"` |
 | loki.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;minio.&ZeroWidthSpace;reclaimPolicy | ReclaimPolicy of minio's localpv hostpath storage class. | `"Delete"` |
 | loki.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;minio.&ZeroWidthSpace;volumeBindingMode | VolumeBindingMode of minio's localpv hostpath storage class. | `"WaitForFirstConsumer"` |
-| nodeSelector | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ Note that if multi-arch images support 'kubernetes.io/arch: amd64' should be removed and set 'nodeSelector' to empty '{}' as default value. | <pre>{<br>"kubernetes.io/arch":"amd64"<br>}</pre> |
+| nodeSelector | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ The images are built for amd64 and arm64, so no architecture is selected here. To confine the pods to one, set e.g. 'kubernetes.io/arch: arm64'. | <pre>{<br><br>}</pre> |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;enabled | Enable callhome | `true` |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;logLevel | Log level for callhome | `"info"` |
 | obs.&ZeroWidthSpace;callhome.&ZeroWidthSpace;nodeSelector | Set nodeSelector, overrides global | <pre>{<br><br>}</pre> |

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -94,10 +94,9 @@ security:
 
 # -- Node labels for pod assignment
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-# Note that if multi-arch images support 'kubernetes.io/arch: amd64'
-# should be removed and set 'nodeSelector' to empty '{}' as default value.
-nodeSelector:
-  kubernetes.io/arch: amd64
+# The images are built for amd64 and arm64, so no architecture is selected here.
+# To confine the pods to one, set e.g. 'kubernetes.io/arch: arm64'.
+nodeSelector: {}
 
 # -- Pod scheduling priority.
 # Setting this value will apply to all components except the external Chart dependencies.
@@ -656,11 +655,9 @@ io_engine:
   # Example: --set='io_engine.coreList={30,31}'
   coreList: [ ]
   # -- Node selectors to designate storage nodes for diskpool creation
-  # Note that if multi-arch images support 'kubernetes.io/arch: amd64'
-  # should be removed.
+  # The images are built for amd64 and arm64, so no architecture is selected here.
   nodeSelector:
     openebs.io/engine: mayastor
-    kubernetes.io/arch: amd64
   resources:
     limits:
       # -- Cpu limits for the io-engine

--- a/tests/bdd/features/test_upgrade.py
+++ b/tests/bdd/features/test_upgrade.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import platform
 
 import common
 import pytest
@@ -20,6 +21,13 @@ logger = logging.getLogger(__name__)
 helm = HelmReleaseClient()
 
 
+# The upgrade starts from the latest released chart, and no release so far ships
+# arm64 images, so there is nothing to upgrade from on an arm64 host. Drop this
+# once a release with arm64 images is out.
+@pytest.mark.skipif(
+    platform.machine() in ("aarch64", "arm64"),
+    reason="no released chart has arm64 images to upgrade from",
+)
 @scenario("upgrade.feature", "Upgrading to the local chart as v-next")
 def test_upgrade_to_vnext():
     """Upgrading to the local chart as v-next."""


### PR DESCRIPTION
    ci(k8s): run the kind tests on arm64 as well as x86
    
    The k8s CI job now runs on a runner matrix of x86 and arm64. With
    helm-pins it stays x86 only: the pinned chart is architecture
    independent and is pushed once.
    
    The upgrade test is skipped on arm64 hosts: it upgrades from the latest
    released chart, and no release ships arm64 images yet.

---

    feat(chart): stop pinning pods to amd64 nodes
    
    The default nodeSelector, and io_engine's, no longer set
    kubernetes.io/arch to amd64: the images are built for amd64 and arm64.
    A nodeSelector cannot express an OR, so this admits any architecture;
    set kubernetes.io/arch explicitly to confine the pods to one.
