### PR TITLE
feat(etcd): add script to migrate mayastor etcd onto labelled nodes

### DIFF
--- a/scripts/k8s/migrate-etcd-to-labelled-nodes/README.md
+++ b/scripts/k8s/migrate-etcd-to-labelled-nodes/README.md
@@ -1,0 +1,312 @@
+# migrate-mayastor-etcd.sh
+
+:warning: This tool performs a **destructive** operation on the etcd cluster that holds the Mayastor
+control plane's entire persistent state — the record of every volume, replica, nexus and pool. It
+destroys and rebuilds one member at a time on purpose. Read this file before running it.
+
+## Overview
+
+Moves the members of the Mayastor etcd StatefulSet onto a specific set of nodes, identified by a node
+label (`node/etcd.io=true` by default), one member at a time, with health and consistency gates
+between every step.
+
+### Why this is not just an affinity edit
+
+Changing `nodeAffinity` on the pod template is accepted by the API server but moves nothing:
+
+- **Pods only move when they are recreated.** Affinity lives in the pod template; existing pods keep
+  running until something deletes them.
+- **The volumes are pinned to their nodes.** etcd storage comes from `mayastor-etcd-localpv`, an
+  OpenEBS localpv **hostpath** StorageClass. Each PV is a directory on one node's filesystem and
+  carries `nodeAffinity` pinning it there. A recreated pod with the same PVC either goes back to the
+  original node, or — once the new affinity excludes that node — sits `Pending` forever with a
+  *volume node affinity conflict*.
+
+So the only way a member moves is: **remove it from etcd membership, destroy its PVC, delete the pod,
+and let it come back empty on a new node and re-sync from the leader.** The entire design of the
+script is about making each repetition safe and verifiable.
+
+## Prerequisites
+
+Apply these with helm **before** running the script. Under the `openebs` umbrella chart everything
+below nests under `mayastor:`.
+
+```yaml
+etcd:
+  nodeAffinityPreset:
+    type: hard
+    key: "node/etcd.io"
+    values: ["true"]
+  podAntiAffinityPreset: "hard"     # keep; do NOT set etcd.affinity
+  updateStrategy:
+    type: OnDelete
+  initialClusterState: "existing"
+```
+
+**`updateStrategy: OnDelete` is the safety model.** Under `RollingUpdate` the StatefulSet controller
+reacts to the template change on its own schedule: it deletes the highest ordinal, the replacement
+cannot schedule because its PVC is still pinned to the old node, the rollout stalls, and you are
+sitting at N-1 members with no plan. Under `OnDelete` the template change is inert until *you* delete
+a pod.
+
+Expect `.status.currentRevision != .status.updateRevision` for the duration. That is correct under
+`OnDelete`, not a fault.
+
+**`initialClusterState: "existing"` is the other half.** The bitnami entrypoint branches on
+`is_new_etcd_cluster`, which is true when `ETCD_INITIAL_CLUSTER_STATE=new` *and* the pod's own peer
+URL appears in `ETCD_INITIAL_CLUSTER` — i.e. true for every member of a fresh install. A member whose
+data directory we just destroyed would take that branch and **bootstrap a brand-new cluster over the
+keyspace**. Pinning the value to `existing` forces the `add_self_to_cluster` branch instead. Note the
+chart only emits the variable when `replicaCount > 1`.
+
+Remove `initialClusterState` after the migration. On a `helm upgrade` the chart already defaults it to
+`existing`, so dropping it changes nothing then — but leaving it pinned breaks a genuine from-scratch
+install later.
+
+### Do not cordon the old nodes
+
+`mayastor-etcd-localpv` has `reclaimPolicy: Delete`. When a PVC is deleted the localpv provisioner
+runs a cleanup pod **on the node hosting the directory**. A cordoned node cannot run it, leaving the
+PV `Released` and the etcd data directory orphaned on disk. The node affinity already does everything
+cordoning would.
+
+## Usage
+
+```bash
+# inspect only (default)
+NS=openebs STS=openebs-etcd ./migrate-mayastor-etcd.sh
+
+# move every member that is not yet on a labelled node, highest ordinal first
+NS=openebs STS=openebs-etcd DRY_RUN=false ./migrate-mayastor-etcd.sh
+
+# one member at a time, which is the recommended way
+NS=openebs STS=openebs-etcd DRY_RUN=false ONLY_ORDINAL=2 ./migrate-mayastor-etcd.sh
+```
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NS` | `mayastor` | namespace |
+| `STS` | `mayastor-etcd` | StatefulSet name |
+| `CN` | `etcd` | container name |
+| `LABEL_KEY` | `node/etcd.io` | target node label key |
+| `LABEL_VALUE` | `true` | target node label value |
+| `DRY_RUN` | `true` | **safe default**; set `false` to execute |
+| `SNAPSHOT` | `true` | take and verify a pre-migration snapshot |
+| `SNAPSHOT_DIR` | `./etcd-snapshots` | where it lands |
+| `ONLY_ORDINAL` | *(unset)* | restrict the run to a single ordinal |
+| `TIMEOUT_SEC` | `900` | bound on every wait loop |
+| `SLEEP_SEC` | `5` | poll interval |
+| `SETTLE_SEC` | `30` | quiet period after each move |
+| `MAX_RESCHEDULE_KICKS` | `6` | retries when a pod lands on an unlabelled node |
+| `ICS_OVERRIDE` | `false` | proceed without `initialClusterState=existing` |
+
+Exit codes: `1` preflight/usage, `5` timeout, `6` member remove failed, `24` health gate failed,
+`25` consistency violation, `30` repeatedly scheduled onto an unlabelled node.
+
+## What the gates check
+
+The health gate is deliberately stricter than a quorum check. A *deliberate* migration should never
+begin from a degraded cluster, whereas `replace-one-laggard.sh` exists precisely to remediate one.
+Every gate requires all expected members to be:
+
+- present and answering,
+- in the **same etcd cluster** (`cluster_id` identical, and identical to the one recorded at the
+  start of the run),
+- agreeing on **one** leader — every member must name the same one, not merely "a leader that is one
+  of ours", which a split brain would satisfy,
+- on one raft term,
+- converged on one revision, and never a revision *lower* than the starting one,
+- reporting an identical `endpoint hashkv`.
+
+The last one matters: equal revisions only say the members agree on how far they have got. Equal
+hashes say they are holding the same bytes. `cluster_id` changing, or the revision going backwards,
+are the signatures of a member having bootstrapped over the keyspace instead of rejoining it — the
+one failure this whole procedure exists to avoid — so both are hard stops (exit 25).
+
+## Notes for anyone modifying this
+
+- **Do not add `--cluster` to the etcdctl calls.** It discards `--endpoints` and rebuilds the list
+  from the member list, which has two consequences: the `exclude` argument becomes silently
+  ineffective, and every member's *second* advertised client URL — the load-balanced
+  `<release>-etcd.<ns>.svc` ClusterIP — joins the query and answers as whichever pod it happens to
+  route to. Explicit endpoints give exactly one row per pod and make exclusion real.
+- **`etcdctl endpoint status` exits non-zero if any endpoint fails but still prints results for the
+  ones that answered.** Do not throw that away with `|| return 1`; validate the JSON instead.
+- **Two number bases coexist in the log output, on purpose.** `member_id_for()` returns a
+  **hexadecimal** ID read straight from `member list` as text and feeds it to `member remove`, which
+  expects hex. The gates compare **decimal** IDs from `endpoint status -w json`. Routing the ID you
+  pass to `member remove` through JSON would expose it to the precision hazard below.
+- **`quote_bigints` is not decoration.** etcd member and cluster IDs are uint64 and routinely exceed
+  2^53; jq before 1.7 parses all numbers as IEEE doubles and silently rounds them. The observed IDs
+  on a real cluster included `16092638608179729187`, well past the limit.
+- **`set -e` interactions.** The script avoids `[[ ... ]] && cmd` and `((...)) && cmd` because a
+  false condition there returns non-zero and can terminate the script. Preserve the explicit
+  `if ...; then ...; fi` style.
+- **Both scripts are deliberately self-contained.** Do not replace the local `say`/`warn`/`die` with
+  `scripts/utils/log.sh`. These run against a live cluster, often from a jump host, and an operator
+  should be able to copy a single file and run it; sourcing anything from the repo breaks that. The
+  sibling `replace-lagging-etcd-member` script is self-contained for the same reason.
+- **A larger labelled pool than `replicaCount` is normal.** The cordon check counts *schedulable*
+  labelled nodes and only refuses when fewer than `replicaCount` remain; do not make it fail on any
+  cordoned node, or labelling a whole zone becomes unusable.
+- **Gate 2/3 is skipped under `DRY_RUN`, deliberately.** In a dry run the `member remove` is only
+  printed, so the post-removal membership the gate exists to check never exists. Evaluating it anyway
+  asks the survivors to agree on a leader drawn only from themselves while the member being moved is
+  still a voter — which fails outright whenever that member happens to be the **current leader**, and
+  passes misleadingly when it does not. Neither answer means anything.
+
+## Replica-count caveats
+
+Fault tolerance *during* the move is the quorum of the **remaining** members. At `replicaCount <= 2`
+there is none, and the script warns about it in preflight.
+
+On a 2-member cluster the migration causes a brief, unavoidable **write outage**. The bitnami
+entrypoint rejoins via `etcdctl member add` as a full voting member, not a learner, so membership
+goes 1 voter → 2 voters and quorum becomes 2 while the new member is still starting.
+
+Both replica counts were measured by sampling `endpoint status` every 2s through the move, on a
+3-worker and a 7-worker cluster, with the same result each time:
+
+| | `replicaCount: 2` | `replicaCount: 3` |
+|---|---|---|
+| membership across the move | 2 → 1 → 2 | 3 → 2 → 3 |
+| quorum while the member rejoins | 2 of 2 — **not met** | 2 of 3 — met |
+| samples with no leader / unreachable | **2** (~11s) | **0** |
+| raft term | advanced (re-election) | unchanged |
+| leader | changed | unchanged |
+
+The mechanism is the window between `member add` and the new member becoming live. At 3 replicas that
+intermediate state is 3 voters with 2 alive, which still has quorum; at 2 replicas it is 2 voters with
+1 alive, which does not.
+
+Mayastor tolerates the outage: the data path does not consult etcd per-IO, so published volumes keep
+serving — the writer workload recorded no gaps in either run. But volume create/delete/publish and
+pool operations fail while it lasts, and an extended quorum loss eventually trips the io-engine's
+`pstorRetries` bound (300 by default), after which a volume target self-shutdowns.
+
+Note also that on a 2-member cluster *any* etcd pod restart loses write quorum until it returns —
+including the rolling restart caused by reverting `updateStrategy` to `RollingUpdate` afterwards.
+That is inherent to `replicaCount: 2`, not to this procedure. At 3 replicas that same revert rolled
+two pods with zero unavailable samples.
+
+---
+
+# test-migration.sh
+
+End-to-end test for the above against a real cluster. It installs `openebs/openebs`, puts genuine
+Mayastor state into etcd (DiskPools, a 3-replica volume, a workload continuously writing to it),
+migrates etcd onto labelled nodes, and then proves nothing was lost.
+
+```bash
+./test-migration.sh all          # setup -> prepare -> migrate -> verify -> revert
+./test-migration.sh setup        # install + seed state
+./test-migration.sh prepare      # apply the helm prerequisites, assert no pod churn
+./test-migration.sh migrate      # dry run, then the real migration
+./test-migration.sh verify       # assertions only, safe to repeat
+./test-migration.sh revert       # back to RollingUpdate, then re-verify
+./test-migration.sh teardown     # remove everything it created
+```
+
+Exit code is 0 only if every assertion passed.
+
+### Cluster requirements
+
+- ≥ 3 worker nodes labelled `openebs.io/engine=mayastor`
+- hugepages configured and nvme kernel modules loaded on those workers
+- one spare unformatted block device per worker (`BLOCK_DEVICE`, default `/dev/sdb`)
+- `kubectl`, `helm`, `jq`, `yq` on the machine running the test
+
+### Knobs
+
+`CHART_VERSION` (4.2.0), `NS`/`REL` (openebs), `ETCD_REPLICAS` (2), `LABEL_KEY`/`LABEL_VALUE`,
+`BLOCK_DEVICE`, `TEST_NS`/`TEST_SC`/`TEST_PVC`/`TEST_APP`, `REUSE_INSTALL`, `WORKDIR`,
+`MIGRATE_SCRIPT`, `PATCH_DEAD_IMAGES`, `ETCD_TOLERATE_CONTROL_PLANE`, `EXTRA_LABELLED`.
+
+`EXTRA_LABELLED=N` labels N nodes beyond the minimum, so the run exercises a larger labelled pool
+with the scheduler free to pick a destination — closer to how this gets used in practice than the
+exact fit the test otherwise sets up. The source node is never among them, so ordinal 0 still has to
+move.
+
+`setup` picks which nodes to label automatically: it labels the node of every member **except ordinal
+0**, plus one node hosting no member at all. That is exactly `ETCD_REPLICAS` labelled nodes — which is
+what `podAntiAffinityPreset: hard` requires — and leaves exactly one member to move. Leaving ordinal 0
+as the one that moves is deliberate: it is the member whose bootstrap semantics could destroy the
+keyspace if `initialClusterState` were wrong, so it is the most informative one to rebuild.
+
+### The node pool has to be bigger than the replica count
+
+There must be somewhere to move a member *to*. With hard anti-affinity a member cannot double up on a
+node that already has one, so the pool of nodes etcd may occupy must be **strictly larger** than
+`ETCD_REPLICAS`. On a cluster with three workers this is automatic at `ETCD_REPLICAS=2` and impossible
+at `ETCD_REPLICAS=3`.
+
+`ETCD_TOLERATE_CONTROL_PLANE=true` brings the control-plane node into the pool and gives etcd a
+matching `NoSchedule` toleration, which is enough to make the 3-replica case testable on a 3-worker
+cluster:
+
+```bash
+ETCD_REPLICAS=3 ETCD_TOLERATE_CONTROL_PLANE=true ./test-migration.sh all
+```
+
+Leave it off wherever there are genuinely spare workers. DiskPools are unaffected either way — they
+only ever live on the mayastor workers.
+
+### What it asserts
+
+| # | Assertion |
+|---|---|
+| 1 | `cluster_id` unchanged from the baseline and identical across members |
+| 2 | every member reachable |
+| 3 | one leader, one raft term, one revision |
+| 4 | revision moved forward, never backwards |
+| 5 | all members report the same `endpoint hashkv` |
+| 6 | every key present at baseline is still present |
+| 7 | every member on a labelled node |
+| 8 | members on distinct nodes (anti-affinity honoured) |
+| 9 | no `Released`/`Failed` etcd PVs |
+| 10 | the writer pod never restarted and its data has no sequence gaps |
+| 11 | the control plane can still provision a **new** volume (etcd is usable, not merely intact) |
+| 12 | all `openebs` pods ready, all DiskPools Online |
+
+`prepare` additionally asserts that the helm upgrade causes **zero** etcd pod churn, which is the
+observable proof that `OnDelete` took effect.
+
+### Dead upstream images
+
+`openebs/openebs` 4.2.0 references two images Docker Hub no longer serves, because Bitnami retired
+their legacy tags in August 2025:
+
+| Chart reference | Status | Replacement used by the test |
+|---|---|---|
+| `docker.io/bitnami/etcd:3.5.6-debian-11-r10` | 404 | `docker.io/openebs/etcd:3.5.6-debian-11-r10` |
+| `docker.io/bitnami/kubectl:1.25.15` (chart `pre-upgrade` hook Job) | 404 | `docker.io/bitnamilegacy/kubectl:1.25.15` |
+
+Without the second one, **every `helm upgrade` hangs** on the pre-upgrade hook — which is fatal here,
+since applying and reverting the migration prerequisites are both upgrades. `test-migration.sh`
+applies both overrides by default; set `PATCH_DEAD_IMAGES=false` once the chart itself is fixed.
+
+### `--dry-run` will always show a `checksum/token-secret` diff on the first upgrade
+
+The etcd subchart annotates the pod template with a checksum of its JWT token Secret, and the helper
+that renders that Secret uses `lookup` to preserve an existing key. Plain `helm upgrade --dry-run`
+cannot perform lookups, so it generates a fresh RSA key and reports a spurious checksum change.
+
+On the first real upgrade after install the checksum *does* change once — the install-time render had
+no Secret to look up — but the Secret's key material is preserved (verified by comparing its sha256
+before and after), and the value is stable across every subsequent upgrade. Under `OnDelete` the
+change is inert. Do not stop on it.
+
+### Teardown ordering
+
+Two orderings in `teardown` are load-bearing and were both found the hard way:
+
+1. **Every Mayastor volume must be gone — PV reclaimed, not merely PVC deleted — before the
+   DiskPools are deleted.** A DiskPool carries an `openebs.io/diskpool-protection` finalizer and sits
+   in `Terminating` indefinitely while any replica still lives on it.
+2. **The StatefulSets must be deleted, then their retained PVCs, and only then `helm uninstall`.**
+   This is a three-way squeeze: a PVC cannot be deleted while a pod still mounts it
+   (`pvc-protection`); the etcd and loki pods only go away when their StatefulSets do; but
+   `helm uninstall` — the obvious way to remove the StatefulSets — *also* deletes the localpv
+   provisioner, and without it nothing reclaims the hostpath PVs or removes the directories. Deleting
+   the StatefulSets by hand first breaks the cycle. Get this wrong and you are left with `Released`
+   PVs and tens of megabytes of orphaned etcd data on every node.

--- a/scripts/k8s/migrate-etcd-to-labelled-nodes/WHAT-IT-DOES.md
+++ b/scripts/k8s/migrate-etcd-to-labelled-nodes/WHAT-IT-DOES.md
@@ -1,0 +1,329 @@
+# What `migrate-mayastor-etcd.sh` does to your cluster
+
+It moves the Mayastor etcd members onto nodes you have labelled, **one member at a time**. Each move
+destroys that member's data and rebuilds it from the others. The etcd keyspace holds the record of
+every volume, replica, pool and nexus, so the script is built around refusing to take the next step
+until the cluster has proved it is healthy.
+
+Read this before running it. The `README.md` next door has the reasoning and the knobs.
+
+---
+
+## Versions
+
+| Component | Version |
+|---|---|
+| openebs umbrella chart | 4.2.0 |
+| mayastor subchart | 2.8.0 |
+| bitnami etcd subchart | 8.6.0 |
+| etcd | 3.5.6 |
+| etcd image | `docker.io/openebs/etcd:3.5.6-debian-11-r10` |
+| Kubernetes (verified on) | v1.35.6 |
+
+Verified end-to-end at `replicaCount` **2** and **3**, on a 3-worker and a 7-worker cluster (four runs,
+44 assertions each, all passing). Preflight warns on any other etcd chart major, because the bootstrap
+semantics it depends on are specific to this one.
+
+> `docker.io/bitnami/etcd:3.5.6-debian-11-r10` and `docker.io/bitnami/kubectl:1.25.15` (the chart's
+> `pre-upgrade` hook) now return **404** — Bitnami retired those tags. Use `openebs/etcd` and
+> `bitnamilegacy/kubectl`, or every `helm upgrade` will hang.
+
+---
+
+## Why a plain affinity edit does not work
+
+- Affinity lives in the pod template, so **nothing moves until a pod is recreated**.
+- etcd storage is `mayastor-etcd-localpv` — a **hostpath** PV pinned to one node. A recreated pod
+  either returns to the old node, or sits `Pending` with a *volume node affinity conflict*.
+
+So a member can only move by being removed from etcd membership, having its PVC destroyed, and
+rejoining empty on the new node. That is what the script automates.
+
+---
+
+## Before you start
+
+**On your workstation:** `kubectl`, `helm`, `jq`, `awk`, `sed`, and **bash 4+** (macOS ships bash 3.2 —
+use `brew install bash`). The script exits immediately if any are missing.
+
+**Find your names.** The script defaults to namespace `mayastor` / StatefulSet `mayastor-etcd`; an
+umbrella-chart install is usually `openebs` / `openebs-etcd`.
+
+```bash
+helm list -A
+kubectl get sts -A -l app.kubernetes.io/name=etcd
+```
+
+**Label your destination nodes** — you need at least `replicaCount` of them, because
+`podAntiAffinityPreset: hard` puts one member per node:
+
+```bash
+kubectl label node <node-a> <node-b> <node-c> node/etcd.io=true
+kubectl get nodes -L node/etcd.io
+```
+
+`node/etcd.io=true` is only the default. **Any valid label key and value works** — set `LABEL_KEY`
+and `LABEL_VALUE` and use the same pair in the helm values below. They must match, or preflight
+refuses to run:
+
+```bash
+export LABEL_KEY=storage.example.com/etcd-tier LABEL_VALUE=primary
+kubectl label node <node-a> <node-b> <node-c> "$LABEL_KEY=$LABEL_VALUE"
+```
+
+Labelling **more** nodes than you have members is fine and is the usual case — label a rack or a
+zone and let the scheduler choose. Preflight only requires that at least `replicaCount` labelled nodes
+are *schedulable*; cordoned ones in a larger pool are reported and skipped rather than being treated
+as an error.
+
+Destination nodes need room for a 2 GiB hostpath volume under
+`/var/local/<release>/localpv-hostpath/etcd`, and any `NoSchedule` taint needs a matching
+`etcd.tolerations`.
+
+**Know where you are moving from.** Every member not already on a labelled node gets rebuilt. If you
+label the nodes members are already on plus one spare, only one member moves.
+
+---
+
+## Two helm values you must apply first
+
+```yaml
+etcd:
+  # key/values must match LABEL_KEY / LABEL_VALUE
+  nodeAffinityPreset: { type: hard, key: "node/etcd.io", values: ["true"] }
+  podAntiAffinityPreset: "hard"     # keep; do NOT set etcd.affinity
+  updateStrategy: { type: OnDelete }
+  initialClusterState: "existing"
+```
+
+- **`OnDelete`** stops the StatefulSet controller from recycling pods on its own schedule into PVCs
+  still pinned to the old nodes. The script refuses to run without it.
+- **`initialClusterState: "existing"`** stops a member with a freshly-emptied data directory from
+  deciding it is a brand-new cluster and **bootstrapping over the keyspace**. This is the single most
+  important value on the page. Remove it after the migration.
+
+Applying these should restart **nothing**. If pods cycle, `OnDelete` did not take effect — stop.
+
+Put them in whatever values file you already manage the release with; do not hand-patch the
+StatefulSet. Two helm traps worth knowing:
+
+- **Do not set `etcd.affinity` directly.** It replaces all three presets at once, including the
+  anti-affinity — which, with node-pinned hostpath PVs, is how you end up with two members on one
+  node. Use `nodeAffinityPreset`.
+- **Helm replaces lists, it does not merge them.** If you override `etcd.extraEnvVars` you must
+  re-include Mayastor's `ETCD_QUOTA_BACKEND_BYTES: "8589934592"`, or you silently reset the backend
+  quota.
+
+---
+
+## Running it
+
+```bash
+chmod +x migrate-mayastor-etcd.sh
+export NS=openebs STS=openebs-etcd          # your names, from above
+
+# 1. Dry run. Changes nothing; runs the full preflight and prints the planned moves.
+./migrate-mayastor-etcd.sh 2>&1 | tee dryrun.log
+
+# 2. Move ONE member and watch it. This is the recommended way.
+#    Start at the HIGHEST ordinal: 2 on a 3-member cluster, 1 on a 2-member one.
+DRY_RUN=false ONLY_ORDINAL=2 ./migrate-mayastor-etcd.sh 2>&1 | tee move-2.log
+
+# 3. Once you are happy, the rest. Work downwards; ordinal 0 goes last.
+DRY_RUN=false ONLY_ORDINAL=1 ./migrate-mayastor-etcd.sh 2>&1 | tee move-1.log
+DRY_RUN=false ONLY_ORDINAL=0 ./migrate-mayastor-etcd.sh 2>&1 | tee move-0.log
+
+#    ...or let it do every remaining member in that order, unattended:
+DRY_RUN=false ./migrate-mayastor-etcd.sh 2>&1 | tee move-rest.log
+```
+
+Ordinal 0 goes last on purpose: it is the member whose bootstrap semantics could destroy the keyspace
+if `initialClusterState` were wrong, so you want the procedure to have proved itself first.
+
+`DRY_RUN=false` gives you a **10-second abort window** before anything is touched. A whole run takes
+roughly 3–4 minutes per member; most of that is the pod being rescheduled and rejoining.
+
+Keep a second terminal on it:
+
+```bash
+watch -n2 'kubectl -n openebs get pods -o wide -l app.kubernetes.io/name=etcd; \
+           kubectl -n openebs get pvc; kubectl get pv | grep -E "etcd|Released|Failed"'
+```
+
+Expect to see, per member: the pod disappear, its PVC and PV disappear, a new PVC bind, and the pod
+return on a labelled node. A pod sitting `Pending` for a few seconds while its new volume is
+provisioned is normal.
+
+### Settings
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NS` / `STS` / `CN` | `mayastor` / `mayastor-etcd` / `etcd` | namespace, StatefulSet, container |
+| `LABEL_KEY` / `LABEL_VALUE` | `node/etcd.io` / `true` | the node label to migrate onto |
+| `DRY_RUN` | `true` | **safe default**; `false` to execute |
+| `ONLY_ORDINAL` | *(unset)* | restrict the run to one member |
+| `SNAPSHOT` / `SNAPSHOT_DIR` | `true` / `./etcd-snapshots` | pre-migration backup |
+| `TIMEOUT_SEC` / `SLEEP_SEC` / `SETTLE_SEC` | `900` / `5` / `30` | wait bound, poll interval, quiet period |
+| `MAX_RESCHEDULE_KICKS` | `6` | retries if a pod lands on an unlabelled node |
+| `ICS_OVERRIDE` | `false` | proceed without `initialClusterState=existing` — **don't** |
+
+---
+
+## What it does, per member
+
+Highest ordinal first, so `etcd-0` — the riskiest to rebuild — goes last. Members already on a
+labelled node are skipped, so re-running it is safe.
+
+1. **Gate 1** — whole cluster healthy and converged. Nothing happens if it is not.
+2. `etcdctl member remove <member>` via a *different* pod.
+3. **Gate 2** — the **remaining** members are healthy. Nothing is deleted until this passes.
+4. Delete the PVC, then the pod. (The StatefulSet controller will not recreate the pod while its PVC
+   is terminating, which is what stops it rebinding the old node-pinned PV.)
+5. Wait for the old PVC to actually be gone. (The localpv provisioner then removes the hostpath
+   directory on the vacated node asynchronously — check for leftovers afterwards.)
+6. Wait for the pod to come back **Ready on a labelled node**.
+7. **Gate 3** — all members healthy, converged, holding identical data.
+8. Re-check the keyspace against the census taken at the start, then settle 30s.
+
+Before any of that: a **snapshot** is taken and validated with `etcdctl snapshot status` (not just a
+size check), and a census of every key is recorded.
+
+---
+
+## Availability — what breaks, and for how long
+
+Measured by sampling `endpoint status` every 2s through a real move, reproduced on both clusters:
+
+| | `replicaCount: 3` | `replicaCount: 2` |
+|---|---|---|
+| membership across the move | 3 → 2 → 3 | 2 → 1 → 2 |
+| quorum while the member rejoins | 2 of 3 — held | 2 of 2 — **not met** |
+| etcd write outage | **none observed** | **~11s** |
+| raft term / leader | unchanged | re-election |
+
+The window exists because bitnami rejoins a member with `member add` as a **full voter, not a
+learner**: quorum rises before the new member is live. At 3 replicas there is still a majority
+without it; at 2 there is not.
+
+**What keeps working regardless:** the Mayastor data path does not consult etcd per-IO, so already-published
+volumes keep serving. In both test runs a pod writing continuously to a 3-replica volume recorded
+**zero gaps** and never restarted.
+
+**What fails while quorum is lost:** volume create/delete/publish/unpublish, pool operations, rebuild
+orchestration. Sustained quorum loss eventually exhausts the io-engine's `pstorRetries` (default 300),
+after which a volume target self-shutdowns — so a stuck migration is urgent, not merely degraded.
+
+At `replicaCount: 2` **any** etcd pod restart loses write quorum — including the rolling restart when
+you later revert `updateStrategy` to `RollingUpdate`. That is inherent to running 2 members.
+
+---
+
+## Consistency — what the gates actually check
+
+Every gate requires **all** expected members to be:
+
+- present and answering, and reporting **healthy**;
+- in the **same etcd cluster** — `cluster_id` identical across members *and* identical to the one
+  recorded before the first move;
+- naming the **same leader** (not merely "a leader that is one of ours", which a split brain
+  satisfies);
+- on one raft term;
+- converged on one revision, never **lower** than the starting revision;
+- reporting an identical `endpoint hashkv`, pinned to the agreed revision.
+
+The last one matters: equal revisions only prove the members agree on *how far* they have got. Equal
+hashes prove they hold *the same bytes*.
+
+**Two things are treated as unrecoverable and stop the run immediately (exit 25):**
+`cluster_id` changing, and the revision going backwards. Both are the signature of a member having
+bootstrapped over the keyspace instead of rejoining it — the exact failure this procedure exists to
+avoid.
+
+This is stricter than a quorum check on purpose. A deliberate migration should never *begin* from a
+degraded cluster.
+
+---
+
+## What is verified, and when
+
+| When | Check |
+|---|---|
+| Preflight | `OnDelete` set; `nodeAffinity` references your label; `podAntiAffinity` intact; `ETCD_INITIAL_CLUSTER_STATE=existing`; StorageClass is `WaitForFirstConsumer` + `Delete`; enough labelled, uncordoned nodes; cluster healthy |
+| Before first move | snapshot taken **and** validated; `cluster_id`, revision and full key list recorded |
+| Between every step | Gates 1–3 above |
+| After each move | every key from the census still present |
+| End of run | final health gate, final key census, placement printed |
+
+Afterwards, confirm yourself: all members on labelled nodes, `kubectl get pv` shows no
+`Released`/`Failed`, and the vacated nodes' hostpath directories are gone.
+
+`test-migration.sh` next door automates all of this against a throwaway cluster, including a workload
+whose data is checked for gaps and a fresh volume provisioned afterwards to prove etcd is *usable*,
+not merely intact.
+
+---
+
+## Things it will not do
+
+- **Run destructively by default.** `DRY_RUN=true` unless you say otherwise, plus a 10s abort window.
+- **Touch a second member** before the first has fully rejoined and converged.
+- **Proceed past a failed gate.** It stops and tells you what it saw.
+- **Cordon anything.** With `reclaimPolicy: Delete` the localpv cleanup pod must run *on the vacated
+  node*; cordoning it strands the PV and leaves etcd data on disk. Do not cordon them yourself.
+
+Exit codes: `1` preflight · `5` timeout · `6` member remove failed · `24` health gate failed ·
+`25` **consistency violation** · `30` pod keeps landing on an unlabelled node.
+
+---
+
+## If it stops
+
+It stops on purpose. The exit code tells you how worried to be.
+
+| Exit | Meaning | What to do |
+|---|---|---|
+| `1` | preflight failed | It names the missing prerequisite. Nothing was touched. |
+| `5` | timed out waiting | Usually a pod that cannot schedule. Check `kubectl describe pod`. |
+| `6` | `member remove` failed | Membership is unchanged. Check `etcdctl member list`. |
+| `24` | a health gate failed | The cluster was not healthy *before* the destructive step, or did not recover after one. Capture state; do not re-run blindly. |
+| `25` | **consistency violation** | `cluster_id` changed or the revision went backwards. **Stop everything and escalate.** You have the snapshot. |
+| `30` | pod keeps landing on an unlabelled node | The pod template's `nodeAffinity` is not what preflight thought. |
+
+Common situations:
+
+- **New pod `Pending`, *volume node affinity conflict*** — it rebound the old node-pinned PV. The
+  script re-deletes the pod up to `MAX_RESCHEDULE_KICKS` times by itself. If it still exits 30, fix
+  the affinity rather than the pod.
+- **PVC stuck `Terminating`** — the `pvc-protection` finalizer holds it until no pod uses it. Check the
+  pod is really gone, and that the vacated node is not cordoned or `NotReady` (the localpv cleanup pod
+  has to run *there*). **Do not remove finalizers by hand** — that orphans the PV and leaves data on disk.
+- **Revisions never converge** — check the new member's logs for a slow snapshot transfer. Raise
+  `TIMEOUT_SEC` only after confirming the revision is actually climbing between samples.
+- **Quorum lost** — urgent, not merely degraded. See the availability section above.
+
+Capture this before asking anyone for help (`$HEALTHY` = any member that is still up — not the one
+being moved):
+
+```bash
+kubectl -n $NS get pods -o wide -l app.kubernetes.io/name=etcd
+kubectl -n $NS get pvc; kubectl get pv
+kubectl -n $NS describe pod <the-problem-pod> | tail -40
+kubectl -n $NS logs <the-problem-pod> -c etcd --tail=200
+kubectl -n $NS logs <the-problem-pod> -c etcd --previous --tail=200 2>/dev/null
+kubectl -n $NS get events --sort-by=.lastTimestamp | tail -40
+kubectl -n $NS exec $HEALTHY -c etcd -- etcdctl member list -w table
+kubectl -n $NS exec $HEALTHY -c etcd -- etcdctl endpoint status --cluster -w table
+```
+
+**Do not improvise recovery.** `etcdctl member remove`, `--force-new-cluster`, deleting PVCs, or
+`helm rollback` run by hand mid-procedure will make a recoverable situation much worse.
+
+---
+
+## Afterwards
+
+Revert `updateStrategy` to `RollingUpdate` and drop `initialClusterState`. Keep
+`nodeAffinityPreset`/`podAntiAffinityPreset`. Leaving `initialClusterState: "existing"` pinned will
+break a genuine from-scratch install later.
+
+Keep the pre-migration snapshot.

--- a/scripts/k8s/migrate-etcd-to-labelled-nodes/migrate-mayastor-etcd.sh
+++ b/scripts/k8s/migrate-etcd-to-labelled-nodes/migrate-mayastor-etcd.sh
@@ -1,0 +1,907 @@
+#!/usr/bin/env bash
+#
+# migrate-mayastor-etcd.sh
+#
+# Relocate the members of the Mayastor etcd StatefulSet onto a labelled set of
+# nodes, ONE MEMBER AT A TIME, with quorum/health/consistency gates between
+# every step.
+#
+# Verified against openebs/openebs 4.2.0 (mayastor 2.8.0, bitnami etcd subchart
+# 8.6.0, etcd 3.5.6) with replicaCount=2 and replicaCount=3. The assumptions it
+# relies on are asserted in preflight(), not just documented here:
+#
+#   * etcd runs as StatefulSet <release>-etcd with ordinal pods and a
+#     <release>-etcd-headless service; member name == pod name.
+#   * auth.rbac.create=false / allowNoneAuthentication=true, so etcdctl needs
+#     no credentials.
+#   * removeMemberOnContainerTermination=false. Mayastor disables the PreStop
+#     hook, so NOTHING removes membership for you. Deleting a pod+PVC without
+#     an explicit `member remove` leaves a member whose ID no longer matches
+#     its (now empty) data dir -> cluster ID mismatch -> CrashLoopBackOff.
+#     That is why step 2 of each move is a manual member remove.
+#   * persistence via mayastor-etcd-localpv: hostpath, WaitForFirstConsumer,
+#     reclaimPolicy Delete. The PV is pinned to its node, so a member cannot
+#     move without destroying its PVC. WaitForFirstConsumer is what lets the
+#     scheduler pick the new node before the volume is provisioned.
+#   * podAntiAffinityPreset=hard, so you need at least replicaCount
+#     schedulable labelled nodes.
+#
+# PREREQUISITE -- apply this with helm BEFORE running the script. For the
+# openebs umbrella chart everything below nests under `mayastor:`.
+#
+#   etcd:
+#     nodeAffinityPreset:
+#       type: hard
+#       key: "node/etcd.io"
+#       values: ["true"]
+#     podAntiAffinityPreset: "hard"     # keep; do not set etcd.affinity
+#     updateStrategy:
+#       type: OnDelete
+#     initialClusterState: "existing"
+#
+# OnDelete is the entire safety model. Under RollingUpdate the StatefulSet
+# controller recycles pods on its own schedule into PVCs pinned to the old
+# nodes, stalls, and leaves you degraded. This script refuses to run without
+# it.
+#
+# initialClusterState is the other half. The bitnami entrypoint branches on
+# `is_new_etcd_cluster`, which is true when ETCD_INITIAL_CLUSTER_STATE=new and
+# the pod's own peer URL appears in ETCD_INITIAL_CLUSTER -- i.e. true for every
+# member of a fresh install. A member whose data directory we just destroyed
+# would take that branch and bootstrap a brand-new cluster over the keyspace.
+# Pinning the value to "existing" forces the `add_self_to_cluster` branch
+# instead. The chart only emits the variable when replicaCount > 1.
+#
+# DO NOT CORDON THE OLD NODES. With reclaimPolicy=Delete the localpv
+# provisioner runs a cleanup pod on the vacated node to remove the hostpath
+# directory. A cordoned node cannot run it, leaving Released PVs and orphaned
+# etcd data. The node affinity already does the job cordoning would.
+#
+# Usage:
+#   DRY_RUN=true  ./migrate-mayastor-etcd.sh     # default: inspect only
+#   DRY_RUN=false ./migrate-mayastor-etcd.sh     # actually move members
+#   DRY_RUN=false ONLY_ORDINAL=2 ./migrate-mayastor-etcd.sh   # one at a time
+#
+# Exit codes:
+#   1  preflight / usage failure
+#   5  timed out waiting for a pod or for resync
+#   6  member remove failed
+#   24 health gate failed
+#   25 consistency violation -- cluster identity or keyspace changed under us
+#   30 pod repeatedly scheduled onto an unlabelled node
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------- config ----
+
+NS="${NS:-mayastor}"                       # namespace holding the StatefulSet
+STS="${STS:-mayastor-etcd}"                # StatefulSet name
+CN="${CN:-etcd}"                           # container name inside the pods
+LABEL_KEY="${LABEL_KEY:-node/etcd.io}"     # node label key to migrate onto
+LABEL_VALUE="${LABEL_VALUE:-true}"         # node label value
+
+TIMEOUT_SEC="${TIMEOUT_SEC:-900}"          # bound on every wait loop
+SLEEP_SEC="${SLEEP_SEC:-5}"                # poll interval
+SETTLE_SEC="${SETTLE_SEC:-30}"             # quiet period after each move
+MAX_RESCHEDULE_KICKS="${MAX_RESCHEDULE_KICKS:-6}"
+
+DRY_RUN="${DRY_RUN:-true}"                 # SAFE DEFAULT: change nothing
+SNAPSHOT="${SNAPSHOT:-true}"               # take an etcd snapshot first
+SNAPSHOT_DIR="${SNAPSHOT_DIR:-./etcd-snapshots}"
+ONLY_ORDINAL="${ONLY_ORDINAL:-}"           # restrict to a single ordinal
+ICS_OVERRIDE="${ICS_OVERRIDE:-false}"      # proceed without initialClusterState
+
+REPLICAS=0
+declare -a PODS=()
+declare -a LABELLED=()
+
+# Cluster identity and keyspace census, captured once before the first move and
+# re-asserted after every step. BASE_CLUSTER_ID changing, or BASE_REVISION going
+# backwards, is the signature of a member having bootstrapped over the keyspace
+# rather than rejoining it -- the one failure this whole procedure exists to
+# avoid. Neither can be explained away, so both are hard stops.
+BASE_CLUSTER_ID=""
+BASE_REVISION=""
+BASE_KEYS_FILE=""
+
+# --------------------------------------------------------------- helpers ----
+
+# Deliberately self-contained -- do NOT replace these with scripts/utils/log.sh.
+# This runs against a live cluster, often from a jump host, and an operator
+# should be able to copy the single file and run it. Sourcing anything from the
+# repo would make that fail. The sibling replace-lagging-etcd-member script is
+# self-contained for the same reason.
+#
+# The timestamps are not decoration either: the procedure is a sequence of
+# gated, destructive steps, and lining a gate up against `kubectl get events` or
+# a pod's restart time is how you work out what happened.
+say()  { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+warn() { printf '[%s] WARN  %s\n' "$(date +%H:%M:%S)" "$*" >&2; }
+die()  { printf '[%s] FATAL %s\n' "$(date +%H:%M:%S)" "$1" >&2; exit "${2:-1}"; }
+
+need_cmd() {
+  local c
+  for c in "$@"; do
+    if ! command -v "$c" >/dev/null 2>&1; then die "required command not found: $c"; fi
+  done
+}
+
+# Run a mutating command, or describe it under DRY_RUN.
+mutate() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    say "  DRY-RUN: would run: $*"
+    return 0
+  fi
+  "$@"
+}
+
+k() { kubectl -n "$NS" "$@"; }
+
+etcd_exec() {                              # <pod> <etcdctl args...>
+  local pod="$1"; shift
+  k exec "$pod" -c "$CN" -- env ETCDCTL_API=3 etcdctl \
+      --dial-timeout=5s --command-timeout=15s "$@"
+}
+
+ep_for() { printf 'http://%s.%s-headless.%s.svc.cluster.local:2379' "$1" "$STS" "$NS"; }
+
+eps_excluding() {                          # <pods to exclude...> -> CSV
+  local -a out=()
+  local p a skip
+  for p in "${PODS[@]}"; do
+    skip=0
+    for a in "$@"; do
+      if [[ -n "$a" && "$p" == "$a" ]]; then skip=1; fi
+    done
+    if (( skip )); then continue; fi
+    out+=("$(ep_for "$p")")
+  done
+  ( IFS=,; printf '%s' "${out[*]}" )
+}
+
+# The StatefulSet name lands inside both a jq regex and an awk regex. Release
+# names are DNS labels so only '-' and '.' can reach us, but '.' as a wildcard
+# would let <release>-etcd match <release>xetcd. Escape it rather than trust it.
+rx_quote() { printf '%s' "$1" | sed -e 's#[^a-zA-Z0-9_-]#\\&#g'; }
+
+# etcd member IDs and cluster IDs are uint64 and routinely exceed 2^53, which
+# jq (<1.7) mangles through double precision. Quote them into JSON strings
+# before jq parses, so equality comparisons stay exact.
+quote_bigints() {
+  sed -E 's/"(member_id|leader|cluster_id)":[[:space:]]*([0-9]+)/"\1":"\2"/g'
+}
+
+# etcdctl's `endpoint status`/`endpoint health` exit non-zero if ANY endpoint
+# failed, but still emit results for the ones that answered. Callers want the
+# partial answer -- the gates decide for themselves whether what came back is
+# enough -- so run the command, keep stdout, and drop the exit status.
+#
+# NOTE: deliberately NO `--cluster`. That flag discards --endpoints and rebuilds
+# the list from the member list, which here means (a) the exclude argument is
+# silently ignored and (b) every member's SECOND advertised client URL, the
+# load-balanced `<release>-etcd.<ns>.svc` ClusterIP, joins the query and answers
+# as whichever pod it happens to route to. Explicit endpoints give exactly one
+# row per pod and make exclusion real.
+etcdctl_soft() {                           # <pod> <etcdctl args...> -> stdout
+  local pod="$1"; shift
+  etcd_exec "$pod" "$@" 2>/dev/null || true
+}
+
+# Pick a pod that can answer etcdctl. Iterates highest ordinal first so that
+# ${STS}-0 -- the one with special bootstrap semantics in the bitnami
+# entrypoint -- is only used as a last resort.
+ctrl_pod() {                               # <pods to avoid...> -> pod name
+  local i p a skip phase
+  for (( i=${#PODS[@]}-1; i>=0; i-- )); do
+    p="${PODS[$i]}"
+    skip=0
+    for a in "$@"; do
+      if [[ -n "$a" && "$p" == "$a" ]]; then skip=1; fi
+    done
+    if (( skip )); then continue; fi
+    phase="$(k get pod "$p" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+    if [[ "$phase" != "Running" ]]; then continue; fi
+    if etcd_exec "$p" endpoint status -w json >/dev/null 2>&1; then
+      printf '%s' "$p"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# One TSV row per reachable member:
+#   <pod> <member_id> <revision> <term> <leader_id> <cluster_id>
+cluster_view() {                           # <ctrl_pod> [exclude_pod]
+  local pod="$1" exclude="${2:-}" json eps sts_rx
+  eps="$(eps_excluding "$exclude")"
+  if [[ -z "$eps" ]]; then return 1; fi
+  json="$(etcdctl_soft "$pod" --endpoints="$eps" endpoint status -w json)"
+  if [[ -z "$json" ]]; then return 1; fi
+  if ! printf '%s' "$json" | jq -e 'type=="array" and length>0' >/dev/null 2>&1; then
+    return 1
+  fi
+  sts_rx="$(rx_quote "$STS")"
+  printf '%s' "$json" | quote_bigints | jq -r --arg sts "$sts_rx" '
+    .[]
+    | select(.Endpoint | test("//\($sts)-[0-9]+\\."))
+    | [ (.Endpoint | capture("//(?<p>[^.:/]+)\\.").p),
+        (.Status.header.member_id // "0"),
+        ((.Status.header.revision // 0) | tostring),
+        (((.Status.header.raft_term // .Status.raftTerm) // 0) | tostring),
+        (.Status.leader // "0"),
+        (.Status.header.cluster_id // "0") ]
+    | @tsv'
+}
+
+# Pod names whose endpoint reports healthy. Pod names are unique, so matching
+# on the hostname in the endpoint URL deduplicates implicitly.
+healthy_pods() {                           # <ctrl_pod> [exclude_pod]
+  local pod="$1" exclude="${2:-}" out eps sts_rx
+  eps="$(eps_excluding "$exclude")"
+  if [[ -z "$eps" ]]; then return 0; fi
+  out="$(etcd_exec "$pod" --endpoints="$eps" endpoint health 2>&1 || true)"
+  sts_rx="$(rx_quote "$STS")"
+  printf '%s\n' "$out" | awk -v sts="$sts_rx" '
+    /is healthy/ {
+      if (match($0, "//" sts "-[0-9]+\\.")) print substr($0, RSTART+2, RLENGTH-3)
+    }'
+}
+
+# <pod> <hash> <compact_revision> per member. Two members that agree on the
+# revision but disagree here are not holding the same data, which no amount of
+# "healthy" reporting would tell you.
+#
+# The revision is pinned with --rev rather than letting each member hash
+# "whatever it holds right now". On a keyspace that is still being written --
+# which Mayastor's is, whenever volumes or pools are changing -- an unpinned
+# hash samples the two members microseconds apart and reports a mismatch that
+# means nothing. Pinning makes the comparison deterministic. Retention is 100
+# revisions, so the revision we just agreed on is never compacted away.
+keyspace_hashes() {                        # <ctrl_pod> <revision> [exclude_pod]
+  local pod="$1" rev="$2" exclude="${3:-}" json eps sts_rx
+  eps="$(eps_excluding "$exclude")"
+  if [[ -z "$eps" ]]; then return 1; fi
+  json="$(etcdctl_soft "$pod" --endpoints="$eps" endpoint hashkv --rev "$rev" -w json)"
+  if [[ -z "$json" ]]; then return 1; fi
+  if ! printf '%s' "$json" | jq -e 'type=="array" and length>0' >/dev/null 2>&1; then
+    return 1
+  fi
+  sts_rx="$(rx_quote "$STS")"
+  printf '%s' "$json" | jq -r --arg sts "$sts_rx" '
+    .[]
+    | select(.Endpoint | test("//\($sts)-[0-9]+\\."))
+    | [ (.Endpoint | capture("//(?<p>[^.:/]+)\\.").p),
+        ((.HashKV.hash // 0) | tostring),
+        ((.HashKV.compact_revision // 0) | tostring) ]
+    | @tsv'
+}
+
+# Strict gate: every expected member must be present, live, in the SAME etcd
+# cluster, sharing one raft term, agreeing on one leader, converged on one
+# revision, and holding a byte-identical keyspace. Stricter than a bare quorum
+# check on purpose -- a deliberate migration should never start from a degraded
+# cluster.
+gate_healthy() {                           # [exclude_pod]
+  local exclude="${1:-}"
+  local -a expect=()
+  local p
+  for p in "${PODS[@]}"; do
+    if [[ "$p" == "$exclude" ]]; then continue; fi
+    expect+=("$p")
+  done
+
+  local ctrl view
+  ctrl="$(ctrl_pod "$exclude")" || { warn "  no pod able to answer etcdctl"; return 1; }
+  view="$(cluster_view "$ctrl" "$exclude")" || { warn "  endpoint status failed via $ctrl"; return 1; }
+
+  local -A MID=() REV=() TERM=() LDR=() CID=()
+  local pod mid rev term ldr cid
+  while IFS=$'\t' read -r pod mid rev term ldr cid; do
+    if [[ -z "$pod" || "$pod" == "$exclude" ]]; then continue; fi
+    MID["$pod"]="$mid"; REV["$pod"]="$rev"; TERM["$pod"]="$term"
+    LDR["$pod"]="$ldr"; CID["$pod"]="$cid"
+  done <<< "$view"
+
+  for p in "${expect[@]}"; do
+    if [[ -z "${REV[$p]:-}" ]]; then warn "  no status from $p"; return 1; fi
+  done
+
+  # Cluster identity. A member that bootstrapped its own cluster instead of
+  # rejoining ours reports a different cluster_id while looking perfectly
+  # healthy in isolation. This is the check that catches it.
+  local cid0=""
+  for p in "${expect[@]}"; do
+    if [[ -z "$cid0" ]]; then cid0="${CID[$p]}"; fi
+    if [[ "${CID[$p]}" != "$cid0" ]]; then
+      warn "  SPLIT BRAIN: $p is in cluster ${CID[$p]}, expected $cid0"
+      return 1
+    fi
+  done
+  if [[ -n "$BASE_CLUSTER_ID" && "$cid0" != "$BASE_CLUSTER_ID" ]]; then
+    die "cluster_id changed from $BASE_CLUSTER_ID to $cid0 -- the keyspace has been replaced, STOP" 25
+  fi
+
+  # One leader, and every member must name the same one. Taking the first
+  # non-zero leader and checking only that it is "one of ours" would accept a
+  # split brain where each half elected itself.
+  local leader=""
+  for p in "${expect[@]}"; do
+    ldr="${LDR[$p]}"
+    if [[ "$ldr" == "0" ]]; then warn "  $p reports no leader (election in progress?)"; return 1; fi
+    if [[ -z "$leader" ]]; then leader="$ldr"; fi
+    if [[ "$ldr" != "$leader" ]]; then
+      warn "  members disagree on the leader: $p says $ldr, expected $leader"
+      return 1
+    fi
+  done
+  local leader_ok=0
+  for p in "${expect[@]}"; do
+    if [[ "${MID[$p]}" == "$leader" ]]; then leader_ok=1; fi
+  done
+  if (( ! leader_ok )); then warn "  leader $leader is not one of the expected members"; return 1; fi
+
+  local t0="" minr="" maxr="" r
+  for p in "${expect[@]}"; do
+    if [[ -z "$t0" ]]; then t0="${TERM[$p]}"; fi
+    if [[ "${TERM[$p]}" != "$t0" ]]; then
+      warn "  raft term mismatch: $p=${TERM[$p]} expected $t0 (election in progress?)"
+      return 1
+    fi
+    r="${REV[$p]}"
+    if [[ -z "$minr" ]]; then minr="$r"; maxr="$r"; fi
+    if (( r < minr )); then minr="$r"; fi
+    if (( r > maxr )); then maxr="$r"; fi
+  done
+  if (( minr != maxr )); then
+    warn "  revisions not converged: min=$minr max=$maxr (still catching up)"
+    return 1
+  fi
+
+  # The keyspace only ever moves forward. Going backwards means somebody
+  # restored or re-bootstrapped underneath us.
+  if [[ -n "$BASE_REVISION" ]] && (( maxr < BASE_REVISION )); then
+    die "revision went backwards: $maxr < $BASE_REVISION -- the keyspace has been rolled back, STOP" 25
+  fi
+
+  local -a hp=()
+  mapfile -t hp < <(healthy_pods "$ctrl" "$exclude")
+  local n=0 h found
+  for p in "${expect[@]}"; do
+    found=0
+    for h in "${hp[@]}"; do
+      if [[ "$h" == "$p" ]]; then found=1; fi
+    done
+    if (( found )); then n=$(( n + 1 )); fi
+  done
+  if (( n != ${#expect[@]} )); then
+    warn "  only $n/${#expect[@]} members report healthy"
+    return 1
+  fi
+
+  # Same revision is necessary but not sufficient: compare the actual keyspace.
+  local hashes hpod hhash hcomp h0="" c0=""
+  hashes="$(keyspace_hashes "$ctrl" "$maxr" "$exclude")" || { warn "  endpoint hashkv failed"; return 1; }
+  local -A SEEN=()
+  while IFS=$'\t' read -r hpod hhash hcomp; do
+    if [[ -z "$hpod" || "$hpod" == "$exclude" ]]; then continue; fi
+    SEEN["$hpod"]=1
+    if [[ -z "$h0" ]]; then h0="$hhash"; c0="$hcomp"; fi
+    if [[ "$hhash" != "$h0" || "$hcomp" != "$c0" ]]; then
+      warn "  keyspace hash mismatch: $hpod=$hhash/$hcomp expected $h0/$c0"
+      return 1
+    fi
+  done <<< "$hashes"
+  for p in "${expect[@]}"; do
+    if [[ -z "${SEEN[$p]:-}" ]]; then warn "  no keyspace hash from $p"; return 1; fi
+  done
+
+  say "  OK: ${#expect[@]} member(s), cluster=$cid0, leader=$leader, term=$t0, revision=$maxr, hashkv=$h0"
+  return 0
+}
+
+wait_gate() {                              # <message> [exclude_pod]
+  local msg="$1" exclude="${2:-}" deadline
+  deadline=$(( $(date +%s) + TIMEOUT_SEC ))
+  say "$msg"
+  while :; do
+    if gate_healthy "$exclude"; then return 0; fi
+    if (( $(date +%s) >= deadline )); then return 1; fi
+    sleep "$SLEEP_SEC"
+  done
+}
+
+# Hex member ID as text, straight from `member list` -- never through jq, so
+# no uint64 precision loss.
+member_id_for() {                          # <pod> <ctrl_pod>
+  local pod="$1" ctrl="$2" out id peer
+  out="$(etcd_exec "$ctrl" --endpoints="$(eps_excluding "$pod")" member list 2>/dev/null)" || return 1
+  # format: <hex id>, started, <name>, <peerURLs>, <clientURLs>, <isLearner>
+  id="$(printf '%s\n' "$out" | awk -F', *' -v n="$pod" '$3==n {gsub(/[ \t]/,"",$1); print $1; exit}')"
+  if [[ -z "$id" ]]; then
+    # An added-but-not-yet-started member has an empty NAME column; match its
+    # peer URL instead.
+    peer="http://${pod}.${STS}-headless.${NS}.svc.cluster.local:2380"
+    id="$(printf '%s\n' "$out" | awk -F', *' -v u="$peer" 'index($4,u)>0 {gsub(/[ \t]/,"",$1); print $1; exit}')"
+  fi
+  if [[ -z "$id" ]]; then return 1; fi
+  printf '%s' "$id"
+}
+
+labelled_nodes() {
+  kubectl get nodes -l "${LABEL_KEY}=${LABEL_VALUE}" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+}
+
+is_labelled_node() {                       # <node>
+  local n
+  for n in "${LABELLED[@]}"; do
+    if [[ "$n" == "$1" ]]; then return 0; fi
+  done
+  return 1
+}
+
+pod_node() { k get pod "$1" -o jsonpath='{.spec.nodeName}' 2>/dev/null || true; }
+pod_uid()  { k get pod "$1" -o jsonpath='{.metadata.uid}' 2>/dev/null || true; }
+
+# -------------------------------------------------------------- preflight ----
+
+preflight() {
+  need_cmd kubectl jq awk sed
+  if (( BASH_VERSINFO[0] < 4 )); then die "bash >= 4 required (associative arrays)"; fi
+
+  if ! k get sts "$STS" >/dev/null 2>&1; then die "StatefulSet $NS/$STS not found"; fi
+
+  REPLICAS="$(k get sts "$STS" -o jsonpath='{.spec.replicas}')"
+  if ! [[ "$REPLICAS" =~ ^[0-9]+$ ]] || (( REPLICAS < 1 )); then
+    die "could not read a sane .spec.replicas from $NS/$STS (got '${REPLICAS:-<empty>}')"
+  fi
+  PODS=()
+  local i
+  for (( i=0; i<REPLICAS; i++ )); do PODS+=("$STS-$i"); done
+  say "StatefulSet $NS/$STS, replicas=$REPLICAS"
+
+  # Fault tolerance during the move is (quorum of the REMAINING members). At
+  # replicaCount<=2 there is none: the survivors are a bare quorum, and the
+  # window where the rejoining member has been `member add`ed but is not yet
+  # live is a window where the cluster cannot commit writes at all.
+  if (( REPLICAS < 3 )); then
+    warn "replicaCount=$REPLICAS: this cluster has NO fault tolerance during the move."
+    warn "  After the member remove the survivor(s) are a bare quorum, and while the"
+    warn "  rejoining member is being added back etcd briefly cannot commit writes."
+    warn "  Mayastor tolerates this (already-published volumes keep serving I/O and"
+    warn "  the control plane retries), but do not run this alongside other work."
+  fi
+  if (( REPLICAS % 2 == 0 )); then
+    warn "replicaCount=$REPLICAS is even: $(( REPLICAS / 2 + 1 )) of $REPLICAS must be up for quorum, so an even count buys no extra tolerance over $(( REPLICAS - 1 ))."
+  fi
+
+  if [[ -n "$ONLY_ORDINAL" ]]; then
+    if ! [[ "$ONLY_ORDINAL" =~ ^[0-9]+$ ]] || (( ONLY_ORDINAL >= REPLICAS )); then
+      die "ONLY_ORDINAL='$ONLY_ORDINAL' is not a valid ordinal for a $REPLICAS-replica StatefulSet (expected 0..$(( REPLICAS - 1 )))"
+    fi
+  fi
+
+  local chart appver
+  chart="$(k get sts "$STS" -o jsonpath='{.metadata.labels.helm\.sh/chart}' 2>/dev/null || true)"
+  appver="$(k get sts "$STS" -o jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' 2>/dev/null || true)"
+  say "chart=${chart:-<none>} appVersion=${appver:-<none>}"
+  if [[ "$chart" != etcd-8.* ]]; then
+    warn "expected bitnami etcd chart 8.x (Mayastor 2.8.0); saw '${chart:-<none>}'."
+    warn "Re-check the bootstrap semantics before trusting this script on another chart major."
+  fi
+
+  # OnDelete is the whole point -- without it the controller recycles pods into
+  # PVCs pinned to the old nodes on its own schedule.
+  local us
+  us="$(k get sts "$STS" -o jsonpath='{.spec.updateStrategy.type}')"
+  if [[ "$us" != "OnDelete" ]]; then
+    die "updateStrategy.type is '${us:-<unset>}', need OnDelete. Apply the helm values in the header first, then confirm with: kubectl -n $NS get sts $STS -o jsonpath='{.spec.updateStrategy}'"
+  fi
+  say "updateStrategy=OnDelete"
+
+  local spec
+  spec="$(k get sts "$STS" -o json)"
+
+  # The new node affinity must actually be on the template, or nothing moves.
+  #
+  # Check the VALUE too, not just the key. Matching on the key alone lets a
+  # mismatch through -- template says values ["true"], LABEL_VALUE says
+  # "primary" -- and that combination passes preflight happily: the key is
+  # present, and the nodes you labelled do carry key=primary. The member is then
+  # removed and its data destroyed before anyone discovers the replacement can
+  # never satisfy an affinity asking for "true".
+  local -a tmpl_values=()
+  mapfile -t tmpl_values < <(printf '%s' "$spec" | jq -r --arg k "$LABEL_KEY" '
+    [ ( .spec.template.spec.affinity.nodeAffinity
+        | (.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms // [])[]?
+        | (.matchExpressions // [])[]? | select(.key == $k) | (.values // [])[]? ),
+      ( .spec.template.spec.affinity.nodeAffinity
+        | (.preferredDuringSchedulingIgnoredDuringExecution // [])[]?
+        | .preference | (.matchExpressions // [])[]? | select(.key == $k) | (.values // [])[]? ),
+      ( (.spec.template.spec.nodeSelector // {}) | to_entries[] | select(.key == $k) | .value )
+    ] | unique[]' 2>/dev/null || true)
+  if (( ${#tmpl_values[@]} == 0 )); then
+    die "pod template does not select on '$LABEL_KEY' in nodeAffinity or nodeSelector; run the helm upgrade first (etcd.nodeAffinityPreset.key must be '$LABEL_KEY')"
+  fi
+  local tv hit=0
+  for tv in "${tmpl_values[@]}"; do
+    if [[ "$tv" == "$LABEL_VALUE" ]]; then hit=1; fi
+  done
+  if (( ! hit )); then
+    die "pod template selects $LABEL_KEY in (${tmpl_values[*]}), but you asked to migrate onto $LABEL_KEY=$LABEL_VALUE. The nodes you labelled would never satisfy the affinity. Make etcd.nodeAffinityPreset.values match LABEL_VALUE."
+  fi
+  say "nodeAffinity selects $LABEL_KEY=$LABEL_VALUE"
+
+  # Mayastor sets podAntiAffinityPreset=hard. Setting etcd.affinity directly
+  # silently discards it, which with hostpath PVs is how you end up with two
+  # members on one node.
+  if ! printf '%s' "$spec" | jq -e '.spec.template.spec.affinity.podAntiAffinity' >/dev/null; then
+    die "pod template has no podAntiAffinity. Mayastor sets podAntiAffinityPreset=hard; you have probably overridden etcd.affinity, which disables all three presets. Use etcd.nodeAffinityPreset instead."
+  fi
+  say "podAntiAffinity present"
+
+  local ics
+  ics="$(printf '%s' "$spec" | jq -r --arg cn "$CN" '
+    .spec.template.spec.containers[] | select(.name==$cn)
+    | (.env // [])[] | select(.name=="ETCD_INITIAL_CLUSTER_STATE") | .value' 2>/dev/null || true)"
+  if [[ "$ics" != "existing" ]]; then
+    if [[ "$ICS_OVERRIDE" == "true" ]]; then
+      warn "ETCD_INITIAL_CLUSTER_STATE='${ics:-<unset>}'; relying on the bitnami entrypoint to auto-detect (ICS_OVERRIDE=true)"
+    else
+      die "ETCD_INITIAL_CLUSTER_STATE is '${ics:-<unset>}', expected 'existing'. Set etcd.initialClusterState='existing' via helm. This is what stops a rejoining member -- especially ${STS}-0 -- from being misread as a fresh cluster and bootstrapping over the keyspace. Set ICS_OVERRIDE=true to proceed anyway."
+    fi
+  else
+    say "ETCD_INITIAL_CLUSTER_STATE=existing"
+  fi
+
+  local sc bm rp
+  sc="$(printf '%s' "$spec" | jq -r '.spec.volumeClaimTemplates[0].spec.storageClassName // empty')"
+  if [[ -z "$sc" ]]; then die "could not read the volumeClaimTemplate storageClassName"; fi
+  bm="$(kubectl get sc "$sc" -o jsonpath='{.volumeBindingMode}')"
+  rp="$(kubectl get sc "$sc" -o jsonpath='{.reclaimPolicy}')"
+  say "storageClass=$sc bindingMode=$bm reclaimPolicy=$rp"
+  if [[ "$bm" != "WaitForFirstConsumer" ]]; then
+    die "storageClass $sc has volumeBindingMode=$bm. Relocation needs WaitForFirstConsumer so the scheduler picks the node before the hostpath is provisioned."
+  fi
+  if [[ "$rp" != "Delete" ]]; then
+    warn "reclaimPolicy=$rp -- old hostpath directories on the vacated nodes will NOT be cleaned up automatically"
+  fi
+
+  mapfile -t LABELLED < <(labelled_nodes)
+  if (( ${#LABELLED[@]} < REPLICAS )); then
+    die "only ${#LABELLED[@]} node(s) carry ${LABEL_KEY}=${LABEL_VALUE}; podAntiAffinityPreset=hard needs at least $REPLICAS"
+  fi
+  say "labelled nodes (${#LABELLED[@]}): ${LABELLED[*]}"
+
+  # What matters is how many labelled nodes can actually take a pod, not whether
+  # every single one can. Labelling a whole rack or zone for a 3-member etcd is
+  # normal, and one unrelated cordoned node in that pool should not abort the
+  # migration while plenty of valid destinations remain.
+  local n unsched taints
+  local -a cordoned=() schedulable=()
+  for n in "${LABELLED[@]}"; do
+    unsched="$(kubectl get node "$n" -o jsonpath='{.spec.unschedulable}' 2>/dev/null || true)"
+    if [[ "$unsched" == "true" ]]; then
+      cordoned+=("$n")
+    else
+      schedulable+=("$n")
+    fi
+    taints="$(kubectl get node "$n" -o jsonpath='{range .spec.taints[?(@.effect=="NoSchedule")]}{.key}{" "}{end}' 2>/dev/null || true)"
+    if [[ -n "$taints" ]]; then
+      warn "node $n has NoSchedule taints ($taints) -- etcd pods need matching tolerations via etcd.tolerations"
+    fi
+  done
+  if (( ${#cordoned[@]} > 0 )); then
+    if (( ${#schedulable[@]} < REPLICAS )); then
+      die "only ${#schedulable[@]} of ${#LABELLED[@]} labelled node(s) are schedulable (cordoned: ${cordoned[*]}); podAntiAffinityPreset=hard needs at least $REPLICAS. Uncordon them -- localpv cleanup pods need to schedule too."
+    fi
+    warn "labelled but cordoned, so unusable as destinations: ${cordoned[*]} (${#schedulable[@]} schedulable, need $REPLICAS)"
+  fi
+
+  say "current placement:"
+  local p
+  for p in "${PODS[@]}"; do
+    n="$(pod_node "$p")"
+    if [[ -n "$n" ]] && is_labelled_node "$n"; then
+      say "  $p -> ${n} (labelled)"
+    else
+      say "  $p -> ${n:-<unscheduled>}"
+    fi
+  done
+
+  if ! wait_gate "Preflight: cluster healthy and converged?"; then
+    die "cluster is not healthy before we start; fix that first" 24
+  fi
+}
+
+# Record what the cluster is and what it holds, so that every later gate has
+# something to be measured against rather than merely being internally
+# consistent.
+capture_baseline() {
+  local ctrl view line
+  ctrl="$(ctrl_pod "")" || die "no pod available to read the baseline from"
+  view="$(cluster_view "$ctrl" "")" || die "could not read cluster state for the baseline"
+  line="$(printf '%s\n' "$view" | head -1)"
+  BASE_REVISION="$(printf '%s' "$line" | cut -f3)"
+  BASE_CLUSTER_ID="$(printf '%s' "$line" | cut -f6)"
+
+  BASE_KEYS_FILE="$(mktemp -t etcd-keys-before.XXXXXX)"
+  etcd_exec "$ctrl" get --prefix "" --keys-only 2>/dev/null \
+    | grep -v '^$' | LC_ALL=C sort > "$BASE_KEYS_FILE" || true
+  say "Baseline: cluster=$BASE_CLUSTER_ID revision=$BASE_REVISION keys=$(wc -l < "$BASE_KEYS_FILE")"
+  say "  key census: $BASE_KEYS_FILE"
+}
+
+# Compare the keyspace against the baseline census. Mayastor's keyspace is live
+# -- lease locks come and go -- so a key appearing is normal and a key vanishing
+# is reported rather than fatal. The fatal signals (cluster_id, revision going
+# backwards) are asserted inside gate_healthy, on every single gate.
+verify_keyspace() {                        # <label>
+  local label="$1" ctrl now missing
+  if [[ -z "$BASE_KEYS_FILE" || ! -s "$BASE_KEYS_FILE" ]]; then return 0; fi
+  ctrl="$(ctrl_pod "")" || { warn "  $label: no pod available to re-read the keyspace"; return 0; }
+  now="$(mktemp -t etcd-keys-now.XXXXXX)"
+  etcd_exec "$ctrl" get --prefix "" --keys-only 2>/dev/null \
+    | grep -v '^$' | LC_ALL=C sort > "$now" || true
+  missing="$(LC_ALL=C comm -23 "$BASE_KEYS_FILE" "$now" || true)"
+  if [[ -n "$missing" ]]; then
+    warn "  $label: keys present at baseline are now absent:"
+    printf '%s\n' "$missing" | sed 's/^/      /' >&2
+    warn "  (StoreLease* keys are lease-bound and may legitimately churn; anything else is not)"
+  else
+    say "  $label: all $(wc -l < "$BASE_KEYS_FILE") baseline keys still present ($(wc -l < "$now") total)"
+  fi
+  rm -f "$now"
+}
+
+take_snapshot() {
+  local ctrl f
+  ctrl="$(ctrl_pod "")" || die "no pod available to snapshot from"
+  mkdir -p "$SNAPSHOT_DIR"
+  f="$SNAPSHOT_DIR/${STS}-$(date +%Y%m%d-%H%M%S).db"
+  say "Snapshotting keyspace via $ctrl -> $f"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    say "  DRY-RUN: would snapshot"
+    return 0
+  fi
+  k exec "$ctrl" -c "$CN" -- sh -c \
+    'ETCDCTL_API=3 etcdctl snapshot save /tmp/pre-migration.db >/dev/null 2>&1 && cat /tmp/pre-migration.db && rm -f /tmp/pre-migration.db' > "$f"
+  if [[ ! -s "$f" ]]; then die "snapshot came back empty -- refusing to continue without a backup"; fi
+  # A non-empty file is not a valid one. `snapshot status` parses the bbolt
+  # pages and the integrity hash, which is what catches a stream mangled in
+  # transit through kubectl exec.
+  local st=""
+  if command -v etcdctl >/dev/null 2>&1; then
+    st="$(ETCDCTL_API=3 etcdctl snapshot status "$f" -w json 2>/dev/null || true)"
+  else
+    k exec -i "$ctrl" -c "$CN" -- sh -c 'cat > /tmp/verify.db' < "$f"
+    st="$(k exec "$ctrl" -c "$CN" -- sh -c 'ETCDCTL_API=3 etcdctl snapshot status /tmp/verify.db -w json 2>/dev/null; rm -f /tmp/verify.db' || true)"
+  fi
+  if [[ -z "$st" ]] || ! printf '%s' "$st" | jq -e '.totalKey >= 0' >/dev/null 2>&1; then
+    die "snapshot at $f did not pass 'etcdctl snapshot status' -- refusing to continue without a usable backup"
+  fi
+  say "Snapshot written: $f ($(wc -c < "$f") bytes, $(printf '%s' "$st" | jq -r '.totalKey') keys, revision $(printf '%s' "$st" | jq -r '.revision'))"
+}
+
+# ------------------------------------------------------------- the move ----
+
+wait_pvc_gone() {                          # <pvc> <old_uid>
+  local pvc="$1" olduid="$2" deadline uid
+  deadline=$(( $(date +%s) + TIMEOUT_SEC ))
+  say "  waiting for old PVC $pvc to be released"
+  while :; do
+    uid="$(k get pvc "$pvc" -o jsonpath='{.metadata.uid}' 2>/dev/null || true)"
+    if [[ -z "$uid" ]] || [[ -n "$olduid" && "$uid" != "$olduid" ]]; then
+      say "  old PVC released"
+      return 0
+    fi
+    if (( $(date +%s) >= deadline )); then
+      die "  timed out waiting for $pvc to delete (pvc-protection finalizer -- is the pod still running?)" 5
+    fi
+    sleep "$SLEEP_SEC"
+  done
+}
+
+wait_pod_on_labelled_node() {              # <pod> <old_pod_uid>
+  local pod="$1" olduid="${2:-}" deadline kicks=0 node phase ready msg uid
+  deadline=$(( $(date +%s) + TIMEOUT_SEC ))
+  say "  waiting for $pod to come back Ready on a labelled node"
+  while :; do
+    uid="$(pod_uid "$pod")"
+
+    # Until the replacement pod exists, everything we can observe still
+    # describes the pod we just deleted. Acting on it would burn a reschedule
+    # kick per poll and delete the new pod the moment it appeared.
+    if [[ -z "$uid" ]] || { [[ -n "$olduid" ]] && [[ "$uid" == "$olduid" ]]; }; then
+      if (( $(date +%s) >= deadline )); then
+        die "  $pod was not recreated within ${TIMEOUT_SEC}s" 5
+      fi
+      sleep "$SLEEP_SEC"
+      continue
+    fi
+
+    phase="$(k get pod "$pod" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+    node="$(pod_node "$pod")"
+    ready="$(k get pod "$pod" -o jsonpath='{range .status.conditions[?(@.type=="Ready")]}{.status}{end}' 2>/dev/null || true)"
+
+    if [[ -n "$node" ]] && ! is_labelled_node "$node"; then
+      # It rebound the stale PV, or affinity is not what we think it is.
+      if (( kicks < MAX_RESCHEDULE_KICKS )); then
+        kicks=$(( kicks + 1 ))
+        warn "  $pod landed on unlabelled node $node; deleting to force rescheduling (kick $kicks/$MAX_RESCHEDULE_KICKS)"
+        k delete pod "$pod" --wait=false --ignore-not-found >/dev/null || true
+        olduid="$uid"
+        sleep "$SLEEP_SEC"
+        continue
+      fi
+      die "  $pod keeps landing on unlabelled nodes -- check the StatefulSet nodeAffinity" 30
+    fi
+
+    if [[ "$phase" == "Running" && "$ready" == "True" ]]; then
+      say "  $pod Ready on $node"
+      return 0
+    fi
+
+    if [[ "$phase" == "Pending" ]]; then
+      msg="$(k get pod "$pod" -o jsonpath='{range .status.conditions[?(@.type=="PodScheduled")]}{.message}{end}' 2>/dev/null || true)"
+      if [[ -n "$msg" ]]; then say "  pending: $msg"; fi
+    fi
+
+    if (( $(date +%s) >= deadline )); then
+      die "  $pod did not become Ready on a labelled node within ${TIMEOUT_SEC}s" 5
+    fi
+    sleep "$SLEEP_SEC"
+  done
+}
+
+move_one() {                               # <pod>
+  local pod="$1"
+  local ordinal="${pod##*-}"
+  local pvc="data-${pod}"
+  local from_node ctrl mid pvc_uid pod_uid_before pv_name unsched
+
+  from_node="$(pod_node "$pod")"
+  say "=== $pod  (ordinal $ordinal, currently on ${from_node:-<unscheduled>}) ==="
+
+  if [[ -n "$from_node" ]] && is_labelled_node "$from_node"; then
+    say "  already on a labelled node -- nothing to do"
+    return 0
+  fi
+
+  if [[ -n "$from_node" ]]; then
+    unsched="$(kubectl get node "$from_node" -o jsonpath='{.spec.unschedulable}' 2>/dev/null || true)"
+    if [[ "$unsched" == "true" ]]; then
+      warn "  source node $from_node is cordoned; the localpv cleanup pod cannot run there and the old hostpath dir will be left behind"
+    fi
+  fi
+
+  if ! wait_gate "  Gate 1/3: whole cluster healthy and converged before touching $pod"; then
+    die "cluster unhealthy before moving $pod -- aborting without changes" 24
+  fi
+
+  ctrl="$(ctrl_pod "$pod")" || die "no control pod available to issue member remove" 6
+  mid="$(member_id_for "$pod" "$ctrl")" || mid=""
+  if [[ -n "$mid" ]]; then
+    say "  removing membership for $pod (member $mid) via $ctrl"
+    if ! mutate etcd_exec "$ctrl" --endpoints="$(eps_excluding "$pod")" member remove "$mid"; then
+      say "  current membership:"
+      etcd_exec "$ctrl" --endpoints="$(eps_excluding "$pod")" member list -w table 2>/dev/null | sed 's/^/    /' || true
+      die "member remove failed for $pod" 6
+    fi
+  else
+    warn "  no member found for $pod (already removed?) -- continuing"
+  fi
+
+  # Nothing destructive happens until the REMAINING cluster proves it is fine.
+  #
+  # Under DRY_RUN the member remove above was only printed, so the membership
+  # this gate exists to check does not exist. Evaluating it anyway asks the
+  # surviving members to agree on a leader drawn only from themselves while
+  # $pod is still a voting member -- which fails outright whenever $pod happens
+  # to be the current leader, and passes misleadingly when it does not. Neither
+  # answer means anything, so say so and move on.
+  if [[ "$DRY_RUN" == "true" ]]; then
+    say "  Gate 2/3: skipped under DRY_RUN (membership was not actually changed)"
+  elif ! wait_gate "  Gate 2/3: remaining members healthy after membership change" "$pod"; then
+    die "remaining cluster is not healthy -- STOP. Do not delete $pvc. Investigate before continuing." 24
+  fi
+
+  pvc_uid="$(k get pvc "$pvc" -o jsonpath='{.metadata.uid}' 2>/dev/null || true)"
+  pod_uid_before="$(pod_uid "$pod")"
+  pv_name="$(k get pvc "$pvc" -o jsonpath='{.spec.volumeName}' 2>/dev/null || true)"
+  say "  destroying $pvc (pv=${pv_name:-<none>}) and pod $pod"
+
+  # PVC first: pvc-protection holds it Terminating until the pod is gone, so
+  # deleting the pod second is what actually releases it. The StatefulSet
+  # controller will not recreate the pod while its PVC has a deletionTimestamp,
+  # which is what stops the replacement from rebinding the old node-pinned PV.
+  mutate k delete pvc "$pvc" --wait=false --ignore-not-found
+  mutate k delete pod "$pod" --wait=false --ignore-not-found
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    say "  DRY-RUN: would now wait for $pod to be rescheduled onto a labelled node and resync"
+    return 0
+  fi
+
+  wait_pvc_gone "$pvc" "$pvc_uid"
+  wait_pod_on_labelled_node "$pod" "$pod_uid_before"
+
+  if ! wait_gate "  Gate 3/3: all $REPLICAS members healthy and revisions converged"; then
+    die "cluster did not converge after moving $pod" 5
+  fi
+  verify_keyspace "after $pod"
+
+  say "  $pod is now on $(pod_node "$pod"); settling for ${SETTLE_SEC}s"
+  sleep "$SETTLE_SEC"
+}
+
+# ------------------------------------------------------------------ main ----
+
+main() {
+  preflight
+
+  # Descending ordinal order, so ${STS}-0 -- the riskiest member to rebuild --
+  # goes last, once the procedure has already proven itself.
+  local -a todo=()
+  local i pod node
+  for (( i=REPLICAS-1; i>=0; i-- )); do
+    pod="$STS-$i"
+    node="$(pod_node "$pod")"
+    if [[ -n "$node" ]] && is_labelled_node "$node"; then
+      say "$pod already on labelled node $node -- no move needed"
+    else
+      todo+=("$pod")
+    fi
+  done
+
+  if [[ -n "$ONLY_ORDINAL" ]]; then
+    # Validated against REPLICAS in preflight. move_one() still re-checks
+    # placement, so naming an already-placed ordinal is a no-op rather than a
+    # needless rebuild.
+    todo=("$STS-$ONLY_ORDINAL")
+    say "ONLY_ORDINAL=$ONLY_ORDINAL -- restricting this run to ${todo[*]}"
+  fi
+
+  if (( ${#todo[@]} == 0 )); then
+    say "Nothing to do: every member is already on a labelled node."
+    return 0
+  fi
+
+  capture_baseline
+  if [[ "$SNAPSHOT" == "true" ]]; then take_snapshot; fi
+
+  say "Members to move, in order: ${todo[*]}"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    say "DRY_RUN=true -- nothing will be changed. Re-run with DRY_RUN=false to execute."
+  else
+    warn "DRY_RUN=false -- this WILL remove etcd members and delete their PVCs."
+    warn "Ctrl-C within 10 seconds to abort."
+    sleep 10
+  fi
+
+  for pod in "${todo[@]}"; do
+    move_one "$pod"
+  done
+
+  if [[ "$DRY_RUN" != "true" ]]; then
+    if ! wait_gate "Final verification: all $REPLICAS members healthy and converged"; then
+      die "final health check failed" 24
+    fi
+    verify_keyspace "final"
+  fi
+
+  say ""
+  if [[ "$DRY_RUN" == "true" ]]; then say "DRY RUN complete. No changes were made. Placement is unchanged:"; else say "Migration complete. Placement:"; fi
+  for pod in "${PODS[@]}"; do
+    say "  $pod -> $(pod_node "$pod")"
+  done
+  say ""
+  say "Follow-up, once you are satisfied:"
+  say "  - revert etcd.updateStrategy.type to RollingUpdate"
+  say "  - remove etcd.initialClusterState='existing' (it would break a genuine fresh bootstrap)"
+  say "  - confirm the old hostpath dirs were cleaned up on the vacated nodes"
+  say "  - kubectl get pv | grep -E 'Released|Failed'   # should be empty"
+}
+
+main "$@"

--- a/scripts/k8s/migrate-etcd-to-labelled-nodes/test-migration.sh
+++ b/scripts/k8s/migrate-etcd-to-labelled-nodes/test-migration.sh
@@ -1,0 +1,798 @@
+#!/usr/bin/env bash
+#
+# test-migration.sh
+#
+# End-to-end test for migrate-mayastor-etcd.sh against a real Kubernetes
+# cluster. It installs openebs/openebs, puts genuine Mayastor state into etcd
+# (pools, a replicated volume, a workload writing to it), migrates the etcd
+# members onto labelled nodes, and then proves that nothing was lost.
+#
+# The point of the test is the verify phase. Everything else exists to create a
+# situation worth verifying. The assertions that matter:
+#
+#   * etcd's cluster_id is the SAME before and after. A member that bootstrapped
+#     a fresh cluster over the keyspace instead of rejoining ours would show a
+#     new one while otherwise looking perfectly healthy.
+#   * the revision never goes backwards.
+#   * every member reports an identical `endpoint hashkv`. Equal revisions only
+#     say the members agree on how far they have got; equal hashes say they are
+#     holding the same bytes.
+#   * every key present before the migration is still present after.
+#   * the workload's data has no gaps and its pod never restarted -- Mayastor's
+#     data path is supposed to keep serving I/O even while etcd is unavailable.
+#   * the control plane can still WRITE: provisioning a new volume afterwards
+#     proves etcd is functional, not merely intact.
+#
+# Requirements on the cluster (a "cluster of this sort"):
+#   * >= 3 worker nodes labelled openebs.io/engine=mayastor
+#   * hugepages configured and nvme kernel modules loaded on those workers
+#   * one spare unformatted block device per worker (BLOCK_DEVICE, default
+#     /dev/sdb) for the DiskPools
+#   * kubectl, helm, jq, yq on the machine running this
+#
+# Usage:
+#   ./test-migration.sh all          # the whole thing
+#   ./test-migration.sh setup        # install + seed state
+#   ./test-migration.sh prepare      # apply the helm prerequisites
+#   ./test-migration.sh migrate      # run the migration under test
+#   ./test-migration.sh verify       # assertions only (safe to repeat)
+#   ./test-migration.sh revert       # post-migration cleanup, back to RollingUpdate
+#   ./test-migration.sh teardown     # remove everything this test created
+#
+# Exit code is 0 only if every assertion passed.
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------- config ----
+
+CHART_VERSION="${CHART_VERSION:-4.2.0}"
+NS="${NS:-openebs}"
+REL="${REL:-openebs}"
+STS="${STS:-${REL}-etcd}"
+CN="${CN:-etcd}"
+
+ETCD_REPLICAS="${ETCD_REPLICAS:-2}"        # the interesting case; 3 also works
+LABEL_KEY="${LABEL_KEY:-node/etcd.io}"
+LABEL_VALUE="${LABEL_VALUE:-true}"
+
+BLOCK_DEVICE="${BLOCK_DEVICE:-/dev/sdb}"   # spare disk on each worker
+TEST_NS="${TEST_NS:-default}"
+TEST_SC="${TEST_SC:-mayastor-test-3}"
+TEST_PVC="${TEST_PVC:-migration-test-data}"
+TEST_APP="${TEST_APP:-migration-test-writer}"
+
+# openebs/openebs 4.2.0 ships two image references that Docker Hub no longer
+# serves: Bitnami retired their legacy tags in Aug 2025, so
+# docker.io/bitnami/etcd:3.5.6-debian-11-r10 and docker.io/bitnami/kubectl:1.25.15
+# both 404. OpenEBS republishes the etcd image under its own org; kubectl is
+# still available under bitnamilegacy. Without these the install never starts
+# and, worse, every `helm upgrade` hangs on the pre-upgrade hook Job.
+# Set PATCH_DEAD_IMAGES=false once the chart itself is fixed.
+PATCH_DEAD_IMAGES="${PATCH_DEAD_IMAGES:-true}"
+ETCD_IMAGE_REPO="${ETCD_IMAGE_REPO:-openebs/etcd}"
+ETCD_IMAGE_TAG="${ETCD_IMAGE_TAG:-3.5.6-debian-11-r10}"
+KUBECTL_IMAGE_REPO="${KUBECTL_IMAGE_REPO:-bitnamilegacy/kubectl}"
+KUBECTL_IMAGE_TAG="${KUBECTL_IMAGE_TAG:-1.25.15}"
+
+# The migration needs somewhere to move a member TO, so the pool of nodes etcd
+# may occupy has to be strictly larger than ETCD_REPLICAS. On a cluster with
+# exactly as many workers as replicas (3 workers, replicaCount 3) there is no
+# spare, and podAntiAffinityPreset=hard means a member cannot double up. Setting
+# this brings the control-plane node into the pool and gives etcd a matching
+# toleration, which is enough to make the 3-replica case testable on a 3-worker
+# cluster. Leave it off wherever there are genuinely spare workers.
+ETCD_TOLERATE_CONTROL_PLANE="${ETCD_TOLERATE_CONTROL_PLANE:-false}"
+
+# Label MORE nodes than there are etcd members. The migration only requires at
+# least replicaCount labelled nodes; a real deployment would label a whole rack
+# or zone and leave the scheduler a choice of destination. Setting this exercises
+# that, rather than the artificially exact fit the test otherwise sets up.
+EXTRA_LABELLED="${EXTRA_LABELLED:-0}"
+
+REUSE_INSTALL="${REUSE_INSTALL:-false}"    # skip install if the release exists
+WORKDIR="${WORKDIR:-$(pwd)/.migration-test}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATE_SCRIPT="${MIGRATE_SCRIPT:-$SCRIPT_DIR/migrate-mayastor-etcd.sh}"
+
+TIMEOUT_SEC="${TIMEOUT_SEC:-900}"
+
+# ------------------------------------------------------------- machinery ----
+
+PASS=0
+FAIL=0
+
+# Self-contained, like the script it tests -- see the note in
+# migrate-mayastor-etcd.sh. Do not replace with scripts/utils/log.sh.
+say()  { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+warn() { printf '[%s] WARN  %s\n' "$(date +%H:%M:%S)" "$*" >&2; }
+die()  { printf '[%s] FATAL %s\n' "$(date +%H:%M:%S)" "$*" >&2; exit 1; }
+hdr()  { printf '\n[%s] ===== %s =====\n' "$(date +%H:%M:%S)" "$*"; }
+
+ok()   { PASS=$(( PASS + 1 )); printf '  PASS  %s\n' "$*"; }
+bad()  { FAIL=$(( FAIL + 1 )); printf '  FAIL  %s\n' "$*" >&2; }
+
+assert_eq() {                              # <what> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then ok "$1 ($3)"; else bad "$1: expected '$2', got '$3'"; fi
+}
+
+k() { kubectl -n "$NS" "$@"; }
+
+etcd_exec() {                              # <pod> <etcdctl args...>
+  local pod="$1"; shift
+  k exec "$pod" -c "$CN" -- env ETCDCTL_API=3 etcdctl \
+      --dial-timeout=5s --command-timeout=15s "$@"
+}
+
+ep_for() { printf 'http://%s.%s-headless.%s.svc.cluster.local:2379' "$1" "$STS" "$NS"; }
+
+all_eps() {
+  local -a out=()
+  local i
+  for (( i=0; i<ETCD_REPLICAS; i++ )); do out+=("$(ep_for "${STS}-$i")"); done
+  ( IFS=,; printf '%s' "${out[*]}" )
+}
+
+# A live etcd pod we can shell into. Never assume ordinal 0 is up.
+any_etcd_pod() {
+  local i p
+  for (( i=ETCD_REPLICAS-1; i>=0; i-- )); do
+    p="${STS}-$i"
+    if [[ "$(k get pod "$p" -o jsonpath='{.status.phase}' 2>/dev/null || true)" == "Running" ]] \
+       && etcd_exec "$p" endpoint status -w json >/dev/null 2>&1; then
+      printf '%s' "$p"; return 0
+    fi
+  done
+  return 1
+}
+
+wait_for() {                               # <desc> <timeout> <shell predicate...>
+  local desc="$1" t="$2"; shift 2
+  local deadline=$(( $(date +%s) + t ))
+  say "waiting: $desc"
+  while :; do
+    if "$@"; then return 0; fi
+    if (( $(date +%s) >= deadline )); then
+      warn "timed out after ${t}s: $desc"
+      return 1
+    fi
+    sleep 5
+  done
+}
+
+etcd_pods_ready() {
+  local n
+  n="$(k get pods -l app.kubernetes.io/name=etcd \
+        -o jsonpath='{range .items[*]}{.status.containerStatuses[0].ready}{"\n"}{end}' 2>/dev/null \
+      | grep -c true || true)"
+  [[ "$n" == "$ETCD_REPLICAS" ]]
+}
+
+# "Nothing is unready" is NOT the same as "everything is up". `helm install`
+# returns before the controllers have created any pods, so an empty pod list
+# makes a naive sweep pass instantly and lets the rest of setup race a cluster
+# that has not started. Anchor on the etcd StatefulSet reporting its full
+# complement first, then sweep for stragglers.
+all_pods_ready() {
+  local ready
+  ready="$(k get sts "$STS" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
+  if [[ "${ready:-0}" != "$ETCD_REPLICAS" ]]; then return 1; fi
+  ! k get pods --no-headers 2>/dev/null \
+    | awk '{split($2,a,"/"); if (a[1]!=a[2] && $3!="Completed") print}' | grep -q .
+}
+
+need() {
+  local c
+  for c in "$@"; do command -v "$c" >/dev/null 2>&1 || die "required command not found: $c"; done
+}
+
+worker_nodes() {
+  kubectl get nodes -l 'openebs.io/engine=mayastor' \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+}
+
+control_plane_nodes() {
+  kubectl get nodes -l 'node-role.kubernetes.io/control-plane' \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+}
+
+# Nodes etcd is allowed to occupy. DiskPools still only ever live on the
+# mayastor workers; this pool is about etcd placement alone.
+candidate_nodes() {
+  worker_nodes
+  if [[ "$ETCD_TOLERATE_CONTROL_PLANE" == "true" ]]; then control_plane_nodes; fi
+}
+
+# ------------------------------------------------------------------ setup ----
+
+phase_setup() {
+  hdr "SETUP: install openebs $CHART_VERSION with a ${ETCD_REPLICAS}-member etcd"
+  need kubectl helm jq yq
+  mkdir -p "$WORKDIR"
+
+  local -a workers=()
+  mapfile -t workers < <(worker_nodes)
+  if (( ${#workers[@]} < 3 )); then
+    die "need >= 3 nodes labelled openebs.io/engine=mayastor, found ${#workers[@]}. Label them first."
+  fi
+  say "mayastor workers (${#workers[@]}): ${workers[*]}"
+
+  if helm -n "$NS" status "$REL" >/dev/null 2>&1; then
+    if [[ "$REUSE_INSTALL" == "true" ]]; then
+      say "release $REL already installed and REUSE_INSTALL=true -- skipping install"
+    else
+      die "release $REL already exists in $NS. Run '$0 teardown' first, or set REUSE_INSTALL=true."
+    fi
+  else
+    helm repo add openebs https://openebs.github.io/openebs >/dev/null 2>&1 || true
+    helm repo update openebs >/dev/null
+    rm -rf "$WORKDIR/chart"
+    mkdir -p "$WORKDIR/chart"
+    helm pull openebs/openebs --version "$CHART_VERSION" --untar -d "$WORKDIR/chart"
+
+    {
+      printf 'mayastor:\n  etcd:\n    replicaCount: %s\n' "$ETCD_REPLICAS"
+      if [[ "$PATCH_DEAD_IMAGES" == "true" ]]; then
+        printf '    image:\n      registry: docker.io\n      repository: %s\n      tag: %s\n' \
+               "$ETCD_IMAGE_REPO" "$ETCD_IMAGE_TAG"
+      fi
+      if [[ "$ETCD_TOLERATE_CONTROL_PLANE" == "true" ]]; then
+        printf '    tolerations:\n      - key: node-role.kubernetes.io/control-plane\n        operator: Exists\n        effect: NoSchedule\n'
+      fi
+      printf '  obs:\n    callhome:\n      sendReport: false\n'
+      if [[ "$PATCH_DEAD_IMAGES" == "true" ]]; then
+        printf 'preUpgradeHook:\n  image:\n    registry: docker.io\n    repo: %s\n    tag: "%s"\n' \
+               "$KUBECTL_IMAGE_REPO" "$KUBECTL_IMAGE_TAG"
+      fi
+    } > "$WORKDIR/install-values.yaml"
+    say "install values:"; sed 's/^/    /' "$WORKDIR/install-values.yaml"
+
+    kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+    helm install "$REL" "$WORKDIR/chart/openebs" -n "$NS" \
+      -f "$WORKDIR/install-values.yaml" --timeout 15m
+  fi
+
+  wait_for "all $NS pods ready" "$TIMEOUT_SEC" all_pods_ready || die "install did not come up"
+  k get pods -o wide
+
+  hdr "SETUP: DiskPools on $BLOCK_DEVICE"
+  local n
+  for n in "${workers[@]}"; do
+    cat <<EOF | kubectl apply -f - >/dev/null
+apiVersion: openebs.io/v1beta2
+kind: DiskPool
+metadata:
+  name: pool-${n}
+  namespace: ${NS}
+spec:
+  node: ${n}
+  disks: ["${BLOCK_DEVICE}"]
+EOF
+  done
+  wait_for "all DiskPools Online" 300 bash -c \
+    "kubectl -n '$NS' get dsp --no-headers 2>/dev/null | awk '\$4!=\"Online\"{f=1} END{exit f?1:0}'" \
+    || die "DiskPools did not come Online -- is $BLOCK_DEVICE free on every worker?"
+  k get dsp
+
+  hdr "SETUP: replicated volume + writer workload"
+  cat <<EOF | kubectl apply -f - >/dev/null
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ${TEST_SC}
+parameters:
+  protocol: nvmf
+  repl: "3"
+  fsType: ext4
+provisioner: io.openebs.csi-mayastor
+volumeBindingMode: Immediate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${TEST_PVC}
+  namespace: ${TEST_NS}
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: ${TEST_SC}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${TEST_APP}
+  namespace: ${TEST_NS}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: ${TEST_APP}}}
+  template:
+    metadata: {labels: {app: ${TEST_APP}}}
+    spec:
+      containers:
+      - name: writer
+        image: busybox:1.36
+        command: ["/bin/sh","-c"]
+        args:
+          - |
+            i=0
+            while true; do
+              i=\$((i+1))
+              echo "\$(date -Iseconds) seq=\$i" >> /data/log.txt
+              sync
+              sleep 2
+            done
+        volumeMounts: [{name: d, mountPath: /data}]
+      volumes:
+      - name: d
+        persistentVolumeClaim: {claimName: ${TEST_PVC}}
+EOF
+  wait_for "writer pod running" 300 bash -c \
+    "kubectl -n '$TEST_NS' get pod -l app='$TEST_APP' -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Running"
+  sleep 20   # let it write something worth losing
+
+  hdr "SETUP: choose the nodes to label"
+  # Label the nodes of every member EXCEPT ordinal 0, plus one node hosting no
+  # member at all. That is exactly ETCD_REPLICAS labelled nodes (which is what
+  # podAntiAffinityPreset=hard requires) and leaves exactly one member to move.
+  # Leaving ordinal 0 as the one that moves is deliberate: it is the member
+  # whose bootstrap semantics could destroy the keyspace if initialClusterState
+  # were wrong, so it is the most informative one to rebuild.
+  local -a etcd_nodes=() candidates=() to_label=()
+  local i p node spare=""
+  for (( i=0; i<ETCD_REPLICAS; i++ )); do
+    p="${STS}-$i"
+    node="$(k get pod "$p" -o jsonpath='{.spec.nodeName}' 2>/dev/null || true)"
+    etcd_nodes+=("$node")
+    say "  $p -> $node"
+  done
+  for (( i=1; i<ETCD_REPLICAS; i++ )); do to_label+=("${etcd_nodes[$i]}"); done
+
+  mapfile -t candidates < <(candidate_nodes)
+  for n in "${candidates[@]}"; do
+    if [[ " ${etcd_nodes[*]} " != *" $n "* ]]; then spare="$n"; break; fi
+  done
+  if [[ -z "$spare" ]]; then
+    die "every candidate node already hosts an etcd member, so there is nowhere to migrate to. Candidates (${#candidates[@]}): ${candidates[*]}. Either free up a node, lower ETCD_REPLICAS, or set ETCD_TOLERATE_CONTROL_PLANE=true to bring the control-plane node into the pool."
+  fi
+  to_label+=("$spare")
+
+  # Spare destinations beyond the minimum. The SOURCE node is deliberately never
+  # labelled -- if it were, ordinal 0 would already be "in place" and the test
+  # would migrate nothing.
+  local extra=0
+  for n in "${candidates[@]}"; do
+    if (( extra >= EXTRA_LABELLED )); then break; fi
+    if [[ " ${to_label[*]} " == *" $n "* ]]; then continue; fi
+    if [[ "$n" == "${etcd_nodes[0]}" ]]; then continue; fi
+    to_label+=("$n")
+    extra=$(( extra + 1 ))
+  done
+  if (( EXTRA_LABELLED > 0 && extra < EXTRA_LABELLED )); then
+    warn "asked for $EXTRA_LABELLED extra labelled node(s), only $extra spare candidate(s) available"
+  fi
+
+  for n in "${to_label[@]}"; do
+    kubectl label node "$n" "${LABEL_KEY}=${LABEL_VALUE}" --overwrite
+  done
+  say "labelled ${#to_label[@]} node(s) for ${ETCD_REPLICAS} member(s): ${to_label[*]}"
+  say "  $spare hosts no etcd member; ${etcd_nodes[0]} is left unlabelled so ${STS}-0 must move there"
+  kubectl get nodes -L "${LABEL_KEY}" 2>/dev/null || kubectl get nodes
+  say "SETUP complete."
+}
+
+# ---------------------------------------------------------------- prepare ----
+
+phase_prepare() {
+  hdr "PREPARE: apply the helm prerequisites (OnDelete, nodeAffinity, initialClusterState)"
+  mkdir -p "$WORKDIR"
+  [[ -d "$WORKDIR/chart/openebs" ]] || die "chart source missing at $WORKDIR/chart/openebs -- run setup first"
+
+  cat > "$WORKDIR/etcd-migration.yaml" <<EOF
+mayastor:
+  etcd:
+    nodeAffinityPreset:
+      type: hard
+      key: "${LABEL_KEY}"
+      values: ["${LABEL_VALUE}"]
+    podAntiAffinityPreset: "hard"
+    updateStrategy:
+      type: OnDelete
+    initialClusterState: "existing"
+EOF
+
+  k get pods -l app.kubernetes.io/name=etcd \
+    -o custom-columns=NAME:.metadata.name,UID:.metadata.uid,NODE:.spec.nodeName,RESTARTS:.status.containerStatuses[0].restartCount \
+    > "$WORKDIR/pods-before-prepare.txt"
+  cat "$WORKDIR/pods-before-prepare.txt"
+
+  helm -n "$NS" upgrade "$REL" "$WORKDIR/chart/openebs" \
+    -f "$WORKDIR/install-values.yaml" -f "$WORKDIR/etcd-migration.yaml" --timeout 10m >/dev/null
+  sleep 30
+
+  hdr "PREPARE: assertions"
+  k get pods -l app.kubernetes.io/name=etcd \
+    -o custom-columns=NAME:.metadata.name,UID:.metadata.uid,NODE:.spec.nodeName,RESTARTS:.status.containerStatuses[0].restartCount \
+    > "$WORKDIR/pods-after-prepare.txt"
+
+  # The whole safety model is that this upgrade moves nothing. If OnDelete did
+  # not take effect, pods are already cycling into PVCs pinned to the old nodes.
+  if diff -u "$WORKDIR/pods-before-prepare.txt" "$WORKDIR/pods-after-prepare.txt" >/dev/null; then
+    ok "helm upgrade caused no etcd pod churn"
+  else
+    bad "helm upgrade churned etcd pods -- OnDelete did not take effect"
+    diff -u "$WORKDIR/pods-before-prepare.txt" "$WORKDIR/pods-after-prepare.txt" || true
+  fi
+
+  assert_eq "updateStrategy" "OnDelete" \
+    "$(k get sts "$STS" -o jsonpath='{.spec.updateStrategy.type}')"
+  assert_eq "ETCD_INITIAL_CLUSTER_STATE" "existing" \
+    "$(k get sts "$STS" -o json | jq -r '.spec.template.spec.containers[]|select(.name=="etcd")|.env[]|select(.name=="ETCD_INITIAL_CLUSTER_STATE")|.value')"
+
+  # Assert the key AND the value. A template selecting the right key with the
+  # wrong value is the mismatch that strands the replacement pod, so the test
+  # should notice it here rather than during the move.
+  assert_eq "nodeAffinity selects ${LABEL_KEY}=${LABEL_VALUE}" "$LABEL_VALUE" \
+    "$(k get sts "$STS" -o json | jq -r --arg k "$LABEL_KEY" '
+        [ ( .spec.template.spec.affinity.nodeAffinity
+            | (.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms // [])[]?
+            | (.matchExpressions // [])[]? | select(.key == $k) | (.values // [])[]? ),
+          ( (.spec.template.spec.nodeSelector // {}) | to_entries[] | select(.key == $k) | .value )
+        ] | unique | join(",")')"
+
+  if k get sts "$STS" -o json | jq -e '.spec.template.spec.affinity.podAntiAffinity' >/dev/null 2>&1; then
+    ok "podAntiAffinity still present"
+  else
+    bad "podAntiAffinity was discarded (did something set etcd.affinity directly?)"
+  fi
+
+  # Expected and correct: the template changed but nothing was recycled.
+  local cur upd
+  cur="$(k get sts "$STS" -o jsonpath='{.status.currentRevision}')"
+  upd="$(k get sts "$STS" -o jsonpath='{.status.updateRevision}')"
+  if [[ "$cur" != "$upd" ]]; then
+    ok "currentRevision != updateRevision (pods deliberately not cycled)"
+  else
+    warn "currentRevision == updateRevision; the template may not have changed"
+  fi
+}
+
+# ------------------------------------------------------- baseline + migrate ----
+
+writer_pod() { kubectl -n "$TEST_NS" get pod -l "app=$TEST_APP" -o jsonpath='{.items[0].metadata.name}'; }
+
+capture_baseline() {
+  mkdir -p "$WORKDIR"
+  local pod
+  pod="$(any_etcd_pod)" || die "no etcd pod able to answer etcdctl"
+
+  etcd_exec "$pod" --endpoints="$(all_eps)" endpoint status -w json \
+    | jq -r '.[0].Status.header.cluster_id' > "$WORKDIR/base-cluster-id.txt"
+  etcd_exec "$pod" --endpoints="$(all_eps)" endpoint status -w json \
+    | jq -r '[.[].Status.header.revision]|max' > "$WORKDIR/base-revision.txt"
+  etcd_exec "$pod" get --prefix "" --keys-only 2>/dev/null \
+    | grep -v '^$' | LC_ALL=C sort > "$WORKDIR/base-keys.txt"
+
+  local w
+  w="$(writer_pod)"
+  kubectl -n "$TEST_NS" exec "$w" -- sh -c 'wc -l < /data/log.txt' | tr -d ' ' > "$WORKDIR/base-writer-lines.txt"
+  kubectl -n "$TEST_NS" get pod "$w" -o jsonpath='{.status.containerStatuses[0].restartCount}' > "$WORKDIR/base-writer-restarts.txt"
+
+  say "baseline: cluster_id=$(cat "$WORKDIR/base-cluster-id.txt") revision=$(cat "$WORKDIR/base-revision.txt") keys=$(wc -l < "$WORKDIR/base-keys.txt") writerLines=$(cat "$WORKDIR/base-writer-lines.txt")"
+}
+
+phase_migrate() {
+  hdr "MIGRATE: baseline"
+  [[ -x "$MIGRATE_SCRIPT" ]] || die "migration script not executable: $MIGRATE_SCRIPT"
+  capture_baseline
+
+  hdr "MIGRATE: dry run"
+  NS="$NS" STS="$STS" CN="$CN" LABEL_KEY="$LABEL_KEY" LABEL_VALUE="$LABEL_VALUE" \
+  DRY_RUN=true "$MIGRATE_SCRIPT" 2>&1 | tee "$WORKDIR/dryrun.log"
+  if [[ "${PIPESTATUS[0]}" == "0" ]]; then ok "dry run exited 0"; else bad "dry run failed"; fi
+
+  hdr "MIGRATE: for real"
+  local start rc
+  start=$(date +%s)
+  set +e
+  NS="$NS" STS="$STS" CN="$CN" LABEL_KEY="$LABEL_KEY" LABEL_VALUE="$LABEL_VALUE" \
+  DRY_RUN=false SNAPSHOT=true SNAPSHOT_DIR="$WORKDIR/etcd-snapshots" \
+  "$MIGRATE_SCRIPT" 2>&1 | tee "$WORKDIR/migrate.log"
+  rc=${PIPESTATUS[0]}
+  set -e
+  say "migration finished in $(( $(date +%s) - start ))s with exit $rc"
+  if [[ "$rc" == "0" ]]; then ok "migration exited 0"; else bad "migration exited $rc"; fi
+
+  local snap
+  snap="$(find "$WORKDIR/etcd-snapshots" -maxdepth 1 -type f -name '*.db' 2>/dev/null | sort | tail -1)"
+  if [[ -s "$snap" ]]; then
+    ok "pre-migration snapshot written ($snap, $(wc -c < "$snap") bytes)"
+  else
+    bad "no pre-migration snapshot was written"
+  fi
+}
+
+# ----------------------------------------------------------------- verify ----
+
+phase_verify() {
+  hdr "VERIFY"
+  [[ -s "$WORKDIR/base-cluster-id.txt" ]] || die "no baseline captured -- run migrate first"
+
+  local pod eps
+  pod="$(any_etcd_pod)" || { bad "no etcd pod able to answer etcdctl"; return; }
+  eps="$(all_eps)"
+
+  local status
+  status="$(etcd_exec "$pod" --endpoints="$eps" endpoint status -w json 2>/dev/null || true)"
+  if [[ -z "$status" ]]; then bad "endpoint status returned nothing"; return; fi
+
+  # --- 1. cluster identity ---------------------------------------------------
+  local base_cid cids
+  base_cid="$(cat "$WORKDIR/base-cluster-id.txt")"
+  cids="$(printf '%s' "$status" | jq -r '[.[].Status.header.cluster_id]|unique|join(",")')"
+  assert_eq "cluster_id unchanged and identical on all members" "$base_cid" "$cids"
+
+  # --- 2. every member answered ---------------------------------------------
+  assert_eq "all members reachable" "$ETCD_REPLICAS" \
+    "$(printf '%s' "$status" | jq -r 'length')"
+
+  # --- 3. one leader, one term, one revision --------------------------------
+  assert_eq "single leader agreed by all members" "1" \
+    "$(printf '%s' "$status" | jq -r '[.[].Status.leader]|unique|length')"
+  assert_eq "single raft term" "1" \
+    "$(printf '%s' "$status" | jq -r '[.[].Status.header.raft_term]|unique|length')"
+  assert_eq "revisions converged" "1" \
+    "$(printf '%s' "$status" | jq -r '[.[].Status.header.revision]|unique|length')"
+
+  # --- 4. revision did not go backwards -------------------------------------
+  local base_rev now_rev
+  base_rev="$(cat "$WORKDIR/base-revision.txt")"
+  now_rev="$(printf '%s' "$status" | jq -r '[.[].Status.header.revision]|max')"
+  if (( now_rev >= base_rev )); then
+    ok "revision moved forward ($base_rev -> $now_rev)"
+  else
+    bad "revision went BACKWARDS ($base_rev -> $now_rev) -- keyspace was rolled back"
+  fi
+
+  # --- 5. members hold identical bytes --------------------------------------
+  local hashes
+  hashes="$(etcd_exec "$pod" --endpoints="$eps" endpoint hashkv -w json 2>/dev/null || true)"
+  if [[ -z "$hashes" ]]; then
+    bad "endpoint hashkv returned nothing"
+  else
+    assert_eq "all members report the same keyspace hash" "1" \
+      "$(printf '%s' "$hashes" | jq -r '[.[].HashKV.hash]|unique|length')"
+    say "  hashkv=$(printf '%s' "$hashes" | jq -r '.[0].HashKV.hash')"
+  fi
+
+  # --- 6. no key was lost ----------------------------------------------------
+  local now_keys missing
+  now_keys="$(mktemp)"
+  etcd_exec "$pod" get --prefix "" --keys-only 2>/dev/null \
+    | grep -v '^$' | LC_ALL=C sort > "$now_keys"
+  missing="$(LC_ALL=C comm -23 "$WORKDIR/base-keys.txt" "$now_keys" || true)"
+  if [[ -z "$missing" ]]; then
+    ok "all $(wc -l < "$WORKDIR/base-keys.txt") baseline keys still present ($(wc -l < "$now_keys") total)"
+  else
+    bad "keys lost during migration:"
+    printf '%s\n' "$missing" | sed 's/^/          /' >&2
+  fi
+  rm -f "$now_keys"
+
+  # --- 7. placement ----------------------------------------------------------
+  local i p node bad_placement=0
+  for (( i=0; i<ETCD_REPLICAS; i++ )); do
+    p="${STS}-$i"
+    node="$(k get pod "$p" -o jsonpath='{.spec.nodeName}' 2>/dev/null || true)"
+    # Resolve via a label selector, the same way the migration script does, so any
+    # valid label key works without having to escape it into a jsonpath.
+    if kubectl get nodes -l "${LABEL_KEY}=${LABEL_VALUE}" \
+         -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+       | grep -qxF "$node"; then
+      say "  $p -> $node (labelled)"
+    else
+      bad_placement=1
+      say "  $p -> $node (NOT labelled)"
+    fi
+  done
+  if (( bad_placement == 0 )); then
+    ok "every etcd member is on a labelled node"
+  else
+    bad "some etcd members are not on labelled nodes"
+  fi
+
+  # --- 8. anti-affinity still honoured --------------------------------------
+  local distinct
+  distinct="$(k get pods -l app.kubernetes.io/name=etcd \
+      -o jsonpath='{range .items[*]}{.spec.nodeName}{"\n"}{end}' | sort -u | grep -c . || true)"
+  assert_eq "members on distinct nodes" "$ETCD_REPLICAS" "$distinct"
+
+  # --- 9. storage was reclaimed ---------------------------------------------
+  if kubectl get pv --no-headers 2>/dev/null | grep -E 'Released|Failed' | grep -q etcd; then
+    bad "etcd PVs left in Released/Failed"
+    kubectl get pv --no-headers | grep -E 'Released|Failed' | sed 's/^/          /' >&2
+  else
+    ok "no Released/Failed etcd PVs"
+  fi
+
+  # --- 10. the data path never noticed --------------------------------------
+  local w lines restarts base_lines base_restarts gaps
+  w="$(writer_pod)"
+  base_lines="$(cat "$WORKDIR/base-writer-lines.txt")"
+  base_restarts="$(cat "$WORKDIR/base-writer-restarts.txt")"
+  restarts="$(kubectl -n "$TEST_NS" get pod "$w" -o jsonpath='{.status.containerStatuses[0].restartCount}')"
+  lines="$(kubectl -n "$TEST_NS" exec "$w" -- sh -c 'wc -l < /data/log.txt' | tr -d ' ')"
+  assert_eq "writer pod did not restart" "$base_restarts" "$restarts"
+  if (( lines > base_lines )); then
+    ok "writer kept writing through the migration ($base_lines -> $lines lines)"
+  else
+    bad "writer stopped writing ($base_lines -> $lines lines)"
+  fi
+  gaps="$(kubectl -n "$TEST_NS" exec "$w" -- sh -c \
+      "awk -F'seq=' '{print \$2}' /data/log.txt | awk 'NR>1 && \$1 != prev+1 {print prev\" -> \"\$1} {prev=\$1}'" || true)"
+  if [[ -z "$gaps" ]]; then
+    ok "no gaps in the written sequence -- replicated volume data intact"
+  else
+    bad "gaps in the written sequence:"; printf '%s\n' "$gaps" | sed 's/^/          /' >&2
+  fi
+
+  # --- 11. the control plane can still WRITE --------------------------------
+  # Intact is not the same as working. Provisioning a fresh volume forces
+  # agent-core to write new VolumeSpec/ReplicaSpec records into etcd.
+  local probe="migration-probe-$$"
+  cat <<EOF | kubectl apply -f - >/dev/null
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: {name: ${probe}, namespace: ${TEST_NS}}
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 500Mi}}
+  storageClassName: ${TEST_SC}
+EOF
+  if wait_for "probe PVC to bind (proves etcd accepts writes)" 180 bash -c \
+       "kubectl -n '$TEST_NS' get pvc '$probe' -o jsonpath='{.status.phase}' 2>/dev/null | grep -q Bound"; then
+    ok "control plane provisioned a new volume after the migration"
+  else
+    bad "control plane could NOT provision a new volume -- etcd is intact but not usable"
+  fi
+  kubectl -n "$TEST_NS" delete pvc "$probe" --wait=false >/dev/null 2>&1 || true
+
+  # --- 12. mayastor itself is healthy ---------------------------------------
+  if k get pods --no-headers | awk '{split($2,a,"/"); if (a[1]!=a[2] && $3!="Completed") print}' | grep -q .; then
+    bad "some $NS pods are not ready:"
+    k get pods --no-headers | awk '{split($2,a,"/"); if (a[1]!=a[2] && $3!="Completed") print "          "$0}' >&2
+  else
+    ok "all $NS pods ready"
+  fi
+  if k get dsp --no-headers 2>/dev/null | awk '$4!="Online"{f=1} END{exit f?1:0}'; then
+    ok "all DiskPools Online"
+  else
+    bad "some DiskPools are not Online"; k get dsp >&2
+  fi
+}
+
+# ----------------------------------------------------------------- revert ----
+
+phase_revert() {
+  hdr "REVERT: back to RollingUpdate, drop the pinned initialClusterState"
+  [[ -d "$WORKDIR/chart/openebs" ]] || die "chart source missing -- run setup first"
+
+  cat > "$WORKDIR/etcd-post.yaml" <<EOF
+mayastor:
+  etcd:
+    nodeAffinityPreset:
+      type: hard
+      key: "${LABEL_KEY}"
+      values: ["${LABEL_VALUE}"]
+    podAntiAffinityPreset: "hard"
+    updateStrategy:
+      type: RollingUpdate
+    # initialClusterState deliberately removed: on an upgrade the chart already
+    # defaults it to "existing", and leaving it pinned would break a genuine
+    # from-scratch install later.
+EOF
+
+  helm -n "$NS" upgrade "$REL" "$WORKDIR/chart/openebs" \
+    -f "$WORKDIR/install-values.yaml" -f "$WORKDIR/etcd-post.yaml" --timeout 10m >/dev/null
+
+  # Any member still on the pre-migration ControllerRevision gets rolled now.
+  # On a 2-member cluster that is another brief write outage, which is inherent
+  # to replicaCount=2 rather than to this procedure.
+  wait_for "StatefulSet rollout to converge" "$TIMEOUT_SEC" bash -c \
+    "[ \"\$(kubectl -n '$NS' get sts '$STS' -o jsonpath='{.status.currentRevision}')\" = \"\$(kubectl -n '$NS' get sts '$STS' -o jsonpath='{.status.updateRevision}')\" ] && [ \"\$(kubectl -n '$NS' get sts '$STS' -o jsonpath='{.status.readyReplicas}')\" = '$ETCD_REPLICAS' ]" \
+    || bad "rollout did not converge after the revert"
+
+  hdr "REVERT: assertions"
+  assert_eq "updateStrategy back to RollingUpdate" "RollingUpdate" \
+    "$(k get sts "$STS" -o jsonpath='{.spec.updateStrategy.type}')"
+  wait_for "etcd pods ready" 300 etcd_pods_ready || bad "etcd pods not ready after revert"
+  phase_verify
+}
+
+# --------------------------------------------------------------- teardown ----
+
+no_test_pvs() {
+  ! kubectl get pv --no-headers 2>/dev/null | grep -q "$TEST_SC"
+}
+
+phase_teardown() {
+  hdr "TEARDOWN"
+  # Order matters. A DiskPool carries an openebs.io/diskpool-protection
+  # finalizer and will sit in Terminating forever while any replica still lives
+  # on it, so every Mayastor volume has to be gone -- PV reclaimed, not merely
+  # PVC deleted -- before the pools can be removed.
+  say "removing the workload"
+  kubectl -n "$TEST_NS" delete deploy "$TEST_APP" --ignore-not-found --wait=true --timeout=180s >/dev/null 2>&1 || true
+  say "removing test PVCs"
+  kubectl -n "$TEST_NS" delete pvc "$TEST_PVC" --ignore-not-found --timeout=180s >/dev/null 2>&1 || true
+  # Anything else this test provisioned on the mayastor StorageClass (probe
+  # PVCs from a failed verify, for instance).
+  local pvc
+  for pvc in $(kubectl -n "$TEST_NS" get pvc -o json 2>/dev/null \
+                 | jq -r --arg sc "$TEST_SC" '.items[]|select(.spec.storageClassName==$sc)|.metadata.name'); do
+    kubectl -n "$TEST_NS" delete pvc "$pvc" --ignore-not-found --timeout=180s >/dev/null 2>&1 || true
+  done
+  wait_for "Mayastor PVs to be reclaimed" 300 no_test_pvs \
+    || warn "Mayastor PVs still present; DiskPool deletion may block"
+
+  say "removing DiskPools"
+  k delete dsp --all --ignore-not-found --timeout=180s >/dev/null 2>&1 \
+    || warn "DiskPool deletion timed out -- check for leftover replicas: kubectl -n $NS get dsp"
+  kubectl delete sc "$TEST_SC" --ignore-not-found >/dev/null 2>&1 || true
+
+  # The etcd and loki PVCs come from volumeClaimTemplates, so helm does not own
+  # them and `helm uninstall` leaves them behind. Getting rid of them cleanly is
+  # a three-way squeeze:
+  #   - a PVC cannot be deleted while a pod still mounts it (pvc-protection),
+  #   - the pods only go away when the StatefulSets do,
+  #   - but `helm uninstall` also deletes the localpv provisioner, and without
+  #     it nothing reclaims the hostpath PVs or removes the directories.
+  # So: drop the StatefulSets by hand first, then the PVCs, and only then
+  # uninstall. Delete the PVCs after the uninstall instead and you are left with
+  # Released PVs and tens of megabytes of orphaned etcd data on every node.
+  say "deleting StatefulSets so their pods release the PVCs"
+  k delete sts --all --ignore-not-found --timeout=300s >/dev/null 2>&1 || true
+  say "removing retained PVCs while the provisioner is still alive"
+  k delete pvc --all --ignore-not-found --timeout=300s >/dev/null 2>&1 || true
+  wait_for "hostpath PVs to be reclaimed" 300 bash -c \
+    "! kubectl get pv --no-headers 2>/dev/null | grep -qE 'localpv|Released'" \
+    || warn "hostpath PVs not reclaimed; expect orphaned directories under /var/local/$REL"
+
+  say "uninstalling the release"
+  helm -n "$NS" uninstall "$REL" --wait --timeout 10m >/dev/null 2>&1 || true
+  # Strip the label from every node it could have been put on, not just the
+  # mayastor workers -- the control-plane node is a candidate too.
+  local n
+  for n in $(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'); do
+    kubectl label node "$n" "${LABEL_KEY}-" >/dev/null 2>&1 || true
+  done
+  say "teardown done (namespace $NS left in place)"
+}
+
+# ------------------------------------------------------------------- main ----
+
+summary() {
+  printf '\n===============================================\n'
+  printf '  PASSED: %d\n  FAILED: %d\n' "$PASS" "$FAIL"
+  printf '  artifacts: %s\n' "$WORKDIR"
+  printf '===============================================\n'
+  if (( FAIL > 0 )); then return 1; fi
+  return 0
+}
+
+main() {
+  local phase="${1:-all}"
+  case "$phase" in
+    setup)    phase_setup ;;
+    prepare)  phase_prepare ;;
+    migrate)  phase_migrate ;;
+    verify)   phase_verify ;;
+    revert)   phase_revert ;;
+    teardown) phase_teardown; return 0 ;;
+    all)      phase_setup; phase_prepare; phase_migrate; phase_verify; phase_revert ;;
+    *)        die "unknown phase '$phase' (setup|prepare|migrate|verify|revert|teardown|all)" ;;
+  esac
+  summary
+}
+
+main "$@"


### PR DESCRIPTION
Moves the etcd members onto nodes carrying a given label, one member at a time, removing each from membership and rebuilding it from the others behind health and keyspace-consistency gates.

Adds an end-to-end test against a live cluster, and operator docs.